### PR TITLE
Fix bug in shadow handling on interfaces

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/MethodMap.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/MethodMap.scala
@@ -309,7 +309,7 @@ object MethodMap {
 
     // For interfaces make sure we have all methods
     if (td.nature == INTERFACE_NATURE) {
-      mergeInterfaces(workingMap, interfaces)
+      interfaces.foreach(interface => mergeInterface(workingMap, interface))
     }
 
     // Add local statics, de-duped
@@ -458,21 +458,22 @@ object MethodMap {
     emptyMethodDeclarations
   }
 
-  private def mergeInterfaces(
-    workingMap: WorkingMap,
-    interfaces: ArraySeq[TypeDeclaration]
-  ): Unit = {
-    interfaces.foreach({
-      case i: TypeDeclaration if i.nature == INTERFACE_NATURE =>
-        mergeInterface(workingMap, i)
-      case _ => ()
-    })
-  }
-
+  /** Update working map with interface methods.
+    *
+    * If interface methods are not in the map then we add, if they are then the 'shadow' relationship is created
+    * linking from the interface method to the previously discovered impl method. This processes interfaces
+    * recursively so we handle interfaces implemented by interfaces.
+    *
+    * @param workingMap map to add to
+    * @param interface interface to process
+    */
   private def mergeInterface(workingMap: WorkingMap, interface: TypeDeclaration): Unit = {
-    if (interface.isInstanceOf[ApexClassDeclaration] && interface.nature == INTERFACE_NATURE)
-      mergeInterfaces(workingMap, interface.interfaceDeclarations)
+    // This should not be needed, but we can't type interfaces here due to platform types
+    if (interface.nature != INTERFACE_NATURE)
+      return
 
+    // We merge top-down here to make sure shadows is always set up in correct direction, doing it bottom
+    // up can result in an inverted shadowing relationship when both interfaces contains the same method
     interface.methods
       .filterNot(_.isStatic)
       .foreach(method => {
@@ -489,6 +490,10 @@ object MethodMap {
           }
         }
       })
+
+    if (interface.isInstanceOf[ApexClassDeclaration] && interface.nature == INTERFACE_NATURE) {
+      interface.interfaceDeclarations.foreach(interface => mergeInterface(workingMap, interface))
+    }
   }
 
   private def checkInterfaces(


### PR DESCRIPTION

This fixes a bug in shadow handling on interface that is triggered by the download FDN metadata. The fix is also on https://github.com/apex-dev-tools/apex-ls/pull/155 but though better to split out as that PR is taking some time. 

The problem here was we could end up with two interface methods each thinking it shadowed the other causing stack overflow in the unused analysis. The cause was the ordering we used to setup the shadow relationship which I have changed to ensure the interfaces are processed in the correct order.