### PR TITLE
Improve switch handling of brackets and integer/long

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val apexls = crossProject(JSPlatform, JVMPlatform)
       "org.scala-lang.modules"  %% "scala-xml"                      % "1.3.0",
       "org.scala-lang.modules"  %% "scala-parallel-collections"     % "1.0.0",
       "org.scala-js"            %% "scalajs-stubs"                  % "1.0.0",
-      "io.github.apex-dev-tools" % "apex-parser"                    % "3.3.0",
+      "io.github.apex-dev-tools" % "apex-parser"                    % "3.4.0",
       "io.github.apex-dev-tools" % "vf-parser"                      % "1.1.0",
       "io.github.apex-dev-tools" % "sobject-types"                  % "57.0.3",
       "io.github.apex-dev-tools" % "standard-types"                 % "57.0.2",


### PR DESCRIPTION
This fixes the handling of brackets around switch then literals, the parser has supported these for a while but apex-ls was broken if you tried to use them.

While working on that I noticed the handling of + & - before integer and long literals was broken. To fix this requires the change in https://github.com/apex-dev-tools/apex-parser/issues/29 which allows for sequences of + & - before either integer or long literals. Only alternating sequences of + and - are supported, + can be treated as a no-op as can an even number of -. Where a long control value is used the when value may be an integer but the reverse is not supported even if the long value may fit in an int.