### PR TITLE
Improve unused messages for outer types

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -5,6 +5,7 @@ indent.defnSite = 2
 optIn.configStyleArguments = false
 align.preset = more
 maxColumn = 100
+docstrings.wrap = "no"
 
 # Shorthand set runner.dialect for sbt files
 fileOverride { "glob:**/*.sbt" = sbt1 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeDeclarations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeDeclarations.scala
@@ -18,11 +18,9 @@ import com.nawforce.apexlink.names.TypeNames
 import com.nawforce.apexlink.org.OPM
 import com.nawforce.apexlink.types.apex.{FullDeclaration, ThisType}
 import com.nawforce.apexparser.ApexParser._
-import com.nawforce.pkgforce.diagnostics.Duplicates.IterableOps
 import com.nawforce.pkgforce.modifiers._
 import com.nawforce.pkgforce.names.{Name, TypeName}
 import com.nawforce.pkgforce.parsers._
-import com.nawforce.runtime.parsers.CodeParser.TerminalNode
 import com.nawforce.runtime.parsers.{CodeParser, Source}
 
 import scala.collection.immutable.ArraySeq
@@ -414,7 +412,8 @@ object EnumDeclaration {
         ApexModifiers.enumConstantModifiers(),
         thisType.typeName,
         VariableDeclarator(thisType.typeName, isReadOnly = true, Id.construct(constant), None)
-          .withContext(constant)
+          .withContext(constant),
+        isEnumConstant = true
       ).withContext(constant)
     })
 

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/SummaryTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/SummaryTest.scala
@@ -18,7 +18,7 @@ import com.nawforce.apexlink.TestHelper
 import com.nawforce.apexlink.api._
 import com.nawforce.apexlink.names.TypeNames
 import com.nawforce.pkgforce.modifiers._
-import com.nawforce.pkgforce.names.{DotName, Name, TypeIdentifier, TypeName}
+import com.nawforce.pkgforce.names.{DotName, Name, TypeName}
 import com.nawforce.pkgforce.parsers.{FIELD_NATURE, PROPERTY_NATURE}
 import com.nawforce.pkgforce.path.Location
 import org.scalatest.funsuite.AnyFunSuite
@@ -28,7 +28,6 @@ import scala.collection.immutable.ArraySeq
 class SummaryTest extends AnyFunSuite with TestHelper {
 
   private val dummyTypeName      = DotName("Dummy").asTypeName()
-  private val dummyTypeId        = TypeIdentifier.fromJava(null, dummyTypeName)
   private val objectTypeName     = DotName("Internal.Object$").asTypeName()
   private val interfaceTypeName  = DotName("Internal.Interface$").asTypeName()
   private val rawIntegerTypeName = DotName("Integer").asTypeName()
@@ -542,7 +541,7 @@ class SummaryTest extends AnyFunSuite with TestHelper {
               dummyTypeName,
               PUBLIC_MODIFIER,
               PUBLIC_MODIFIER,
-              Array(TypeDependentSummary(dummyTypeId, -1270140630))
+              Array()
             ),
             FieldSummary(
               Location(1, 19, 1, 20),
@@ -553,7 +552,7 @@ class SummaryTest extends AnyFunSuite with TestHelper {
               dummyTypeName,
               PUBLIC_MODIFIER,
               PUBLIC_MODIFIER,
-              Array(TypeDependentSummary(dummyTypeId, -1270140630))
+              Array()
             ),
             FieldSummary(
               Location(1, 25, 1, 26),
@@ -564,7 +563,7 @@ class SummaryTest extends AnyFunSuite with TestHelper {
               dummyTypeName,
               PUBLIC_MODIFIER,
               PUBLIC_MODIFIER,
-              Array(TypeDependentSummary(dummyTypeId, -1270140630))
+              Array()
             )
           ),
           ArraySeq(),


### PR DESCRIPTION
This changes the messages used when reporting an outer type is used only by test code. For classes we suggest using @isTest or @SuppressWarnings('Unused') if they need to keep the code, for interface & enum its similar but you can't use @isTest.

As part this I have added a workaround for an issue in the dependency handling for enum constants. We model these constants as fields with a value of the enclosing enum type. The validation on `ApexFieldDeclaration` was then creating a dependency between the field and its enclosing enum type which caused issues for the unused analysis.  The workaround simply disables validation for `ApexFieldDeclaration` used as constants. We really need a better way to determine if body declarations have a dependency on the enclosing types but that is significantly more work then this issue justifies.
