### PR TITLE
Add missing Id verify for formal parameters

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
@@ -268,6 +268,7 @@ class ApexMethodDeclaration(
     }
 
     returnTypeName.dependOn(id.location, context)
+    id.validate(context)
     parameters.foreach(_.verify(context))
 
     val blockContext =

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
@@ -463,8 +463,8 @@ final case class FormalParameter(
   }
 
   def verify(context: BodyDeclarationVerifyContext): Unit = {
+    id.validate(context)
     modifiers.issues.foreach(context.log)
-    // This is validated when made available to a Block
   }
 }
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
@@ -268,7 +268,7 @@ class ApexMethodDeclaration(
     }
 
     returnTypeName.dependOn(id.location, context)
-    id.validate(context)
+    id.validate(context, isMethod = true)
     parameters.foreach(_.verify(context))
 
     val blockContext =

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/CST.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/CST.scala
@@ -43,13 +43,17 @@ object CST {
 }
 
 final case class Id(name: Name) extends CST {
-  def validate(context: VerifyContext): Unit = {
+  def validate(context: VerifyContext, isMethod: Boolean = false): Unit = {
     if (name.nonEmpty) {
       val illegalError = name.isLegalIdentifier
       if (illegalError.nonEmpty)
         context.log(IssueOps.illegalIdentifier(location, name, illegalError.get))
-      else if (name.isReservedIdentifier)
-        context.log(IssueOps.reservedIdentifier(location, name))
+      else {
+        val isReserved =
+          if (isMethod) name.isReservedMethodIdentifier else name.isReservedIdentifier
+        if (isReserved)
+          context.log(IssueOps.reservedIdentifier(location, name))
+      }
     }
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/names/XNames.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/names/XNames.scala
@@ -85,8 +85,11 @@ object XNames {
     /** Check is name is a legal identifier, None if OK or error message string. */
     def isLegalIdentifier: Option[String] = Identifier.isLegalIdentifier(name)
 
-    /** Check is name is a reserved identifier, None if OK or error message string. */
+    /** Check is name is a reserved identifier. */
     def isReservedIdentifier: Boolean = Identifier.isReservedIdentifier(name)
+
+    /** Check is method name is a reserved identifier, special rules apply. */
+    def isReservedMethodIdentifier: Boolean = Identifier.isReservedMethodIdentifier(name)
 
     def isEmpty: Boolean = name.value.isEmpty
 

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
@@ -43,6 +43,18 @@ class MethodTest extends AnyFunSuite with TestHelper {
     assert(dummyIssues.isEmpty)
   }
 
+  test("Method call illegal param") {
+    typeDeclaration("public class Dummy {void f1(Integer _a){} void f2() {f1(1);} }")
+    assert(
+      dummyIssues == "Error: line 1 at 36-38: '_a' is not legal identifier in Apex, identifiers can not start or end with '_'\n"
+    )
+  }
+
+  test("Method call reserved param") {
+    typeDeclaration("public class Dummy {void f1(Integer limit){} void f2() {f1(1);} }")
+    assert(dummyIssues == "Error: line 1 at 36-41: 'limit' is a reserved identifier in Apex\n")
+  }
+
   test("Method call wrong arguments") {
     typeDeclaration("public class Dummy {static void f1(String a){} void f2() {f1();} }")
     assert(
@@ -448,7 +460,7 @@ class MethodTest extends AnyFunSuite with TestHelper {
         "force-app/Dummy.cls" ->
           """public class Dummy { {
             |ext.Something a;
-            | // Legal as should return an Any as we don't know which 'publish' was intended  
+            | // Legal as should return an Any as we don't know which 'publish' was intended
             |String b = EventBus.publish(a); } }
             |""".stripMargin
       )

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
@@ -43,6 +43,18 @@ class MethodTest extends AnyFunSuite with TestHelper {
     assert(dummyIssues.isEmpty)
   }
 
+  test("Method call illegal name") {
+    typeDeclaration("public class Dummy {void _a(){} void f2() {_a();} }")
+    assert(
+      dummyIssues == "Error: line 1 at 25-27: '_a' is not legal identifier in Apex, identifiers can not start or end with '_'\n"
+    )
+  }
+
+  test("Method call reserved name") {
+    typeDeclaration("public class Dummy {void limit(){} void f2() {limit();} }")
+    assert(dummyIssues == "Error: line 1 at 25-30: 'limit' is a reserved identifier in Apex\n")
+  }
+
   test("Method call illegal param") {
     typeDeclaration("public class Dummy {void f1(Integer _a){} void f2() {f1(1);} }")
     assert(

--- a/shared/src/main/scala/com/nawforce/pkgforce/names/Identifier.scala
+++ b/shared/src/main/scala/com/nawforce/pkgforce/names/Identifier.scala
@@ -21,7 +21,7 @@ object Identifier {
     assert(value.nonEmpty)
 
     if (value.startsWith("__sfdc_trigger")) {
-      if (!value.matches("^((__sfdc_trigger)[/][0-9a-zA-Z_]+)([/][0-9a-zA-Z_]+)?$")) {
+      if (!value.matches("^((__sfdc_trigger)/[0-9a-zA-Z_]+)(/[0-9a-zA-Z_]+)?$")) {
         return Some(
           "can only be in the format '__sfdc_trigger/namespace/name' or '__sfdc_trigger/name'"
         )
@@ -42,12 +42,17 @@ object Identifier {
 
   /** Check is name is a reserved identifier, None if OK or error message string. */
   def isReservedIdentifier(name: Name): Boolean = {
-    allReservedIdentifiers.contains(name)
+    reservedIdentifiers.contains(name)
   }
 
-  // This is the official reserved keyword list, not all are actually reserved, some are for "future" use, I have
-  // removed those known not to be enforced
-  lazy val reservedIdentifiers: Set[Name] = Set(
+  /** Check is name is a reserved identifier, None if OK or error message string. */
+  def isReservedMethodIdentifier(name: Name): Boolean = {
+    !methodNotReservedIdentifiers.contains(name) && reservedIdentifiers.contains(name)
+  }
+
+  // This is the official reserved keyword list, from
+  // https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_reserved_words.htm
+  private lazy val reservedIdentifiers: Set[Name] = Set(
     Name("abstract"),
     Name("activate"),
     Name("and"),
@@ -59,6 +64,7 @@ object Identifier {
     Name("begin"),
     Name("bigdecimal"),
     Name("blob"),
+    Name("boolean"),
     Name("break"),
     Name("bulk"),
     Name("by"),
@@ -72,11 +78,15 @@ object Identifier {
     Name("commit"),
     Name("const"),
     Name("continue"),
+    Name("currency"),
+    Name("date"),
+    Name("datetime"),
     Name("decimal"),
     Name("default"),
     Name("delete"),
     Name("desc"),
     Name("do"),
+    Name("double"),
     Name("else"),
     Name("end"),
     Name("enum"),
@@ -102,9 +112,10 @@ object Identifier {
     Name("inner"),
     Name("insert"),
     Name("instanceof"),
+    Name("int"),
+    Name("integer"),
     Name("interface"),
     Name("into"),
-    Name("int"),
     Name("join"),
     Name("like"),
     Name("limit"),
@@ -136,8 +147,10 @@ object Identifier {
     Name("select"),
     Name("set"),
     Name("short"),
+    Name("sobject"),
     Name("sort"),
     Name("static"),
+    Name("string"),
     Name("super"),
     Name("switch"),
     Name("synchronized"),
@@ -146,6 +159,7 @@ object Identifier {
     Name("then"),
     Name("this"),
     Name("throw"),
+    Name("time"),
     Name("transaction"),
     Name("trigger"),
     Name("true"),
@@ -155,23 +169,72 @@ object Identifier {
     Name("upsert"),
     Name("using"),
     Name("virtual"),
+    Name("void"),
     Name("webservice"),
     Name("when"),
     Name("where"),
     Name("while")
   )
 
-  // These are identifiers that don't work but are not reserved, yeah go figure
-  lazy val badIdentifiers: Set[Name] = Set(
+  // Methods can use some identifiers that are reserved
+  private lazy val methodNotReservedIdentifiers: Set[Name] = Set(
+    Name("activate"),
+    Name("any"),
+    Name("array"),
+    Name("autonomous"),
+    Name("begin"),
+    Name("bigdecimal"),
+    Name("blob"),
     Name("boolean"),
+    Name("byte"),
+    Name("case"),
+    Name("cast"),
+    Name("char"),
+    Name("collect"),
+    Name("const"),
     Name("currency"),
     Name("date"),
     Name("datetime"),
+    Name("decimal"),
+    Name("default"),
     Name("double"),
+    Name("end"),
+    Name("exception"),
+    Name("exit"),
+    Name("export"),
+    Name("float"),
+    Name("goto"),
+    Name("group"),
+    Name("hint"),
+    Name("import"),
+    Name("inner"),
     Name("integer"),
+    Name("int"),
+    Name("into"),
+    Name("join"),
+    Name("long"),
+    Name("loop"),
+    Name("number"),
+    Name("object"),
+    Name("of"),
+    Name("outer"),
+    Name("package"),
+    Name("parallel"),
+    Name("pragma"),
+    Name("retrieve"),
+    Name("rollback"),
+    Name("set"),
+    Name("short"),
+    Name("sobject"),
+    Name("sort"),
     Name("string"),
-    Name("time")
+    Name("switch"),
+    Name("synchronized"),
+    Name("system"),
+    Name("then"),
+    Name("time"),
+    Name("transaction"),
+    Name("void"),
+    Name("when")
   )
-
-  lazy val allReservedIdentifiers: Set[Name] = reservedIdentifiers ++ badIdentifiers
 }

--- a/shared/src/test/scala/com/nawforce/pkgforce/names/IdentifierTest.scala
+++ b/shared/src/test/scala/com/nawforce/pkgforce/names/IdentifierTest.scala
@@ -38,8 +38,9 @@ class IdentifierTest extends AnyFunSuite {
     "can only be in the format '__sfdc_trigger/namespace/name' or '__sfdc_trigger/name'"
 
   implicit class NameUtils(name: Name) {
-    def isLegalIdentifier: Option[String] = Identifier.isLegalIdentifier(name)
-    def isReservedIdentifier: Boolean     = Identifier.isReservedIdentifier(name)
+    def isLegalIdentifier: Option[String]   = Identifier.isLegalIdentifier(name)
+    def isReservedIdentifier: Boolean       = Identifier.isReservedIdentifier(name)
+    def isReservedMethodIdentifier: Boolean = Identifier.isReservedMethodIdentifier(name)
   }
 
   test("Illegal identifiers") {
@@ -67,5 +68,11 @@ class IdentifierTest extends AnyFunSuite {
     assert(Name("if").isReservedIdentifier)
     assert(Name("date").isReservedIdentifier)
     assert(!Name("foo").isReservedIdentifier)
+  }
+
+  test("Reserved method identifiers") {
+    assert(!Name("foo").isReservedMethodIdentifier)
+    assert(!Name("void").isReservedMethodIdentifier)
+    assert(Name("and").isReservedMethodIdentifier)
   }
 }


### PR DESCRIPTION
Alongside formal params I have revisited reserved names generally as the doc has been updated. Although when I tested methods you can use lots of the reserved names so I have added an exception list for these.