### PR TITLE
303 improve super type declaration performance lookup

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/types/apex/ApexDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/apex/ApexDeclaration.scala
@@ -228,11 +228,25 @@ trait ApexClassDeclaration extends ApexDeclaration with DependencyHolder {
   /** Override to handle request to flush the type to passed cache if dirty */
   def flush(pc: ParsedCache, context: PackageContext): Unit
 
-  override def superClassDeclaration: Option[TypeDeclaration] =
-    superClass.flatMap(sc => TypeResolver(sc, this).toOption)
+  private var _superClassDeclaration: Option[TypeDeclaration] = None
 
-  override def interfaceDeclarations: ArraySeq[TypeDeclaration] =
-    interfaces.flatMap(i => TypeResolver(i, this).toOption)
+  override def superClassDeclaration: Option[TypeDeclaration] = {
+    // Don't cache empty as maybe currently missing
+    if (_superClassDeclaration.isEmpty) {
+      _superClassDeclaration = superClass.flatMap(sc => TypeResolver(sc, this).toOption)
+    }
+    _superClassDeclaration
+  }
+
+  private var _interfaceDeclarations: ArraySeq[TypeDeclaration] = ArraySeq.empty
+
+  override def interfaceDeclarations: ArraySeq[TypeDeclaration] = {
+    // Don't cache empty as maybe currently missing
+    if (_interfaceDeclarations.size != interfaces.size) {
+      _interfaceDeclarations = interfaces.flatMap(i => TypeResolver(i, this).toOption)
+    }
+    _interfaceDeclarations
+  }
 
   /** Obtain a source hash for this class and all it's ancestors */
   def deepHash: Int = {


### PR DESCRIPTION
This depends on https://github.com/apex-dev-tools/apex-ls/pull/302

It adds caching support for super type declarations and interface for Apex classes. This improves loading time on large workspaces by ~20%. 

As super class and interface may be missing and subsequently added to the workspace that caching is only used if the superclass/interface can be resolved to type declarations.