### PR TITLE
301 improve schema type lookup performance

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/org/ModuleFind.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/ModuleFind.scala
@@ -91,18 +91,17 @@ trait ModuleFind {
       return declaration
 
     // SObject and alike, we want module specific version of these
-    declaration = types.get(targetType.withTail(TypeNames.Schema))
+    declaration = types.getWithSchema(targetType)
     if (declaration.nonEmpty)
       return declaration
 
     if (
-      targetType.params.isEmpty && (targetType.outer.isEmpty || targetType.outer.contains(
-        TypeNames.Schema
-      ))
+      targetType.params.isEmpty &&
+      (targetType.outer.isEmpty || targetType.outer.contains(TypeNames.Schema))
     ) {
       val encName = EncodedName(targetType.name).defaultNamespace(namespace)
       if (encName.ext.nonEmpty) {
-        return types.get(TypeName(encName.fullName, Nil, Some(TypeNames.Schema)))
+        return types.getWithSchema(TypeName(encName.fullName, Nil, None))
       }
     }
     None

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/PackageAPI.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/PackageAPI.scala
@@ -247,10 +247,12 @@ trait PackageAPI extends Package {
   def flush(pc: ParsedCache): Unit = {
     val context = packageContext
     modules.foreach(module => {
-      module.types.values.foreach({
-        case ad: ApexClassDeclaration => ad.flush(pc, context)
-        case _                        => ()
-      })
+      module.types
+        .values()
+        .foreach({
+          case ad: ApexClassDeclaration => ad.flush(pc, context)
+          case _                        => ()
+        })
     })
   }
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/TypeDeclarationCache.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/TypeDeclarationCache.scala
@@ -64,9 +64,10 @@ class TypeDeclarationCache {
   }
 
   def remove(typeName: TypeName): Option[TypeDeclaration] = {
-    val result = allTypes.remove(typeName)
-    if (typeName.outer.contains(TypeName.Schema)) {
-      schemaTypes.remove(typeName.withOuter(None))
+    val result   = allTypes.remove(typeName)
+    val stripped = typeName.replaceTail(TypeName.Schema, None)
+    if (stripped != typeName) {
+      schemaTypes.remove(stripped)
     }
     result
   }

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/TypeDeclarationCache.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/TypeDeclarationCache.scala
@@ -6,6 +6,7 @@ package com.nawforce.apexlink.org
 
 import com.nawforce.apexlink.types.core.TypeDeclaration
 import com.nawforce.pkgforce.names.TypeName
+import com.nawforce.pkgforce.names.TypeNameFuncs.TypeNameFuncs
 
 import scala.collection.mutable
 
@@ -27,9 +28,9 @@ class TypeDeclarationCache {
   /** Upsert an entry. Beware, assumes the TypeName is fully qualified. */
   def put(typeName: TypeName, td: TypeDeclaration): Unit = {
     allTypes.put(typeName, td)
-    if (typeName.outer.contains(TypeName.Schema)) {
-      schemaTypes.put(typeName.withOuter(None), td)
-    }
+    val stripped = typeName.replaceTail(TypeName.Schema, None)
+    if (stripped ne typeName)
+      schemaTypes.put(stripped, td)
   }
 
   def get(typeName: TypeName): Option[TypeDeclaration] = {

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/TypeDeclarationCache.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/TypeDeclarationCache.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 Certinia Inc. All rights reserved.
+ */
+
+package com.nawforce.apexlink.org
+
+import com.nawforce.apexlink.types.core.TypeDeclaration
+import com.nawforce.pkgforce.names.TypeName
+
+import scala.collection.mutable
+
+/** Cache of TypeDeclarations against their TypeName. Provided to speed up Schema namespace
+  * searched by avoiding the need to construct a new TypeName for each search.
+  */
+class TypeDeclarationCache {
+  private val allTypes    = mutable.Map[TypeName, TypeDeclaration]()
+  private val schemaTypes = mutable.Map[TypeName, TypeDeclaration]()
+
+  def size: Int = {
+    allTypes.size
+  }
+
+  def put(td: TypeDeclaration, altTypeName: Option[TypeName] = None): Unit = {
+    put(altTypeName.getOrElse(td.typeName), td)
+  }
+
+  /** Upsert an entry. Beware, assumes the TypeName is fully qualified. */
+  def put(typeName: TypeName, td: TypeDeclaration): Unit = {
+    allTypes.put(typeName, td)
+    if (typeName.outer.contains(TypeName.Schema)) {
+      schemaTypes.put(typeName.withOuter(None), td)
+    }
+  }
+
+  def get(typeName: TypeName): Option[TypeDeclaration] = {
+    allTypes.get(typeName)
+  }
+
+  def getUnsafe(typeName: TypeName): TypeDeclaration = {
+    allTypes(typeName)
+  }
+
+  def getWithSchema(typeName: TypeName): Option[TypeDeclaration] = {
+    schemaTypes.get(typeName)
+  }
+
+  def contains(typeName: TypeName): Boolean = {
+    allTypes.contains(typeName)
+  }
+
+  def values(): Iterable[TypeDeclaration] = {
+    allTypes.values
+  }
+
+  def filter(
+    pred: ((TypeName, TypeDeclaration)) => Boolean
+  ): mutable.Map[TypeName, TypeDeclaration] = {
+    allTypes.filter(pred)
+  }
+
+  def collect[T](pf: PartialFunction[(TypeName, TypeDeclaration), T]): mutable.Iterable[T] = {
+    allTypes.collect(pf)
+  }
+
+  def remove(typeName: TypeName): Option[TypeDeclaration] = {
+    val result = allTypes.remove(typeName)
+    if (typeName.outer.contains(TypeName.Schema)) {
+      schemaTypes.remove(typeName.withOuter(None))
+    }
+    result
+  }
+}

--- a/jvm/src/test/scala/com/nawforce/apexlink/org/TypeDeclarationCacheTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/org/TypeDeclarationCacheTest.scala
@@ -22,19 +22,21 @@ class TypeDeclarationCacheTest extends AnyFunSuite with TestHelper {
   private val nestedSchemaTypeName =
     TypeName(Name("Fake"), Nil, Some(TypeName(Name("Account"), Nil, Some(TypeNames.Schema))))
 
-  test("Empty cache has no size") {
-    assert(new TypeDeclarationCache().size == 0)
+  test("Empty cache behaviour") {
+    val cache = new TypeDeclarationCache()
+    assert(cache.size == 0)
+    assert(cache.values().toList == Nil)
+    assert(cache.filter(_ => true).isEmpty)
+    assert(cache.collect { case _ => }.isEmpty)
   }
 
   forAll(
     List(
-      /*
       simpleTypeName,
       scopedTypeName,
       systemTypeName,
       genericTypeName,
       schemaTypeName,
-       */
       nestedSchemaTypeName
     )
   ) { testTypeName =>
@@ -56,6 +58,14 @@ class TypeDeclarationCacheTest extends AnyFunSuite with TestHelper {
 
       assert(cache.remove(testTypeName).contains(null))
       assert(cache.size == 0)
+      assert(!cache.contains(testTypeName))
+      assert(cache.get(testTypeName).isEmpty)
+      assert(cache.getWithSchema(testTypeName).isEmpty)
+      if (stripped != testTypeName)
+        assert(cache.getWithSchema(stripped).isEmpty)
+      assert(cache.values().toList == Nil)
+      assert(cache.filter(_._1 == testTypeName).isEmpty)
+      assert(cache.collect { case (t: TypeName, null) if t == testTypeName => }.isEmpty)
     }
   }
 

--- a/jvm/src/test/scala/com/nawforce/apexlink/org/TypeDeclarationCacheTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/org/TypeDeclarationCacheTest.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024 Certinia Inc. All rights reserved.
+ */
+package com.nawforce.apexlink.org
+
+import com.nawforce.apexlink.TestHelper
+import com.nawforce.apexlink.names.TypeNames
+import com.nawforce.pkgforce.names.TypeNameFuncs.TypeNameFuncs
+import com.nawforce.pkgforce.names.{Name, TypeName}
+import org.scalatest.Inspectors.forAll
+import org.scalatest.funsuite.AnyFunSuite
+
+class TypeDeclarationCacheTest extends AnyFunSuite with TestHelper {
+
+  private val simpleTypeName = TypeName(Name("Simple"))
+  private val scopedTypeName = TypeName(Name("Scoped"), Nil, Some(TypeName(Name("Outer"))))
+  private val systemTypeName = TypeName(Name("String"), Nil, Some(TypeName(Name("System"))))
+  private val genericTypeName =
+    TypeName(Name("List"), systemTypeName :: Nil, Some(TypeName(Name("System"))))
+  private val schemaTypeName =
+    TypeName(Name("Account"), Nil, Some(TypeNames.Schema))
+  private val nestedSchemaTypeName =
+    TypeName(Name("Fake"), Nil, Some(TypeName(Name("Account"), Nil, Some(TypeNames.Schema))))
+
+  test("Empty cache has no size") {
+    assert(new TypeDeclarationCache().size == 0)
+  }
+
+  forAll(
+    List(
+      /*
+      simpleTypeName,
+      scopedTypeName,
+      systemTypeName,
+      genericTypeName,
+      schemaTypeName,
+       */
+      nestedSchemaTypeName
+    )
+  ) { testTypeName =>
+    test(s"$testTypeName name can be added and removed") {
+      val cache = new TypeDeclarationCache()
+      cache.put(testTypeName, null)
+
+      assert(cache.size == 1)
+      assert(cache.contains(testTypeName))
+      assert(cache.get(testTypeName).contains(null))
+      assert(cache.getUnsafe(testTypeName) == null)
+      assert(cache.getWithSchema(testTypeName).isEmpty)
+      val stripped = testTypeName.replaceTail(TypeName.Schema, None)
+      if (stripped != testTypeName)
+        assert(cache.getWithSchema(stripped).nonEmpty)
+      assert(cache.values().toList == List(null))
+      assert(cache.filter(_._1 == testTypeName).nonEmpty)
+      assert(cache.collect { case (t: TypeName, null) if t == testTypeName => }.nonEmpty)
+
+      assert(cache.remove(testTypeName).contains(null))
+      assert(cache.size == 0)
+    }
+  }
+
+}

--- a/shared/src/main/scala/com/nawforce/pkgforce/names/TypeNameFuncs.scala
+++ b/shared/src/main/scala/com/nawforce/pkgforce/names/TypeNameFuncs.scala
@@ -20,5 +20,23 @@ object TypeNameFuncs {
     def outerName: Name =
       typeName.outer.map(_.outerName).getOrElse(typeName.name)
 
+    /** Replace the tail section of a TypeName with something else.
+      * @return an updated TypeName or this if not matched.
+      */
+    def replaceTail(tail: TypeName, replacement: Option[TypeName]): TypeName = {
+      if (typeName.outer.contains(tail))
+        return TypeName(typeName.name, typeName.params, replacement)
+
+      typeName.outer
+        .map(outer => {
+          val dropped = outer.replaceTail(tail, replacement)
+          if (dropped ne outer) {
+            TypeName(typeName.name, typeName.params, Some(dropped))
+          } else {
+            typeName
+          }
+        })
+        .getOrElse(typeName)
+    }
   }
 }


### PR DESCRIPTION
This improves loading performance on large workspaces by ~1/3rd by avoiding the need to create TypeNames just for searching for a matching Schema type declaration for the name. 

It introduces a cache type that maintains a separate dictionary for Schema types so given a TypeName we can just test for a match without creating a new TypeName. The Schema dictionary is constructed as types are added to the cache.