### PR TITLE
Remove SObjectField resolution via ID field

### DIFF
--- a/jvm/src/test/scala/com/nawforce/apexlink/types/StandardObjectTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/types/StandardObjectTest.scala
@@ -254,25 +254,6 @@ class StandardObjectTest extends AnyFunSuite with TestHelper {
     }
   }
 
-  /*
-  test("Lookup SObjectField (via id field)") {
-    FileSystemHelper.run(
-      Map(
-        "Dummy.cls" ->
-          "public class Dummy { {SObjectField a = Opportunity.AccountId.Name;} }"
-      )
-    ) { root: PathLike =>
-      val org = createOrg(root)
-      assert(org.issues.isEmpty)
-      assert(
-        unmanagedClass("Dummy").get.blocks.head.dependencies().toSet == Set(
-          unmanagedSObject("Opportunity").get,
-          unmanagedSObject("Account").get
-        )
-      )
-    }
-  }*/
-
   test("Lookup SObjectField (passed to method)") {
     FileSystemHelper.run(
       Map(


### PR DESCRIPTION
Having tested against samples with the SOjectField ID special field handling disabled we are not seeing any impact. We had an internal test for 

`SObjectField a = Opportunity.AccountId.Name;`

But as this is the only code we have that needs this handling I think it is better to remove it for now rather than try a repair. 

For future reference my guess is that this expression is being handled by the Salesforce Apex parser in a special way, namely that 'AccountId' is interpreted as the Account relationship iff there is a rhs. 