### PR TITLE
Fix missing manifest entry used for cache key

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,8 @@ lazy val apexls = crossProject(JSPlatform, JVMPlatform)
       "com.google.jimfs"         % "jimfs"                      % "1.1"   % Test
     ),
     packageOptions += Package.ManifestAttributes(
-      "Class-Path" -> (Compile / dependencyClasspath).value.files.map(_.getName.trim).mkString(" ")
+      "Class-Path" -> (Compile / dependencyClasspath).value.files.map(_.getName.trim).mkString(" "),
+      "Implementation-Build" -> java.time.Instant.now().toEpochMilli.toString
     )
   )
   .jsSettings(


### PR DESCRIPTION
Adds `Implementation-Build` back using the current timestamp as an incrementing value. We could also combine it with the version number for the key but its likely to be a unique string given inclusion of milliseconds.

```txt
Manifest-Version: 1.0
Implementation-Title: apex-ls
Implementation-Version: 3.0.1+8-83b78255+20220923-0954-SNAPSHOT
Specification-Vendor: io.github.apex-dev-tools
Implementation-Build: 1663923242771
...
```