### PR TITLE
Check @isTest classes are not abstract or virtual

### DIFF
--- a/shared/src/main/scala/com/nawforce/pkgforce/modifiers/Modifier.scala
+++ b/shared/src/main/scala/com/nawforce/pkgforce/modifiers/Modifier.scala
@@ -391,6 +391,12 @@ object ApexModifiers {
         } else if (!outer && mods.contains(ISTEST_ANNOTATION)) {
           logger.logError(idContext, s"isTest can only be used on outer classes")
           mods.filterNot(_ == ISTEST_ANNOTATION)
+        } else if (
+          mods.contains(ISTEST_ANNOTATION) && (mods
+            .contains(ABSTRACT_MODIFIER) || mods.contains(VIRTUAL_MODIFIER))
+        ) {
+          logger.logError(idContext, s"isTest classes can not be abstract or virtual")
+          mods.filterNot(_ == ISTEST_ANNOTATION)
         } else {
           mods
         }

--- a/shared/src/test/scala/com/nawforce/pkgforce/modifiers/ClassModifierTest.scala
+++ b/shared/src/test/scala/com/nawforce/pkgforce/modifiers/ClassModifierTest.scala
@@ -111,6 +111,38 @@ class ClassModifierTest extends AnyFunSuite {
     assert(legalClassAccess(ArraySeq(ISTEST_ANNOTATION)))
   }
 
+  test("isTest and abstract modifier") {
+    val issues = illegalClassAccess(ArraySeq(ISTEST_ANNOTATION, ABSTRACT_MODIFIER))
+    assert(
+      issues == Seq[Issue](
+        Issue(
+          Path("Dummy.cls"),
+          diagnostics.Diagnostic(
+            ERROR_CATEGORY,
+            Location(1, 23, 1, 28),
+            "isTest classes can not be abstract or virtual"
+          )
+        )
+      )
+    )
+  }
+
+  test("isTest and virtual modifier") {
+    val issues = illegalClassAccess(ArraySeq(ISTEST_ANNOTATION, VIRTUAL_MODIFIER))
+    assert(
+      issues == Seq[Issue](
+        Issue(
+          Path("Dummy.cls"),
+          diagnostics.Diagnostic(
+            ERROR_CATEGORY,
+            Location(1, 22, 1, 27),
+            "isTest classes can not be abstract or virtual"
+          )
+        )
+      )
+    )
+  }
+
   test("Abstract modifier") {
     assert(legalClassAccess(ArraySeq(ABSTRACT_MODIFIER, PUBLIC_MODIFIER)))
   }


### PR DESCRIPTION

This just adds a simple check that you are not trying to use @isTest with virtual or abstract. @isTest is not legal on enums or interfaces or inner classes which we are checking so I think these are the only missed cases.