### PR TITLE
Limit use of unused plugins to full validation

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
@@ -18,7 +18,13 @@ import com.nawforce.apexlink.finding.{RelativeTypeContext, RelativeTypeName}
 import com.nawforce.apexlink.memory.SkinnySet
 import com.nawforce.apexlink.names.TypeNames
 import com.nawforce.apexlink.org.Referenceable
-import com.nawforce.apexlink.types.apex.{ApexBlockLike, ApexConstructorLike, ApexFieldLike, ApexMethodLike, ThisType}
+import com.nawforce.apexlink.types.apex.{
+  ApexBlockLike,
+  ApexConstructorLike,
+  ApexFieldLike,
+  ApexMethodLike,
+  ThisType
+}
 import com.nawforce.apexlink.types.core._
 import com.nawforce.apexparser.ApexParser._
 import com.nawforce.pkgforce.diagnostics.{ERROR_CATEGORY, Issue}
@@ -210,7 +216,7 @@ final case class ApexInitializerBlock(_modifiers: ModifierResults, block: Block,
   override def verify(context: BodyDeclarationVerifyContext): Unit = {
     val blockContext = new OuterBlockVerifyContext(context, isStatic)
     block.verify(blockContext)
-    context.typePlugin.onBlockValidated(block, isStatic, blockContext)
+    context.typePlugin.foreach(_.onBlockValidated(block, isStatic, blockContext))
 
     setDepends(context.dependencies)
   }
@@ -348,8 +354,7 @@ final case class ApexFieldDeclaration(
   override def verify(context: BodyDeclarationVerifyContext): Unit = {
     val staticContext = if (isStatic) Some(true) else None
 
-
-    if(isStatic && modifiers.contains(PROTECTED_MODIFIER)) {
+    if (isStatic && modifiers.contains(PROTECTED_MODIFIER)) {
       context.log(
         Issue(
           location.path,
@@ -418,7 +423,7 @@ final case class ApexConstructorDeclaration(
       )
     )
     block.verify(blockContext)
-    context.typePlugin.onBlockValidated(block, isStatic = false, blockContext)
+    context.typePlugin.foreach(_.onBlockValidated(block, isStatic = false, blockContext))
 
     setDepends(context.dependencies)
   }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/ConstructorMap.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/ConstructorMap.scala
@@ -67,7 +67,7 @@ final case class ConstructorMap(
         if (ConstructorMap.isCtorAccessible(ctor, context.thisType, context.superType)) {
           Right(ctor)
         } else {
-          //Check the rest of assignable for accessible ctors, if not return the original error
+          // Check the rest of assignable for accessible ctors, if not return the original error
           findPotentialMatch(matches.filterNot(_ == ctor), params, context) match {
             case Right(ctor) => Right(ctor)
             case _           => Left(s"Constructor is not visible: $getCtorString")
@@ -95,14 +95,12 @@ final case class ConstructorMap(
     else {
       Some(
         assignable
-          .find(
-            ctor =>
-              assignable.forall(
-                c =>
-                  c == ctor || ctor
-                    .hasMoreSpecificParams(c.parameters, params, context)
-                    .contains(true)
-              )
+          .find(ctor =>
+            assignable.forall(c =>
+              c == ctor || ctor
+                .hasMoreSpecificParams(c.parameters, params, context)
+                .contains(true)
+            )
           )
           .map(Right(_))
           .getOrElse(Left("Ambiguous constructor call"))
@@ -158,8 +156,8 @@ object ConstructorMap {
       val key                      = ctor.parameters.length
       val ctorsWithSameParamLength = workingMap.getOrElse(key, Nil)
       val platformGenericDupes =
-        ctorsWithSameParamLength.find(
-          x => x.hasSameParameters(ctor, allowPlatformGenericEquivalence = true)
+        ctorsWithSameParamLength.find(x =>
+          x.hasSameParameters(ctor, allowPlatformGenericEquivalence = true)
         )
       if (platformGenericDupes.nonEmpty)
         setConstructorDuplicateError(ctor, platformGenericDupes.head, errors)
@@ -220,7 +218,7 @@ object ConstructorMap {
             superClassMap
               .findConstructorByParams(
                 ArraySeq.empty,
-                new TypeVerifyContext(None, ad, None)
+                new TypeVerifyContext(None, ad, None, enablePlugins = false)
               ) match {
               case Left(error) =>
                 val msg =

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/MethodMap.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/MethodMap.scala
@@ -807,7 +807,7 @@ object MethodMap {
     else {
       from match {
         case ad: ApexDeclaration =>
-          val context = new TypeVerifyContext(None, ad, None)
+          val context = new TypeVerifyContext(None, ad, None, enablePlugins = false)
           isAssignable(toType, fromType, strictConversions = false, context)
         case _ =>
           false

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Properties.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Properties.scala
@@ -139,7 +139,7 @@ final case class GetterPropertyBlock(modifiers: ModifierResults, block: Option[B
       val blockContext = new OuterBlockVerifyContext(context, isStatic, propertyType.typeName)
       block.verify(blockContext)
       blockContext.logControlFlowIssues()
-      context.typePlugin.onBlockValidated(block, isStatic, blockContext)
+      context.typePlugin.foreach(_.onBlockValidated(block, isStatic, blockContext))
     })
   }
 }
@@ -163,7 +163,7 @@ final case class SetterPropertyBlock(
         propertyType
       )
       block.verify(blockContext)
-      context.typePlugin.onBlockValidated(block, isStatic, blockContext)
+      context.typePlugin.foreach(_.onBlockValidated(block, isStatic, blockContext))
     })
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
@@ -62,7 +62,7 @@ final case class LazyBlock(
     val blockContext = new InnerBlockVerifyContext(context)
     statements().foreach(_.verify(blockContext))
     verifyControlPath(blockContext, BlockControlPattern())
-    context.typePlugin.onBlockValidated(this, context.isStatic, blockContext)
+    context.typePlugin.foreach(_.onBlockValidated(this, context.isStatic, blockContext))
   }
 
   def statements(): Seq[Statement] = {
@@ -163,7 +163,9 @@ final case class IfStatement(expression: Expression, statements: Seq[Statement])
       }
       stmt.verify(stmtContext)
       if (isBlock)
-        context.typePlugin.onBlockValidated(stmt.asInstanceOf[Block], context.isStatic, stmtContext)
+        context.typePlugin.foreach(
+          _.onBlockValidated(stmt.asInstanceOf[Block], context.isStatic, stmtContext)
+        )
     })
 
     verifyControlPath(stmtRootContext, BranchControlPattern(Some(expr), 2))
@@ -427,7 +429,7 @@ final case class CatchClause(
         exceptionType
       )
       block.verify(blockContext)
-      context.typePlugin.onBlockValidated(block, context.isStatic, blockContext)
+      context.typePlugin.foreach(_.onBlockValidated(block, context.isStatic, blockContext))
     })
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeDeclarations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeDeclarations.scala
@@ -80,7 +80,7 @@ final case class ClassDeclaration(
 
   override def verify(context: BodyDeclarationVerifyContext): Unit = {
     verifyCommon(context)
-    super.verify(new TypeVerifyContext(Some(context), this, None))
+    super.verify(new TypeVerifyContext(Some(context), this, None, enablePlugins = true))
   }
 
   private def verifyCommon(context: VerifyContext): Unit = {
@@ -210,7 +210,7 @@ final case class InterfaceDeclaration(
   override val nature: Nature = INTERFACE_NATURE
 
   override def verify(context: BodyDeclarationVerifyContext): Unit = {
-    super.verify(new TypeVerifyContext(Some(context), this, None))
+    super.verify(new TypeVerifyContext(Some(context), this, None, enablePlugins = true))
   }
 }
 
@@ -307,7 +307,7 @@ final case class EnumDeclaration(
   override val nature: Nature = ENUM_NATURE
 
   override def verify(context: BodyDeclarationVerifyContext): Unit = {
-    super.verify(new TypeVerifyContext(Some(context), this, None))
+    super.verify(new TypeVerifyContext(Some(context), this, None, enablePlugins = true))
   }
 
   override lazy val localMethods: ArraySeq[ApexMethodDeclaration] = {

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/stmts/Switch.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/stmts/Switch.scala
@@ -199,7 +199,7 @@ final case class WhenControl(whenValue: WhenValue, block: Block) extends CST {
     val blockContext = new InnerBlockVerifyContext(context).setControlRoot(context)
     whenValue.verify(blockContext)
     block.verify(blockContext)
-    context.typePlugin.onBlockValidated(block, context.isStatic, blockContext)
+    context.typePlugin.foreach(_.onBlockValidated(block, context.isStatic, blockContext))
   }
 }
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/apex/FullDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/apex/FullDeclaration.scala
@@ -120,7 +120,7 @@ abstract class FullDeclaration(
     LoggerOps.debugTime(s"Validated ${location.path}") {
       // Validate inside a parsing context as LazyBlock may call parser
       CST.sourceContext.withValue(Some(source)) {
-        val context = new TypeVerifyContext(None, this, None)
+        val context = new TypeVerifyContext(None, this, None, enablePlugins = true)
         modifierIssues.foreach(context.log)
         verify(context)
         propagateOuterDependencies(new TypeCache())
@@ -289,7 +289,7 @@ abstract class FullDeclaration(
       getBodyDeclarationFromLocation(line, offset)
         .map(typeAndBody => {
           // Validate the body declaration for the side-effect of being able to collect a map of expression results
-          val typeContext = new TypeVerifyContext(None, typeAndBody._1, None)
+          val typeContext = new TypeVerifyContext(None, typeAndBody._1, None, enablePlugins = false)
           val resultMap   = mutable.Map[Location, ValidationResult]()
           val context =
             new BodyDeclarationVerifyContext(typeContext, typeAndBody._2, Some(resultMap))

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/core/TypeDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/core/TypeDeclaration.scala
@@ -304,7 +304,7 @@ trait MethodDeclaration extends DependencyHolder with Dependent with Parameters 
     if (name != implMethod.name || parameters.length != implMethod.parameters.length)
       return false
 
-    val context    = new TypeVerifyContext(None, from, None)
+    val context    = new TypeVerifyContext(None, from, None, enablePlugins = false)
     val paramTypes = implMethod.parameters.map(_.typeName)
     parameters
       .zip(paramTypes)

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/other/VFContainer.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/other/VFContainer.scala
@@ -30,7 +30,7 @@ class VFContainer(module: OPM.Module, event: VFEvent) extends DependencyHolder {
   def validate(): Set[Dependent] = {
     val controllers = getControllers
     val controllerContexts = controllers.map(controller => {
-      val context = new TypeVerifyContext(None, controller, None)
+      val context = new TypeVerifyContext(None, controller, None, enablePlugins = false)
       context.addDependency(controller)
       context
     })


### PR DESCRIPTION
This makes use of plugins in TypeVerifyContext optional based on a flag. We only turn the flag on during full validation so that we are not creating plugins in other operations such as when validating to get additional information for code completion. 

I can not be completely sure this fixes the issue with intermittent problems with unused, but after making the fix and doing some manual testing I could not replicate the issue I was seeing before where saving and then using code completion quickly afterwards did result in false positive issues.