### PR TITLE
Add cache directory option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,14 @@ The jar is also executable without a client via the commands, `CheckForIssues` a
 
 The following arguments are available:
 
-| Argument | Description | Supported Commands |
-| --- | --- | --- |
-| `--format` / `-f` | Output format: `text (default) \| json \| pmd` | All |
-| `--logging` / `-l` | Text output logging level: `none (default) \| info \| debug` | All |
-| `--nocache` / `-n` | Do not load from or write to an existing apex-ls cache. | All |
-| `--workspace` / `-w` | Workspace directory path, defaults to current directory. Must contain an `sfdx-project.json` file. | All |
-| `--detail` / `-d` | Detail level: `errors (default) \| warnings \| unused` | CheckForIssues |
+| Argument             | Description                                                                                        | Supported Commands |
+|----------------------|----------------------------------------------------------------------------------------------------|--------------------|
+| `--format` / `-f`    | Output format: `text (default) \| json \| pmd`                                                     | All                |
+| `--logging` / `-l`   | Text output logging level: `none (default) \| info \| debug`                                       | All                |
+| `--nocache` / `-n`   | Do not load from or write to an existing apex-ls cache.                                            | All                |
+| `--cache-dir` / `-c` | Cache directory path, defaults to `APEXLINK_CACHE_DIR` env or `$HOME/.apexlink_cache`.             | All                |
+| `--workspace` / `-w` | Workspace directory path, defaults to current directory. Must contain an `sfdx-project.json` file. | All                |
+| `--detail` / `-d`    | Detail level: `errors (default) \| warnings \| unused`                                             | CheckForIssues     |
 
 ## Development
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/api/Org.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/api/Org.scala
@@ -273,13 +273,18 @@ object Org {
     )
     options.cacheDirectory.foreach(path => {
       Environment.setCacheDirOverride(Some(Some(Path(path))))
-      ServerOps.setAutoFlush(path.nonEmpty)
+      ServerOps.setAutoFlush(true)
     })
     options.indexerConfiguration.foreach(values =>
       ServerOps.setIndexerConfiguration(IndexerConfiguration(values._1, values._2))
     )
     options.autoFlush.foreach(enabled => ServerOps.setAutoFlush(enabled))
-    options.cache.foreach(enabled => if (!enabled) Environment.setCacheDirOverride(Some(None)))
+    options.cache.foreach(enabled =>
+      if (!enabled) {
+        Environment.setCacheDirOverride(Some(None))
+        ServerOps.setAutoFlush(false)
+      }
+    )
     options.unused.foreach(enabled =>
       if (!enabled) PluginsManager.removePlugins(Seq(classOf[UnusedPlugin]))
     )

--- a/jvm/src/main/scala/com/nawforce/apexlink/rpc/OrgAPI.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/rpc/OrgAPI.scala
@@ -213,7 +213,7 @@ case class OpenOptions private (
   }
 
   def withCacheDirectory(path: String): OpenOptions = {
-    copy(cacheDirectory = Some(path))
+    copy(cacheDirectory = Option(path).filter(_.nonEmpty))
   }
 
   def withCache(enabled: Boolean): OpenOptions = {

--- a/jvm/src/main/scala/com/nawforce/apexlink/rpc/OrgAPIImpl.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/rpc/OrgAPIImpl.scala
@@ -558,7 +558,7 @@ class OrgAPIImpl extends OrgAPI {
   }
 
   override def setCacheDirectory(path: Option[String]): Future[Unit] = {
-    Environment.setCacheDirOverride(Some(path.map(p => Path(p))))
+    Environment.setCacheDirOverride(Some(path.filter(_.nonEmpty).map(p => Path(p))))
     ServerOps.setAutoFlush(path.nonEmpty)
     Future.successful(())
   }

--- a/jvm/src/main/scala/com/nawforce/runtime/platform/Environment.scala
+++ b/jvm/src/main/scala/com/nawforce/runtime/platform/Environment.scala
@@ -42,11 +42,11 @@ object Environment {
     }
   }
 
-  // Only for test usage
   def setCacheDirOverride(value: Option[Option[PathLike]]): Unit = {
     cacheDirOverride = value
   }
 
+  // Only for test usage
   def getCacheDirOverride: Option[Option[PathLike]] = {
     cacheDirOverride
   }

--- a/jvm/src/main/scala/io/github/apexdevtools/apexls/CheckForIssues.scala
+++ b/jvm/src/main/scala/io/github/apexdevtools/apexls/CheckForIssues.scala
@@ -84,9 +84,11 @@ object CheckForIssues {
     )
     param: Seq[Param],
     @arg(short = 'w', doc = "Workspace directory path, defaults to current directory")
-    workspace: String = ""
+    workspace: String = "",
+    @arg(short = 'c', doc = "Cache directory path, defaults to env or home dir")
+    cacheDir: String = ""
   ): Unit = {
-    System.exit(run(format, logging, detail, nocache.value, param, workspace))
+    System.exit(run(format, logging, detail, nocache.value, param, workspace, cacheDir))
   }
 
   def main(args: Array[String]): Unit = {
@@ -99,7 +101,8 @@ object CheckForIssues {
     detail: String,
     nocache: Boolean,
     params: Seq[Param],
-    directory: String
+    directory: String,
+    cacheDirectory: String
   ): Int = {
     try {
       val workspace = Path(directory)
@@ -141,6 +144,7 @@ object CheckForIssues {
         .withExternalAnalysisMode(LoadAndRefreshAnalysis.shortName, Param.toMap(params))
         .withLoggingLevel(loggingLevel)
         .withCache(!nocache)
+        .withCacheDirectory(cacheDirectory)
         .withUnused(detailLevel == "unused")
 
       // Load org and flush to cache if we are using it

--- a/jvm/src/main/scala/io/github/apexdevtools/apexls/DependencyReport.scala
+++ b/jvm/src/main/scala/io/github/apexdevtools/apexls/DependencyReport.scala
@@ -43,16 +43,24 @@ object DependencyReport {
     @arg(short = 'n', doc = "Disable cache use")
     nocache: Flag,
     @arg(short = 'w', doc = "Workspace directory path, defaults to current directory")
-    workspace: String = ""
+    workspace: String = "",
+    @arg(short = 'c', doc = "Cache directory path, defaults to env or home dir")
+    cacheDir: String = ""
   ): Unit = {
-    System.exit(run(format, logging, nocache.value, workspace))
+    System.exit(run(format, logging, nocache.value, workspace, cacheDir))
   }
 
   def main(args: Array[String]): Unit = {
     ParserForMethods(this).runOrExit(ArraySeq.unsafeWrapArray(args))
   }
 
-  def run(format: String, logging: String, nocache: Boolean, directory: String): Int = {
+  def run(
+    format: String,
+    logging: String,
+    nocache: Boolean,
+    directory: String,
+    cacheDirectory: String
+  ): Int = {
     try {
       val workspace = Path(directory)
       val outputFormat = format match {
@@ -83,6 +91,7 @@ object DependencyReport {
         .withAutoFlush(enabled = false)
         .withLoggingLevel(loggingLevel)
         .withCache(!nocache)
+        .withCacheDirectory(cacheDirectory)
         .withUnused(enabled = false)
 
       // Load org and flush to cache if we are using it


### PR DESCRIPTION
Allows setting a cache directory override (`--cache-dir`/`-c`) for the APEXLINK_CACHE_DIR env for the main CLI classes. This is to make programmatic use of the commands a bit easier. Slight fix at the same time to avoid empty path strings overriding the env by default.