### PR TITLE
109 catch exceptions during outline cst construction

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/opcst/OutlineParserFullDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/opcst/OutlineParserFullDeclaration.scala
@@ -69,8 +69,6 @@ object OutlineParserFullDeclaration {
     outerTypeName: Option[TypeName]
   ): Option[ClassDeclaration] = {
 
-    throw new NoSuchElementException()
-
     val source: Source     = Source(cls.path, srcData, 0, 0, None)
     val thisTypeNameWithNS = TypeName(cls.name).withNamespace(module.namespace)
 


### PR DESCRIPTION
This is just to make sure an issue with Outline parser output can not shutdown the server.