### PR TITLE
Improve validation on Expression Statement

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
@@ -538,6 +538,9 @@ final case class PostfixExpression(expression: Expression, op: String) extends E
 }
 
 final case class PrefixExpression(expression: Expression, op: String) extends Expression {
+
+  def isAssignmentOperation: Boolean = op == "++" || op == "--"
+
   override def verify(input: ExprContext, context: ExpressionVerifyContext): ExprContext = {
     val inter = expression.verify(input, context)
     if (!inter.isDefined)
@@ -576,7 +579,7 @@ final case class NegationExpression(expression: Expression, isBitwise: Boolean) 
 }
 
 final case class BinaryExpression(lhs: Expression, rhs: Expression, op: String) extends Expression {
-  private lazy val operation = op match {
+  private lazy val operation: Operation = op match {
     case "="    => AssignmentOperation
     case "&&"   => LogicalOperation
     case "||"   => LogicalOperation
@@ -610,6 +613,8 @@ final case class BinaryExpression(lhs: Expression, rhs: Expression, op: String) 
     case ">>="  => BitwiseAssignmentOperation
     case ">>>=" => BitwiseAssignmentOperation
   }
+
+  def isAssignmentOperation: Boolean = operation.isAssignmentOperation
 
   override def verify(input: ExprContext, context: ExpressionVerifyContext): ExprContext = {
     val leftInter  = lhs.verify(input, context)

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Operations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Operations.scala
@@ -21,6 +21,9 @@ import com.nawforce.apexlink.types.platform.PlatformTypes
 import com.nawforce.pkgforce.names.TypeName
 
 abstract class Operation {
+
+  def isAssignmentOperation: Boolean = false
+
   def verify(
     leftType: ExprContext,
     rightContext: ExprContext,
@@ -224,6 +227,8 @@ object Operation {
 }
 
 case object AssignmentOperation extends Operation {
+  override def isAssignmentOperation: Boolean = true
+
   override def verify(
     leftContext: ExprContext,
     rightContext: ExprContext,
@@ -374,6 +379,8 @@ case object ArithmeticOperation extends Operation {
 }
 
 case object ArithmeticAddSubtractAssignmentOperation extends Operation {
+  override def isAssignmentOperation: Boolean = true
+
   override def verify(
     leftContext: ExprContext,
     rightContext: ExprContext,
@@ -396,6 +403,8 @@ case object ArithmeticAddSubtractAssignmentOperation extends Operation {
 }
 
 case object ArithmeticMultiplyDivideAssignmentOperation extends Operation {
+  override def isAssignmentOperation: Boolean = true
+
   override def verify(
     leftContext: ExprContext,
     rightContext: ExprContext,
@@ -431,6 +440,8 @@ case object BitwiseOperation extends Operation {
 }
 
 case object BitwiseAssignmentOperation extends Operation {
+  override def isAssignmentOperation: Boolean = true
+
   override def verify(
     leftContext: ExprContext,
     rightContext: ExprContext,

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/ExpressionStatementTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/ExpressionStatementTest.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2023 Certinia Inc. All rights reserved.
+ */
+package com.nawforce.apexlink.cst
+
+import com.nawforce.apexlink.TestHelper
+import org.scalatest.funsuite.AnyFunSuite
+
+class ExpressionStatementTest extends AnyFunSuite with TestHelper {
+
+  test("New expression") {
+    happyTypeDeclaration("public class Dummy {{ new Dummy(); }}")
+  }
+
+  test("Method call expression") {
+    happyTypeDeclaration("public class Dummy { void func() { func(); } }")
+  }
+
+  test("Method call dot expression") {
+    happyTypeDeclaration("public class Dummy { static void func() { Dummy.func(); } }")
+  }
+
+  test("Postfix assignment expression") {
+    happyTypeDeclaration("public class Dummy {{ Integer i; i++; }}")
+  }
+
+  test("Prefix assignment expression") {
+    happyTypeDeclaration("public class Dummy {{ Integer i; ++i; }}")
+  }
+
+  test("Binary assignment expression") {
+    happyTypeDeclaration("public class Dummy {{ Integer i; i&=i; }}")
+  }
+
+  test("Sub expression") {
+    happyTypeDeclaration("public class Dummy {{ (new Account()); }}")
+  }
+
+  test("Field dot expression") {
+    typeDeclaration("public class Dummy {{ Account.Name; }}")
+    assert(
+      dummyIssues == "Error: line 1 at 22-34: Only assignment, new & method call expressions can be used as statements\n"
+    )
+  }
+
+  test("Array expression") {
+    typeDeclaration("public class Dummy {{ List<Object> a; a[1]; }}")
+    assert(
+      dummyIssues == "Error: line 1 at 38-42: Only assignment, new & method call expressions can be used as statements\n"
+    )
+  }
+
+  test("Cast expression") {
+    typeDeclaration("public class Dummy {{ (Account)(new Account()); }}")
+    assert(
+      dummyIssues == "Error: line 1 at 22-46: Only assignment, new & method call expressions can be used as statements\n"
+    )
+  }
+
+  test("Prefix expression") {
+    typeDeclaration("public class Dummy {{ Integer i; -i; }}")
+    assert(
+      dummyIssues == "Error: line 1 at 33-35: Only assignment, new & method call expressions can be used as statements\n"
+    )
+  }
+
+  test("Negation expression") {
+    typeDeclaration("public class Dummy {{ Boolean b; !b; }}")
+    assert(
+      dummyIssues == "Error: line 1 at 33-35: Only assignment, new & method call expressions can be used as statements\n"
+    )
+  }
+
+  test("Arithmetic expression") {
+    typeDeclaration("public class Dummy {{ Integer i; i+i; }}")
+    assert(
+      dummyIssues == "Error: line 1 at 33-36: Only assignment, new & method call expressions can be used as statements\n"
+    )
+  }
+
+  test("Bit expression") {
+    typeDeclaration("public class Dummy {{ Integer i; i&i; }}")
+    assert(
+      dummyIssues == "Error: line 1 at 33-36: Only assignment, new & method call expressions can be used as statements\n"
+    )
+  }
+
+  test("Comparison expression") {
+    typeDeclaration("public class Dummy {{ Integer i; i>=i; }}")
+    assert(
+      dummyIssues == "Error: line 1 at 33-37: Only assignment, new & method call expressions can be used as statements\n"
+    )
+  }
+
+  test("InstanceOf expression") {
+    typeDeclaration("public class Dummy {{ Integer i; i instanceOf Dummy; }}")
+    assert(
+      dummyIssues == "Error: line 1 at 33-51: Only assignment, new & method call expressions can be used as statements\n"
+    )
+  }
+
+  test("Equality expression") {
+    typeDeclaration("public class Dummy {{ Integer i; i <> i; }}")
+    assert(
+      dummyIssues == "Error: line 1 at 33-39: Only assignment, new & method call expressions can be used as statements\n"
+    )
+  }
+
+  test("Logical expression") {
+    typeDeclaration("public class Dummy {{ Boolean b; b && b; }}")
+    assert(
+      dummyIssues == "Error: line 1 at 33-39: Only assignment, new & method call expressions can be used as statements\n"
+    )
+  }
+
+}

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/FieldTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/FieldTest.scala
@@ -70,7 +70,7 @@ class FieldTest extends AnyFunSuite with TestHelper {
     typeDeclarations(
       Map(
         "Foo.cls" -> "public virtual class Foo {  public final static Bar Account {get {return new Bar();}} }",
-        "Bar.cls" -> "public class Bar extends Foo { public void method(){Account.Name;} }"
+        "Bar.cls" -> "public class Bar extends Foo { public void method(){SObjectField a = Account.Name;} }"
       )
     )
     assert(getMessages(root.join("Bar.cls")).isEmpty)

--- a/jvm/src/test/scala/com/nawforce/apexlink/types/ComponentTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/types/ComponentTest.scala
@@ -48,7 +48,7 @@ class ComponentTest extends AnyFunSuite with TestHelper {
     FileSystemHelper.run(
       Map(
         "Test.component" -> "<apex:component/>",
-        "Dummy.cls"      -> "public class Dummy { {Component.Test;} }"
+        "Dummy.cls"      -> "public class Dummy { {Object a = Component.Test;} }"
       )
     ) { root: PathLike =>
       createOrg(root)
@@ -57,13 +57,14 @@ class ComponentTest extends AnyFunSuite with TestHelper {
   }
 
   test("Missing component") {
-    FileSystemHelper.run(Map("Dummy.cls" -> "public class Dummy { {Component.Test;} }")) {
-      root: PathLike =>
-        createOrg(root)
-        assert(
-          getMessages(root.join("Dummy.cls")) ==
-            "Missing: line 1 at 22-36: Unknown field or type 'Test' on 'Component'\n"
-        )
+    FileSystemHelper.run(
+      Map("Dummy.cls" -> "public class Dummy { {Object a = Component.Test;} }")
+    ) { root: PathLike =>
+      createOrg(root)
+      assert(
+        getMessages(root.join("Dummy.cls")) ==
+          "Missing: line 1 at 33-47: Unknown field or type 'Test' on 'Component'\n"
+      )
     }
   }
 

--- a/jvm/src/test/scala/com/nawforce/apexlink/types/InterviewTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/types/InterviewTest.scala
@@ -35,7 +35,10 @@ class InterviewTest extends AnyFunSuite with TestHelper {
 
   test("Custom flow (MDAPI)") {
     FileSystemHelper.run(
-      Map("Test.flow" -> "", "Dummy.cls" -> "public class Dummy { {Flow.Interview.Test;} }")
+      Map(
+        "Test.flow" -> "",
+        "Dummy.cls" -> "public class Dummy { {Object a = Flow.Interview.Test;} }"
+      )
     ) { root: PathLike =>
       val org = createOrg(root)
       assert(org.issues.isEmpty)
@@ -46,7 +49,7 @@ class InterviewTest extends AnyFunSuite with TestHelper {
     FileSystemHelper.run(
       Map(
         "Test.flow-meta.xml" -> "",
-        "Dummy.cls"          -> "public class Dummy { {Flow.Interview.Test;} }"
+        "Dummy.cls"          -> "public class Dummy { {Object a = Flow.Interview.Test;} }"
       )
     ) { root: PathLike =>
       val org = createOrg(root)
@@ -55,14 +58,15 @@ class InterviewTest extends AnyFunSuite with TestHelper {
   }
 
   test("Missing flow") {
-    FileSystemHelper.run(Map("Dummy.cls" -> "public class Dummy { {Flow.Interview.Test;} }")) {
-      root: PathLike =>
-        createOrg(root)
-        // TODO: This should be a missing issue
-        assert(
-          getMessages(root.join("Dummy.cls")) ==
-            "Missing: line 1 at 22-41: Unknown field or type 'Test' on 'Flow.Interview'\n"
-        )
+    FileSystemHelper.run(
+      Map("Dummy.cls" -> "public class Dummy { {Object a = Flow.Interview.Test;} }")
+    ) { root: PathLike =>
+      createOrg(root)
+      // TODO: This should be a missing issue
+      assert(
+        getMessages(root.join("Dummy.cls")) ==
+          "Missing: line 1 at 33-52: Unknown field or type 'Test' on 'Flow.Interview'\n"
+      )
     }
   }
 


### PR DESCRIPTION

This add validation to ExpressionStatement (expression used as a statement) to handle the equivalent of the "Expression cannot be a statement" error you get in Apex. 

There are actually very few expressions that can be used as statements, broadly they are method & constructor call expressions, assignment expressions, new expression. You can also put brackets around these which is a sub expression in our CST.  