### PR TITLE
Improve derived field handling to setup dependency

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/types/schema/SObjectDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/schema/SObjectDeclaration.scala
@@ -26,7 +26,6 @@ import com.nawforce.apexlink.types.synthetic.{
   CustomMethodDeclaration,
   CustomParameterDeclaration
 }
-import com.nawforce.pkgforce.diagnostics.{Diagnostic, Issue, MISSING_CATEGORY}
 import com.nawforce.pkgforce.documents._
 import com.nawforce.pkgforce.modifiers._
 import com.nawforce.pkgforce.names.{Name, TypeName}
@@ -125,52 +124,64 @@ final case class SObjectDeclaration(
 
   override def validate(withRelationshipCollection: Boolean): Unit = {
     // Check field types, can be ignored for Feed, Share & History synthetic SObjects
-    if (!isSynthetic) {
+    if (isSynthetic) return
 
-      // Check lookup like fields refer to valid SObjects
-      fields
-        .collect { case field: CustomField => field }
-        .filter(_.relationshipName.nonEmpty)
-        .foreach(field => {
-          TypeResolver(field.typeName, module) match {
-            case Right(td: SObjectDeclaration) if !td.moduleDeclaration.contains(module) =>
-              // Create a module specific version for related lists to live on
-              val deployer = new SObjectDeployer(module)
-              val replacement = deployer.extendExistingSObject(
-                Some(td),
-                Array(),
-                td.typeName,
-                td.sobjectNature,
-                ArraySeq(),
-                ArraySeq(),
-                ArraySeq()
-              )
-              module.types.put(replacement.typeName, replacement)
-              module.schemaSObjectType.add(replacement.typeName.name, hasFieldSets = true)
-            case Left(_) =>
-              if (module.isGhostedType(field.typeName)) {
-                // Create ghost SObject for later validations
-                val ghostedSObject = GhostSObjectDeclaration(module, field.typeName)
-                module.types.put(field.typeName, ghostedSObject)
-                module.schemaSObjectType.add(ghostedSObject.typeName.name, hasFieldSets = true)
-              } else {
-                OrgInfo.logMissing(
-                  field.location,
-                  s"Lookup object ${field.typeName} does not exist for field '${field.name}'"
-                )
-              }
-            case _ => ()
-          }
-        })
-
-      // Update dependencies from field types
-      fields.map(_.typeName).toSet.filterNot(_ == typeName).foreach(updateDependencies)
-      propagateDependencies()
-      propagateOuterDependencies(new TypeCache())
+    // Lookup like and summary field need specific validations
+    fields.foreach {
+      case field: CustomField if field.relationshipName.nonEmpty =>
+        validateLookupLike(field)
+      case field: CustomField if field.derivedFrom.nonEmpty =>
+        validateSummary(field)
+      case _ => ()
     }
+
+    // Update dependencies from field types
+    fields.map(_.typeName).toSet.filterNot(_ == typeName).foreach(updateDependencies)
+    propagateDependencies()
+    propagateOuterDependencies(new TypeCache())
 
     if (withRelationshipCollection)
       collectRelationshipFields(getTypeDependencyHolders.toSet)
+  }
+
+  private def validateLookupLike(field: CustomField): Unit = {
+    TypeResolver(field.typeName, module) match {
+      case Right(td: SObjectDeclaration) if !td.moduleDeclaration.contains(module) =>
+        // Create a module specific version for related lists to live on
+        val deployer = new SObjectDeployer(module)
+        val replacement = deployer.extendExistingSObject(
+          Some(td),
+          Array(),
+          td.typeName,
+          td.sobjectNature,
+          ArraySeq(),
+          ArraySeq(),
+          ArraySeq()
+        )
+        module.types.put(replacement.typeName, replacement)
+        module.schemaSObjectType.add(replacement.typeName.name, hasFieldSets = true)
+      case Left(_) =>
+        if (module.isGhostedType(field.typeName)) {
+          // Create ghost SObject for later validations
+          val ghostedSObject = GhostSObjectDeclaration(module, field.typeName)
+          module.types.put(field.typeName, ghostedSObject)
+          module.schemaSObjectType.add(ghostedSObject.typeName.name, hasFieldSets = true)
+        } else {
+          OrgInfo.logMissing(
+            field.location,
+            s"Lookup object ${field.typeName} does not exist for field '${field.name}'"
+          )
+        }
+      case _ => ()
+    }
+
+    if (field.typeName != typeName)
+      updateDependencies(field.typeName)
+  }
+
+  private def validateSummary(field: CustomField): Unit = {
+    // Depend on the SObjects the field is derived from
+    field.derivedFrom.foreach(updateDependencies)
   }
 
   private def updateDependencies(typeName: TypeName): Unit = {

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/synthetic/CustomFieldDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/synthetic/CustomFieldDeclaration.scala
@@ -22,8 +22,11 @@ import com.nawforce.pkgforce.path.{Locatable, PathLocation}
 
 import scala.collection.immutable.ArraySeq
 
-abstract class CustomField(asStatic: Boolean, val relationshipName: Option[String] = None)
-    extends FieldDeclaration {
+abstract class CustomField(
+  asStatic: Boolean,
+  val relationshipName: Option[String] = None,
+  val derivedFrom: List[TypeName] = Nil
+) extends FieldDeclaration {
   override val modifiers: ArraySeq[Modifier] = CustomField.getModifiers(asStatic)
   override val readAccess: Modifier          = PUBLIC_MODIFIER
   override val writeAccess: Modifier         = PUBLIC_MODIFIER
@@ -66,6 +69,7 @@ final case class LocatableCustomFieldDeclaration(
   typeName: TypeName,
   idTarget: Option[TypeName],
   asStatic: Boolean = false,
-  override val relationshipName: Option[String] = None
-) extends CustomField(asStatic, relationshipName)
+  override val relationshipName: Option[String] = None,
+  override val derivedFrom: List[TypeName] = Nil
+) extends CustomField(asStatic, relationshipName, derivedFrom)
     with Locatable {}

--- a/shared/src/main/scala/com/nawforce/pkgforce/stream/SObjectGenerator.scala
+++ b/shared/src/main/scala/com/nawforce/pkgforce/stream/SObjectGenerator.scala
@@ -50,8 +50,8 @@ final case class CustomFieldEvent(
   sourceInfo: SourceInfo,
   name: Name,
   rawType: Name,
-  referenceTo: Option[(Name, Name)],
-  relatedField: Option[(Name, Name)]
+  referenceTo: Option[(Name, Name)], // For lookups like fields (referenceTo, relationshipName)
+  relatedField: Option[(Name, Name)] // For summary fields (sobject, field)
 ) extends PackageEvent
 final case class FieldsetEvent(sourceInfo: SourceInfo, name: Name)      extends PackageEvent
 final case class SharingReasonEvent(sourceInfo: SourceInfo, name: Name) extends PackageEvent


### PR DESCRIPTION

This fixes the issue described on https://github.com/apex-dev-tools/apex-ls/issues/190 but there was some additional complexity in that we had a test for removing the field being derived from but it was not functioning correctly. After correcting the test I also needed to add some additional dependency handling so that the object containing the derived field would be revalidated if the object containing the field being derived from was changed. 