### PR TITLE
Support param passing to analysis providers

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/api/Org.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/api/Org.scala
@@ -269,7 +269,7 @@ object Org {
     options.loggingLevel.foreach(LoggerOps.setLoggingLevel)
     options.parser.foreach(ServerOps.setCurrentParser)
     options.externalAnalysisMode.foreach(mode =>
-      ServerOps.setExternalAnalysis(ExternalAnalysisConfiguration(mode))
+      ServerOps.setExternalAnalysis(ExternalAnalysisConfiguration(mode._1, mode._2))
     )
     options.cacheDirectory.foreach(path => {
       Environment.setCacheDirOverride(Some(Some(Path(path))))

--- a/jvm/src/main/scala/com/nawforce/apexlink/rpc/OrgAPI.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/rpc/OrgAPI.scala
@@ -190,7 +190,7 @@ object TestMethodItemsResult {
 case class OpenOptions private (
   parser: Option[String] = None,
   loggingLevel: Option[String] = None,
-  externalAnalysisMode: Option[String] = None,
+  externalAnalysisMode: Option[(String, Map[String, List[(String, List[String])]])] = None,
   cache: Option[Boolean] = None,
   cacheDirectory: Option[String] = None,
   indexerConfiguration: Option[(Long, Long)] = None,
@@ -205,8 +205,11 @@ case class OpenOptions private (
     copy(loggingLevel = Some(level))
   }
 
-  def withExternalAnalysisMode(mode: String): OpenOptions = {
-    copy(externalAnalysisMode = Some(mode))
+  def withExternalAnalysisMode(
+    mode: String,
+    params: Map[String, List[(String, List[String])]]
+  ): OpenOptions = {
+    copy(externalAnalysisMode = Some(mode, params))
   }
 
   def withCacheDirectory(path: String): OpenOptions = {

--- a/jvm/src/main/scala/io/github/apexdevtools/apexls/DependencyReport.scala
+++ b/jvm/src/main/scala/io/github/apexdevtools/apexls/DependencyReport.scala
@@ -81,7 +81,6 @@ object DependencyReport {
         .default()
         .withParser("OutlineSingle")
         .withAutoFlush(enabled = false)
-        .withExternalAnalysisMode(LoadAndRefreshAnalysis.shortName)
         .withLoggingLevel(loggingLevel)
         .withCache(!nocache)
         .withUnused(enabled = false)

--- a/jvm/src/test/scala/com/nawforce/apexlink/rpc/OrgAPITest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/rpc/OrgAPITest.scala
@@ -190,7 +190,7 @@ class OrgAPITest extends AsyncFunSuite with BeforeAndAfterEach with TestHelper {
       .default()
       .withParser("OutlineSingle")
       .withLoggingLevel("DEBUG")
-      .withExternalAnalysisMode("NoAnalysis")
+      .withExternalAnalysisMode(NoAnalysis.shortName, Map())
       .withCacheDirectory(cacheDir.toString)
       .withIndexerConfiguration(1, 2)
     val oldLogger = LoggerOps.setLogger(new TestNullLogger())


### PR DESCRIPTION
This adds support for passing parameters to Analysis providers via `CheckForIssues` command line. Note it changes the `OpenOptions` flags which will cause compatibility issues where `OpenOptions.withExternalAnalysisMode` is used.