### PR TITLE
114 throw statement and catch clause dont check for exception types

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
@@ -25,8 +25,8 @@ import com.nawforce.apexlink.types.other.AnyDeclaration
 import com.nawforce.apexlink.types.platform.{PlatformTypeDeclaration, PlatformTypes}
 import com.nawforce.apexlink.types.synthetic.CustomConstructorDeclaration
 import com.nawforce.apexparser.ApexParser._
-import com.nawforce.pkgforce.diagnostics.{Issue, WARNING_CATEGORY}
-import com.nawforce.pkgforce.names.{EncodedName, Name, TypeName}
+import com.nawforce.pkgforce.diagnostics.{ERROR_CATEGORY, Issue, WARNING_CATEGORY}
+import com.nawforce.pkgforce.names.{EncodedName, Name, Names, TypeName}
 import com.nawforce.pkgforce.path.{Locatable, PathLocation}
 import com.nawforce.runtime.parsers.CodeParser
 
@@ -75,12 +75,75 @@ object ExprContext {
   }
 }
 
+/** base for any type of expression, provides helpers for type validation */
 sealed abstract class Expression extends CST {
   def verify(input: ExprContext, context: ExpressionVerifyContext): ExprContext
 
   def verify(context: BlockVerifyContext): ExprContext = {
     val staticContext = if (context.isStatic) Some(true) else None
     verify(ExprContext(staticContext, context.thisType), new ExpressionVerifyContext(context))
+  }
+
+  /** Verify an expression result type is an exception
+    *
+    * @param context    verify context to use
+    * @param prefix     for the log issue
+    */
+  def verifyIsExceptionInstance(
+    context: BlockVerifyContext,
+    prefix: String
+  ): (Boolean, ExprContext) = {
+    val verifyResult = verify(context)
+    if (
+      verifyResult.isDefined && (verifyResult.isStatic
+        .contains(true) || !verifyResult.typeName.name.endsWith(Names.Exception))
+    ) {
+      val resultQualifier = if (verifyResult.isStatic.contains(true)) "type" else "instance"
+      context.log(
+        Issue(
+          ERROR_CATEGORY,
+          location,
+          s"$prefix expression should return an Exception instance, not a '${verifyResult.typeName}' $resultQualifier"
+        )
+      )
+      (false, verifyResult)
+    } else {
+      (true, verifyResult)
+    }
+  }
+
+  /** Verify an expression result type matches a specific type logging an issue if not
+    *
+    * @param context    verify context to use
+    * @param typeName   to check for
+    * @param isStatic   check for static or instance value
+    * @param prefix     for the log issue
+    */
+  def verifyIs(
+    context: BlockVerifyContext,
+    typeName: TypeName,
+    isStatic: Boolean,
+    prefix: String
+  ): (Boolean, ExprContext) = {
+    val verifyResult = verify(context)
+    if (
+      verifyResult.isDefined && (!verifyResult.isStatic.contains(
+        isStatic
+      ) || verifyResult.typeName != typeName)
+    ) {
+      val qualifier       = if (isStatic) "type" else "instance"
+      val resultQualifier = if (verifyResult.isStatic.contains(true)) "type" else "instance"
+      context.log(
+        Issue(
+          ERROR_CATEGORY,
+          location,
+          s"$prefix expression should return a '$typeName' $qualifier, not a '${verifyResult.typeName}' $resultQualifier"
+        )
+      )
+      (false, verifyResult)
+    } else {
+      (true, verifyResult)
+    }
   }
 }
 
@@ -229,7 +292,7 @@ final case class DotExpressionWithId(expression: Expression, safeNavigation: Boo
       PlatformTypeDeclaration.namespaces.contains(name)
   }
 
-  def verifyWithId(input: ExprContext, context: ExpressionVerifyContext): ExprContext = {
+  private def verifyWithId(input: ExprContext, context: ExpressionVerifyContext): ExprContext = {
     val inputType = input.declaration.get
 
     val name = target.name

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
@@ -31,39 +31,6 @@ import scala.collection.mutable
 
 abstract class Statement extends CST with ControlFlow {
   def verify(context: BlockVerifyContext): Unit
-
-  /** Verify an expression result type matches a specific type logging an issue if not
-    *
-    * @param expression to verify
-    * @param context verify context to use
-    * @param typeName to check for
-    * @param isStatic check for static or instance value
-    * @param prefix for the log issue
-    */
-  def verifyExpressionIs(
-    expression: Expression,
-    context: BlockVerifyContext,
-    typeName: TypeName,
-    isStatic: Boolean,
-    prefix: String
-  ): (Boolean, ExprContext) = {
-    val expr = expression.verify(context)
-    if (expr.isDefined && (!expr.isStatic.contains(isStatic) || expr.typeName != typeName)) {
-      val qualifier       = if (isStatic) "type" else "instance"
-      val resultQualifier = if (expr.isStatic.contains(true)) "type" else "instance"
-      context.log(
-        Issue(
-          ERROR_CATEGORY,
-          expression.location,
-          s"$prefix expression should return a '$typeName' $qualifier, not a '${expr.typeName}' $resultQualifier"
-        )
-      )
-      (false, expr)
-    } else {
-      (true, expr)
-    }
-  }
-
 }
 
 // Treat Block as Statement for blocks in blocks
@@ -185,7 +152,7 @@ object LocalVariableDeclarationStatement {
 final case class IfStatement(expression: Expression, statements: Seq[Statement]) extends Statement {
   override def verify(context: BlockVerifyContext): Unit = {
     val exprResult =
-      verifyExpressionIs(expression, context, TypeNames.Boolean, isStatic = false, "If")
+      expression.verifyIs(context, TypeNames.Boolean, isStatic = false, "If")
 
     // This is replicating a feature where non-block statements can pass declarations forward
     val stmtRootContext = new InnerBlockVerifyContext(context).withBranchingControl()
@@ -372,7 +339,7 @@ object ForUpdate {
 final case class WhileStatement(expression: Expression, statement: Option[Statement])
     extends Statement {
   override def verify(context: BlockVerifyContext): Unit = {
-    verifyExpressionIs(expression, context, TypeNames.Boolean, isStatic = false, "While")
+    expression.verifyIs(context, TypeNames.Boolean, isStatic = false, "While")
     statement.foreach(_.verify(context))
   }
 }
@@ -389,7 +356,7 @@ object WhileStatement {
 final case class DoWhileStatement(statement: Option[Statement], expression: Expression)
     extends Statement {
   override def verify(context: BlockVerifyContext): Unit = {
-    verifyExpressionIs(expression, context, TypeNames.Boolean, isStatic = false, "While")
+    expression.verifyIs(context, TypeNames.Boolean, isStatic = false, "While")
     statement.foreach(_.verify(context))
   }
 }
@@ -452,7 +419,19 @@ final case class CatchClause(
           case Left(_) =>
             context.missingType(qname.location, exceptionTypeName)
             context.module.any
-          case Right(td) => td
+          case Right(td) =>
+            if (exceptionTypeName.name.endsWith(Names.Exception)) {
+              td
+            } else {
+              context.log(
+                Issue(
+                  ERROR_CATEGORY,
+                  qname.location,
+                  s"Catch clause should catch an Exception instance, not a '${exceptionTypeName}' instance"
+                )
+              )
+              context.module.any
+            }
         }
       // definition = None disables issues like 'Unused' for exceptions
       blockContext.addVar(
@@ -529,19 +508,7 @@ object ReturnStatement {
 
 final case class ThrowStatement(expression: Expression) extends Statement {
   override def verify(context: BlockVerifyContext): Unit = {
-    val expr = expression.verify(context)
-    if (expr.isDefined) {
-      if (expr.isStatic.contains(true) || !expr.typeName.name.endsWith(Names.Exception)) {
-        context.log(
-          Issue(
-            expression.location.path,
-            ERROR_CATEGORY,
-            expression.location.location,
-            s"Only Exception objects may be thrown, not '${expr.typeName}'"
-          )
-        )
-      }
-    }
+    expression.verifyIsExceptionInstance(context, "Throw")
     verifyControlPath(context, ExitControlPattern(exitsMethod = true, exitsBlock = true))
   }
 }

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/CatchTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/CatchTest.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 Certinia Inc. All rights reserved.
+ */
+package com.nawforce.apexlink.cst
+
+import com.nawforce.apexlink.TestHelper
+import org.scalatest.funsuite.AnyFunSuite
+
+class CatchTest extends AnyFunSuite with TestHelper {
+
+  test("Catch platform exception") {
+    happyTypeDeclaration("public class Dummy {{ try {} catch (AssertException a) {} }}")
+  }
+
+  test("Catch custom exception") {
+    typeDeclarations(
+      Map(
+        "MyException.cls" -> "public class MyException extends Exception {}",
+        "Dummy.cls"       -> "public class Dummy {{ try {} catch (MyException a) {} }}"
+      )
+    )
+    assert(!hasIssues)
+  }
+
+  test("Catch non-exception class errors") {
+    typeDeclarations(
+      Map(
+        "MyClass.cls" -> "public class MyClass {}",
+        "Dummy.cls"   -> "public class Dummy {{ try {} catch (MyClass a) {} }}"
+      )
+    )
+    assert(
+      dummyIssues == "Error: line 1 at 36-43: Catch clause should catch an Exception instance, not a 'MyClass' instance\n"
+    )
+  }
+
+  test("Catch platform type errors") {
+    typeDeclaration("public class Dummy {{ try {} catch (String a) {} }}")
+    assert(
+      dummyIssues == "Error: line 1 at 36-42: Catch clause should catch an Exception instance, not a 'String' instance\n"
+    )
+  }
+}

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/DependencyTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/DependencyTest.scala
@@ -25,7 +25,7 @@ import org.scalatest.funsuite.AnyFunSuite
 class DependencyTest extends AnyFunSuite with TestHelper {
 
   test("Empty class has no imports") {
-    val tds = typeDeclarations(Map("Dummy.cls" -> "public class Dummy {}"))
+    typeDeclarations(Map("Dummy.cls" -> "public class Dummy {}"))
     assert(!hasIssues)
   }
 
@@ -270,8 +270,8 @@ class DependencyTest extends AnyFunSuite with TestHelper {
   test("Catch creates dependency") {
     val tds = typeDeclarations(
       Map(
-        "Dummy.cls" -> "public class Dummy { void func() { try {} catch(A a){} } }",
-        "A.cls"     -> "public class A {}"
+        "Dummy.cls"      -> "public class Dummy { void func() { try {} catch(AException a){} } }",
+        "AException.cls" -> "public class AException extends Exception {}"
       )
     )
     assert(!hasIssues)
@@ -452,8 +452,8 @@ class DependencyTest extends AnyFunSuite with TestHelper {
   test("Inner Catch creates dependency") {
     val tds = typeDeclarations(
       Map(
-        "Dummy.cls" -> "public class Dummy { class Inner {void func() { try {} catch(A a){} } } }",
-        "A.cls"     -> "public class A {}"
+        "Dummy.cls" -> "public class Dummy { class Inner {void func() { try {} catch(AException a){} } } }",
+        "AException.cls" -> "public class AException extends Exception {}"
       )
     )
     assert(!hasIssues)

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/ThrowsTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/ThrowsTest.scala
@@ -15,7 +15,7 @@ class ThrowsTest extends AnyFunSuite with TestHelper {
   test("Throw platform exception class errors") {
     typeDeclaration("public class Dummy {{ throw AssertException; }}")
     assert(
-      dummyIssues == "Error: line 1 at 28-43: Only Exception objects may be thrown, not 'System.AssertException'\n"
+      dummyIssues == "Error: line 1 at 28-43: Throw expression should return an Exception instance, not a 'System.AssertException' type\n"
     )
   }
 
@@ -37,7 +37,7 @@ class ThrowsTest extends AnyFunSuite with TestHelper {
       )
     )
     assert(
-      dummyIssues == "Error: line 1 at 28-39: Only Exception objects may be thrown, not 'MyException'\n"
+      dummyIssues == "Error: line 1 at 28-39: Throw expression should return an Exception instance, not a 'MyException' type\n"
     )
   }
 
@@ -49,15 +49,14 @@ class ThrowsTest extends AnyFunSuite with TestHelper {
       )
     )
     assert(
-      dummyIssues == "Error: line 1 at 28-41: Only Exception objects may be thrown, not 'MyClass'\n"
+      dummyIssues == "Error: line 1 at 28-41: Throw expression should return an Exception instance, not a 'MyClass' instance\n"
     )
   }
 
   test("Throw primitive errors") {
     typeDeclaration("public class Dummy {{ throw 'Hello'; }}")
     assert(
-      dummyIssues == "Error: line 1 at 28-35: Only Exception objects may be thrown, not 'System.String'\n"
+      dummyIssues == "Error: line 1 at 28-35: Throw expression should return an Exception instance, not a 'System.String' instance\n"
     )
   }
-
 }


### PR DESCRIPTION
This just improves the validation on throw and catch to make sure we are dealing with Exception types.