### PR TITLE
Set test concurrency to 1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,9 @@ lazy val Dev   = config("dev") extend Compile
 // Don't publish root
 publish / skip := true
 
+// Limit to sequential test for both cross projects
+Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)
+
 lazy val apexls = crossProject(JSPlatform, JVMPlatform)
   .in(file("."))
   .configs(Dev)


### PR DESCRIPTION
Both jvm/js test runs are sequential - but they can run in competition which causes issues for filesystem usage occasionally.

This sets the concurrency of test tasks to 1, so sbt can only run a single test task at a time.