### PR TITLE
Fix handling of abstract classes

### DIFF
--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/ImplementsTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/ImplementsTest.scala
@@ -22,14 +22,24 @@ class ImplementsTest extends AnyFunSuite with TestHelper {
   test("No implementation of interface method") {
     typeDeclarations(
       Map(
-        "Dummy.cls" -> "global class Dummy implements A {}",
+        "Dummy.cls" -> "public class Dummy implements A {}",
         "A.cls"     -> "public interface A {void func();}"
       )
     )
     assert(
       dummyIssues ==
-        "Missing: line 1 at 13-18: Method 'void func()' from interface 'A' must be implemented\n"
+        "Missing: line 1 at 13-18: Non-abstract class must implement method 'void func()' from interface 'A'\n"
     )
+  }
+
+  test("No implementation of interface method on abstract class") {
+    typeDeclarations(
+      Map(
+        "Dummy.cls" -> "public abstract class Dummy implements A {}",
+        "A.cls"     -> "public interface A {void func();}"
+      )
+    )
+    assert(dummyIssues.isEmpty)
   }
 
   test("Global implementation of interface method") {

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodShadowTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodShadowTest.scala
@@ -193,7 +193,7 @@ class MethodShadowTest extends AnyFunSuite with TestHelper {
         "AFoo.cls"  -> "public abstract class AFoo implements Foo { public void m1(){} }",
         "Dummy.cls" -> "public class Dummy extends AFoo {  }"
       ),
-      "Missing: line 1 at 13-18: Non-abstract class must implement method 'void m2()' from type 'Foo'\n"
+      "Missing: line 1 at 13-18: Non-abstract class must implement method 'void m2()' from interface 'Foo'\n"
     )
   }
 
@@ -213,7 +213,7 @@ class MethodShadowTest extends AnyFunSuite with TestHelper {
         "Foo.cls"   -> "public interface Foo { void fn(SObject ac); }",
         "Dummy.cls" -> "public class Dummy implements Foo { public void fn(Account ac){} }"
       ),
-      "Missing: line 1 at 13-18: Method 'void fn(System.SObject)' from interface 'Foo' must be implemented\n"
+      "Missing: line 1 at 13-18: Non-abstract class must implement method 'void fn(System.SObject)' from interface 'Foo'\n"
     )
   }
 
@@ -243,7 +243,7 @@ class MethodShadowTest extends AnyFunSuite with TestHelper {
         "Foo.cls"   -> "public interface Foo { void fn(Account ac); }",
         "Dummy.cls" -> "public class Dummy implements Foo { public void fn(Opportunity ac){} }"
       ),
-      "Missing: line 1 at 13-18: Method 'void fn(Schema.Account)' from interface 'Foo' must be implemented\n"
+      "Missing: line 1 at 13-18: Non-abstract class must implement method 'void fn(Schema.Account)' from interface 'Foo'\n"
     )
   }
 
@@ -283,7 +283,7 @@ class MethodShadowTest extends AnyFunSuite with TestHelper {
         "Foo.cls"   -> "public interface Foo { void fn(Long ac); }",
         "Dummy.cls" -> "public class Dummy implements Foo { public void fn(Integer ac){} }"
       ),
-      "Missing: line 1 at 13-18: Method 'void fn(System.Long)' from interface 'Foo' must be implemented\n"
+      "Missing: line 1 at 13-18: Non-abstract class must implement method 'void fn(System.Long)' from interface 'Foo'\n"
     )
   }
 

--- a/jvm/src/test/scala/com/nawforce/apexlink/pkg/RefreshTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/pkg/RefreshTest.scala
@@ -147,7 +147,7 @@ class RefreshTest extends AnyFunSuite with TestHelper {
         )
         assert(
           getMessages(root.join("pkg").join("C.cls"))
-            == "Missing: line 1 at 13-14: Method 'void func(Foo)' from interface 'A' must be implemented\n"
+            == "Missing: line 1 at 13-14: Non-abstract class must implement method 'void func(Foo)' from interface 'A'\n"
         )
 
         refresh(pkg, root.join("pkg/Foo.cls"), "public class Foo {}")


### PR DESCRIPTION
This PR changes the handling of abstract classes, we have been checking interfaces for abstract classes when this is not actually needed. However when we disable that we need to expand how we check non-abstracts so that all interfaces (from supertypes) are considered rather than just those visible on the class.
 