### PR TITLE
Allow EncodedName to be constructed with a default namespace

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/VerifyContext.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/VerifyContext.scala
@@ -461,5 +461,5 @@ final class ExpressionVerifyContext(parentContext: BlockVerifyContext) extends V
     parentContext.getVar(name, markUsed: Boolean)
 
   def defaultNamespace(name: Name): Name =
-    EncodedName(name).defaultNamespace(module.namespace).fullName
+    EncodedName(name, module.namespace).fullName
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/ModuleFind.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/ModuleFind.scala
@@ -99,7 +99,7 @@ trait ModuleFind {
       targetType.params.isEmpty &&
       (targetType.outer.isEmpty || targetType.outer.contains(TypeNames.Schema))
     ) {
-      val encName = EncodedName(targetType.name).defaultNamespace(namespace)
+      val encName = EncodedName(targetType.name, namespace)
       if (encName.ext.nonEmpty) {
         return types.getWithSchema(TypeName(encName.fullName, Nil, None))
       }

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/SObjectDeployer.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/SObjectDeployer.scala
@@ -59,7 +59,7 @@ class SObjectDeployer(module: OPM.Module) {
 
     while (objectsEvents.hasNext) {
       val sObjectEvent = objectsEvents.next().asInstanceOf[SObjectEvent]
-      val encodedName  = EncodedName(sObjectEvent.name).defaultNamespace(module.namespace)
+      val encodedName  = EncodedName(sObjectEvent.name, module.namespace)
       val typeName     = TypeName(encodedName.fullName, Nil, Some(TypeNames.Schema))
       val nature       = SObjectNature(sObjectEvent.name, sObjectEvent)
 
@@ -632,7 +632,7 @@ class SObjectDeployer(module: OPM.Module) {
   }
 
   private def defaultNamespace(name: Name): Name = {
-    EncodedName(name).defaultNamespace(module.namespace).fullName
+    EncodedName(name, module.namespace).fullName
   }
 
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/schema/SObjectFieldFinder.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/schema/SObjectFieldFinder.scala
@@ -70,7 +70,7 @@ trait SObjectFieldFinder {
   }
 
   private def getRelationshipField(name: Name): Option[FieldDeclaration] = {
-    val encodedName = EncodedName(name).defaultNamespace(module.namespace)
+    val encodedName = EncodedName(name, module.namespace)
     if (encodedName.ext.contains(relationshipExtension)) {
       getRelationshipField(this, encodedName)
         .orElse(

--- a/shared/src/main/scala/com/nawforce/pkgforce/names/EncodedName.scala
+++ b/shared/src/main/scala/com/nawforce/pkgforce/names/EncodedName.scala
@@ -55,7 +55,11 @@ object EncodedName {
     apply(name.value)
   }
 
-  def apply(name: String): EncodedName = {
+  def apply(name: Name, defaultNamespace: Option[Name]): EncodedName = {
+    apply(name.value, defaultNamespace)
+  }
+
+  def apply(name: String, defaultNamespace: Option[Name] = None): EncodedName = {
     val parts = nameSplit(name)
     parts.size match {
       case 3 =>
@@ -69,7 +73,7 @@ object EncodedName {
       case 2 =>
         val normalExt = parts(1).toLowerCase
         if (extensions.contains(normalExt) || normalExt.endsWith("__s"))
-          EncodedName(Name(parts.head), Some(Name(parts(1))), None)
+          EncodedName(Name(parts.head), Some(Name(parts(1))), defaultNamespace)
         else
           EncodedName(Name(parts(1)), None, Some(Name(parts.head)))
       case 0 => EncodedName(Name(name), None, None)


### PR DESCRIPTION
This gives a small gain, ~7%, when loading large workspaces by avoiding an additional call to default the namespace on an EncodedName. 