### PR TITLE
feat: add ignoreIssues option to workspaces.get

### DIFF
--- a/js/src/main/scala/io/github/apexdevtools/apexls/api/Workspaces.scala
+++ b/js/src/main/scala/io/github/apexdevtools/apexls/api/Workspaces.scala
@@ -41,7 +41,7 @@ object Workspaces {
   private val workspaces = new mutable.HashMap[String, Workspace]()
 
   @JSExport
-  def get(wsPath: String): Workspace = {
+  def get(wsPath: String, ignoreIssues:Boolean = false): Workspace = {
 
     val ws = workspaces.get(wsPath)
     if (ws.nonEmpty)
@@ -50,7 +50,7 @@ object Workspaces {
     val issuesManager = new IssuesManager
     val workspace     = SWorkspace(Path(wsPath), issuesManager)
     val issues        = issuesManager.hasUpdatedIssues
-    if (issues.nonEmpty) {
+    if (issues.nonEmpty && !ignoreIssues) {
       throw new WorkspaceException(issues.head)
     }
 


### PR DESCRIPTION
Needed in flow so we can use this to find file paths from the names. Sometimes the exception was thrown but we would still like to get back the workspace 