### PR TITLE
Improve validation on RunAsStatement

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
@@ -115,29 +115,33 @@ sealed abstract class Expression extends CST {
   /** Verify an expression result type matches a specific type logging an issue if not
     *
     * @param context    verify context to use
-    * @param typeName   to check for
+    * @param typeNames  set of permitted types
     * @param isStatic   check for static or instance value
     * @param prefix     for the log issue
     */
   def verifyIs(
     context: BlockVerifyContext,
-    typeName: TypeName,
+    typeNames: Set[TypeName],
     isStatic: Boolean,
     prefix: String
   ): (Boolean, ExprContext) = {
     val verifyResult = verify(context)
     if (
-      verifyResult.isDefined && (!verifyResult.isStatic.contains(
-        isStatic
-      ) || verifyResult.typeName != typeName)
+      verifyResult.isDefined && (!verifyResult.isStatic.contains(isStatic) ||
+        !typeNames.contains(verifyResult.typeName))
     ) {
-      val qualifier       = if (isStatic) "type" else "instance"
       val resultQualifier = if (verifyResult.isStatic.contains(true)) "type" else "instance"
+      val qualifier       = if (isStatic) "type" else "instance"
+      val requiredTypes = if (typeNames.size == 1) {
+        s"a '${typeNames.head}' $qualifier"
+      } else {
+        typeNames.map(n => s"'$n'").mkString("one of ", " or ", s" ${qualifier}s")
+      }
       context.log(
         Issue(
           ERROR_CATEGORY,
           location,
-          s"$prefix expression should return a '$typeName' $qualifier, not a '${verifyResult.typeName}' $resultQualifier"
+          s"$prefix expression should return $requiredTypes, not a '${verifyResult.typeName}' $resultQualifier"
         )
       )
       (false, verifyResult)

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
@@ -152,7 +152,7 @@ object LocalVariableDeclarationStatement {
 final case class IfStatement(expression: Expression, statements: Seq[Statement]) extends Statement {
   override def verify(context: BlockVerifyContext): Unit = {
     val exprResult =
-      expression.verifyIs(context, TypeNames.Boolean, isStatic = false, "If")
+      expression.verifyIs(context, Set(TypeNames.Boolean), isStatic = false, "If")
 
     // This is replicating a feature where non-block statements can pass declarations forward
     val stmtRootContext = new InnerBlockVerifyContext(context).withBranchingControl()
@@ -339,7 +339,7 @@ object ForUpdate {
 final case class WhileStatement(expression: Expression, statement: Option[Statement])
     extends Statement {
   override def verify(context: BlockVerifyContext): Unit = {
-    expression.verifyIs(context, TypeNames.Boolean, isStatic = false, "While")
+    expression.verifyIs(context, Set(TypeNames.Boolean), isStatic = false, "While")
     statement.foreach(_.verify(context))
   }
 }
@@ -356,7 +356,7 @@ object WhileStatement {
 final case class DoWhileStatement(statement: Option[Statement], expression: Expression)
     extends Statement {
   override def verify(context: BlockVerifyContext): Unit = {
-    expression.verifyIs(context, TypeNames.Boolean, isStatic = false, "While")
+    expression.verifyIs(context, Set(TypeNames.Boolean), isStatic = false, "While")
     statement.foreach(_.verify(context))
   }
 }
@@ -427,7 +427,7 @@ final case class CatchClause(
                 Issue(
                   ERROR_CATEGORY,
                   qname.location,
-                  s"Catch clause should catch an Exception instance, not a '${exceptionTypeName}' instance"
+                  s"Catch clause should catch an Exception instance, not a '$exceptionTypeName' instance"
                 )
               )
               context.module.any
@@ -634,7 +634,22 @@ object MergeStatement {
 final case class RunAsStatement(expressions: ArraySeq[Expression], block: Option[Block])
     extends Statement {
   override def verify(context: BlockVerifyContext): Unit = {
-    expressions.foreach(_.verify(context))
+    if (expressions.size != 1) {
+      context.log(
+        Issue(
+          ERROR_CATEGORY,
+          location,
+          s"System.runAs must be provided a User or Version argument, not ${expressions.size} arguments"
+        )
+      )
+    } else {
+      expressions.head.verifyIs(
+        context,
+        Set(TypeNames.UserSObject, TypeNames.Version),
+        isStatic = false,
+        "System.runAs"
+      )
+    }
     block.foreach(_.verify(context))
     verifyControlPath(context)
   }

--- a/jvm/src/main/scala/com/nawforce/apexlink/names/TypeNames.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/names/TypeNames.scala
@@ -112,6 +112,9 @@ object TypeNames extends InternCache[TypeName] {
   lazy val QueryLocator: TypeName =
     TypeName(XNames.QueryLocator, Nil, Some(TypeNames.Database)).intern
 
+  lazy val UserSObject: TypeName = TypeName(Names.User, Nil, Some(TypeNames.Schema))
+  lazy val Version: TypeName     = TypeName(Names.Version, Nil, Some(TypeNames.System))
+
   lazy val User: TypeName             = TypeName(Names.User).intern
   lazy val UserRecordAccess: TypeName = TypeName(Names.UserRecordAccess).intern
 

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/RunAsTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/RunAsTest.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 Certinia Inc. All rights reserved.
+ */
+package com.nawforce.apexlink.cst
+
+import com.nawforce.apexlink.TestHelper
+import org.scalatest.funsuite.AnyFunSuite
+
+class RunAsTest extends AnyFunSuite with TestHelper {
+
+  test("runAs with User") {
+    happyTypeDeclaration("public class Dummy {{ User u; System.runAs(u) {} }}")
+  }
+
+  test("runAs with Version") {
+    happyTypeDeclaration("public class Dummy {{ Version v; System.runAs(v) {} }}")
+  }
+
+  test("runAs with String") {
+    typeDeclaration("public class Dummy {{ System.runAs('') {} }}")
+    assert(
+      dummyIssues == "Error: line 1 at 35-37: System.runAs expression should return one of 'Schema.User' or 'System.Version' instances, not a 'System.String' instance\n"
+    )
+  }
+
+  test("runAs with SObject") {
+    typeDeclaration("public class Dummy {{ Account a; System.runAs(a) {} }}")
+    assert(
+      dummyIssues == "Error: line 1 at 46-47: System.runAs expression should return one of 'Schema.User' or 'System.Version' instances, not a 'Schema.Account' instance\n"
+    )
+  }
+
+  test("runAs with multiple args") {
+    typeDeclaration("public class Dummy {{ User u; System.runAs(u, u) {} }}")
+    assert(
+      dummyIssues == "Error: line 1 at 30-51: System.runAs must be provided a User or Version argument, not 2 arguments\n"
+    )
+  }
+}

--- a/shared/src/main/scala/com/nawforce/pkgforce/names/Names.scala
+++ b/shared/src/main/scala/com/nawforce/pkgforce/names/Names.scala
@@ -138,4 +138,5 @@ object Names extends CleanableCache {
   lazy val SetName: Name                 = cache("Set")
   lazy val MapName: Name                 = cache("Map")
   lazy val Exception: Name               = cache("Exception")
+  lazy val Version: Name                 = cache("Version")
 }


### PR DESCRIPTION
This depends on 114-throw-statement-and-catch-clause-dont-check-for-exception-types

It improves the validation on System.runAs. This is parsed a statement because of the associated block but Salesforce refer to it as a method. To handle more like a method the apex-parser allows for multiple parameters but in reality only one is supported which must either be a User SObject or System.Version object. We validate the expression provided returns one of these. 

I did think we should check this is only used in test context but its allowed in any code and produces a runtime exception if used outside of a test context so I have not added a check for being used in a test class. 