### PR TITLE
307 improve type finding performance

### DIFF
--- a/shared/src/main/scala/com/nawforce/pkgforce/pkgs/TriHierarchy.scala
+++ b/shared/src/main/scala/com/nawforce/pkgforce/pkgs/TriHierarchy.scala
@@ -55,13 +55,13 @@ abstract class TriHierarchy {
     /** Is this a ghost package, aka it has no modules. */
     lazy val isGhosted: Boolean = modules.isEmpty
 
-    /* Find first module in search order (may not be in this package) */
-    def firstModule: Option[TModule] = {
+    /** Find first module in search order (may not be in this package) */
+    lazy val firstModule: Option[TModule] = {
       orderedModules.headOption
         .orElse(basePackages.headOption.flatMap(_.firstModule))
     }
 
-    /* Check if a type is ghosted in this package */
+    /** Check if a type is ghosted in this package */
     def isGhostedType(typeName: TypeName): Boolean = {
       if (typeName.outer.contains(TypeName.Schema)) {
         val encName = EncodedName(typeName.name)
@@ -92,8 +92,11 @@ abstract class TriHierarchy {
     /** The modules that this module depends on deploy order */
     val dependents: ArraySeq[TModule]
 
-    /** The module (& owning package namespace) */
+    /** The module (& owning package) namespace */
     lazy val namespace: Option[Name] = pkg.namespace
+
+    /** The module (& owning package) namespace prefix */
+    lazy val namespacePrefix: String = namespace.map(ns => ns.toString + "__").getOrElse("")
 
     /** The package the parent package depends on in reverse deploy order */
     lazy val basePackages: ArraySeq[TPackage] = pkg.basePackages.reverse
@@ -101,25 +104,18 @@ abstract class TriHierarchy {
     /** The modules that this module depends on in reverse deploy order */
     lazy val baseModules: ArraySeq[TModule] = dependents.reverse
 
-    /** Test if a file is visible to this module, i.e. in scope & not ignored */
-    def isVisibleFile(path: PathLike): Boolean
-
-    /* Transitive Modules (dependent modules for this modules & its dependents) */
-    def transitiveModules: Set[TModule] = {
-      namespace
-        .map(_ => dependents.toSet ++ dependents.flatMap(_.transitiveModules))
-        .getOrElse(baseModules.toSet)
-    }
-
-    /* Find next module in search order */
-    def nextModule: Option[TModule] = {
+    /** Find next module in search order */
+    lazy val nextModule: Option[TModule] = {
       baseModules.headOption.orElse(basePackages.headOption.flatMap(_.firstModule))
     }
 
-    /* Check if a type name is ghosted in this module */
+    /** Test if a file is visible to this module, i.e. in scope & not ignored */
+    def isVisibleFile(path: PathLike): Boolean
+
+    /** Check if a type name is ghosted in this module */
     def isGhostedType(typeName: TypeName): Boolean = pkg.isGhostedType(typeName)
 
-    /* Check if a field name is ghosted in this module */
+    /** Check if a field name is ghosted in this module */
     def isGhostedFieldName(name: Name): Boolean = pkg.isGhostedFieldName(name)
   }
 }

--- a/shared/src/test/scala/com/nawforce/pkgforce/names/EncodedNameTest.scala
+++ b/shared/src/test/scala/com/nawforce/pkgforce/names/EncodedNameTest.scala
@@ -27,6 +27,7 @@
  */
 package com.nawforce.pkgforce.names
 
+import org.scalatest.Inspectors.forAll
 import org.scalatest.funsuite.AnyFunSuite
 
 class EncodedNameTest extends AnyFunSuite {
@@ -138,4 +139,29 @@ class EncodedNameTest extends AnyFunSuite {
     assert(testName.fullName == Name("ns__Foo__x"))
     assert(testName.asTypeName == TypeName(Name("ns__Foo__x"), Nil, None))
   }
+
+  forAll(List("c", "r", "e", "b", "mdt", "share", "history", "feed")) { ext =>
+    test(s"needs namespace simple extensions $ext") {
+      assert(!EncodedName.encodedNeedsNamespace(Name("")))
+      assert(!EncodedName.encodedNeedsNamespace(Name(s"$ext")))
+      assert(!EncodedName.encodedNeedsNamespace(Name(s"__$ext")))
+      assert(EncodedName.encodedNeedsNamespace(Name(s"a__$ext")))
+      assert(EncodedName.encodedNeedsNamespace(Name(s"abc__$ext")))
+      assert(!EncodedName.encodedNeedsNamespace(Name(s"__abc__$ext")))
+      assert(!EncodedName.encodedNeedsNamespace(Name(s"n__abc__$ext")))
+    }
+  }
+
+  test("needs namespace subfield extension") {
+    assert(!EncodedName.encodedNeedsNamespace(Name("")))
+    assert(!EncodedName.encodedNeedsNamespace(Name("s")))
+    assert(!EncodedName.encodedNeedsNamespace(Name("__s")))
+    assert(EncodedName.encodedNeedsNamespace(Name("a__s")))
+    assert(EncodedName.encodedNeedsNamespace(Name("abc__s")))
+    assert(EncodedName.encodedNeedsNamespace(Name("__abc__s")))
+    assert(EncodedName.encodedNeedsNamespace(Name("a__abc__s")))
+    assert(EncodedName.encodedNeedsNamespace(Name("abc__abc__s")))
+    assert(!EncodedName.encodedNeedsNamespace(Name("n__abc__abc__s")))
+  }
+
 }


### PR DESCRIPTION
This depends on https://github.com/apex-dev-tools/apex-ls/pull/306.

It improves loading performance of a large workspace by ~8%. This is achieved by streamlining the detection of when namespaces need to be defaulted on Encoded Names and changing modules access defs to lazy vals so they cache.