### PR TITLE
Fix NullPointerException on while loop without block

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
@@ -479,7 +479,7 @@ object WhileStatement {
   def construct(parser: CodeParser, statement: WhileStatementContext): WhileStatement = {
     WhileStatement(
       Expression.construct(statement.parExpression().expression()),
-      Statement.construct(parser, statement.statement())
+      CodeParser.toScala(statement.statement()).flatMap(stmt => Statement.construct(parser, stmt))
     ).withContext(statement)
   }
 }

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/ForTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/ForTest.scala
@@ -191,4 +191,8 @@ class ForTest extends AnyFunSuite with TestHelper {
         "Error: line 1 at 28-29: For condition expression should return a 'System.Boolean' instance, not a 'System.Integer' instance\n"
     )
   }
+
+  test("for condition no block") {
+    happyTypeDeclaration("public class Dummy {{ for(;;); }}")
+  }
 }

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/WhileTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/WhileTest.scala
@@ -43,4 +43,8 @@ class WhileTest extends AnyFunSuite with TestHelper {
   test("Single block") {
     happyTypeDeclaration("public class Dummy {{ while (true) {System.debug('');} }}")
   }
+
+  test("No block") {
+    happyTypeDeclaration("public class Dummy {{ while (true); }}")
+  }
 }


### PR DESCRIPTION
[Issue](https://jira.internal.certinia.com/browse/TOOL-167)

Code was assuming the statement always existed, but parser allows both while and for loops to have condition only. This is already handled correctly by ForStatement so replicated this for WhileStatement.

