### PR TITLE
chore: Disable parallel execution of js tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,7 @@ lazy val apexls = crossProject(JSPlatform, JVMPlatform)
   .jsSettings(
     build       := buildJs(Compile / fullLinkJS).value,
     Dev / build := buildJs(Compile / fastLinkJS).value,
+    Test / parallelExecution := false,
     libraryDependencies ++= Seq("net.exoego" %%% "scala-js-nodejs-v14" % "0.12.0"),
     scalaJSUseMainModuleInitializer := false,
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }


### PR DESCRIPTION
Seems to now run JS tests in the same order every run now which is a good sign.