### PR TITLE
Fix missing Enum and Schema types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,8 +59,8 @@ lazy val apexls = crossProject(JSPlatform, JVMPlatform)
       "org.scala-js"            %% "scalajs-stubs"                  % "1.0.0",
       "io.github.apex-dev-tools" % "apex-parser"                    % "4.3.1",
       "io.github.apex-dev-tools" % "vf-parser"                      % "1.1.0",
-      "io.github.apex-dev-tools" % "sobject-types"                  % "62.0.0",
-      "io.github.apex-dev-tools" % "standard-types"                 % "62.0.0",
+      "io.github.apex-dev-tools" % "sobject-types"                  % "62.0.1",
+      "io.github.apex-dev-tools" % "standard-types"                 % "62.0.1",
       "io.methvin"              %% "directory-watcher-better-files" % "0.18.0",
       "com.github.nawforce"      % "uber-apex-jorje"                % "1.0.0" % Test,
       "com.google.jimfs"         % "jimfs"                          % "1.1"   % Test

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/platform/PlatformTypeDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/platform/PlatformTypeDeclaration.scala
@@ -489,6 +489,12 @@ object PlatformTypeDeclaration {
         Name("hashCode"),
         TypeNames.Integer,
         CustomMethodDeclaration.emptyParameters
+      ),
+      CustomMethodDeclaration(
+        Location.empty,
+        Name("toString"),
+        TypeNames.String,
+        CustomMethodDeclaration.emptyParameters
       )
     )
 }

--- a/jvm/src/test/scala/com/nawforce/apexlink/types/PlatformTypesValidationTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/types/PlatformTypesValidationTest.scala
@@ -186,11 +186,21 @@ class PlatformTypesValidationTest extends AnyFunSuite with TestHelper {
       })
   }
 
-  test("Enums should have ordinal method (bug)") {
+  test("Enums should have default methods") {
     val td = PlatformTypes.get(TypeName(Name("LoggingLevel")), None).getOrElse(null)
 
     assert(td.fields.exists(_.name == Name("DEBUG")))
-    assert(td.methods.exists(_.name == Name("ordinal")))
+    assert(
+      td.methods.map(_.toString).sorted.mkString("\n") == Seq(
+        "public System.String name()",
+        "public System.Integer ordinal()",
+        "public static System.List<System.LoggingLevel> values()",
+        "public static System.LoggingLevel valueOf(System.String name)",
+        "public System.Boolean equals(Object other)",
+        "public System.Integer hashCode()",
+        "public System.String toString()"
+      ).sorted.mkString("\n")
+    )
   }
 
   test("Extending platform type fulfills base Object interface") {


### PR DESCRIPTION
Add some types for `Schema.DescribeSObjectResult` and `toString` for enums.