### PR TITLE
Add refresh listener to Org API

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/api/Org.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/api/Org.scala
@@ -14,7 +14,7 @@
 
 package com.nawforce.apexlink.api
 
-import com.nawforce.apexlink.org.OPM
+import com.nawforce.apexlink.org.{OPM, RefreshListener}
 import com.nawforce.apexlink.plugins.{PluginsManager, UnusedPlugin}
 import com.nawforce.apexlink.rpc.{
   BombScore,
@@ -74,6 +74,13 @@ trait Org {
     * determine if the queue of changes to be processed is empty.
     */
   def isDirty(): Boolean
+
+  /** Add or remove a listener which is called when all metadata changes have been processed.
+    *
+    * Similar to polling until isDirty = false, though the action will run on the same thread as
+    * the flusher and block it until completed. Use with caution.
+    */
+  def setRefreshListener(rl: Option[RefreshListener]): Unit
 
   /** Collection of all current issues reported against this org.
     */
@@ -242,6 +249,7 @@ trait Org {
     * Class namespaces are NOT included.
     */
   def getTestMethodItems(paths: Array[String]): Array[MethodTestItem]
+
 }
 
 object Org {

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/Flusher.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/Flusher.scala
@@ -22,8 +22,8 @@ import com.nawforce.pkgforce.path.PathLike
 import scala.collection.mutable
 
 trait RefreshListener {
-  def onRefresh(orgPath: PathLike, updatedPath: PathLike): Unit
-  def onRefreshAll(orgPath: PathLike, updatedPaths: Seq[PathLike]): Unit
+  def onRefreshOne(orgPath: PathLike, updatedPath: PathLike): Unit
+  def onRefreshMany(orgPath: PathLike, updatedPaths: Seq[PathLike]): Unit
 }
 
 case class RefreshRequest(pkg: OPM.PackageImpl, path: PathLike, highPriority: Boolean)
@@ -47,7 +47,7 @@ class Flusher(org: OPM.OrgImpl, parsedCache: Option[ParsedCache]) {
       org.refreshLock.synchronized {
         val updated = request.pkg.refreshBatched(Seq(request))
         // Notify of updated path
-        if (updated) listener.foreach(_.onRefresh(org.path, request.path))
+        if (updated) listener.foreach(_.onRefreshOne(org.path, request.path))
 
         // Tell auto flush we skipped the queue
         skippedQueue |= updated
@@ -84,7 +84,7 @@ class Flusher(org: OPM.OrgImpl, parsedCache: Option[ParsedCache]) {
         flush()
 
         // Notify of updated paths
-        if (updated) listener.foreach(_.onRefreshAll(org.path, updatedPaths.toSeq))
+        if (updated) listener.foreach(_.onRefreshMany(org.path, updatedPaths.toSeq))
 
         updated
       }

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/Flusher.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/Flusher.scala
@@ -21,6 +21,11 @@ import com.nawforce.pkgforce.path.PathLike
 
 import scala.collection.mutable
 
+trait RefreshListener {
+  def onRefresh(orgPath: PathLike, updatedPath: PathLike): Unit
+  def onRefreshAll(orgPath: PathLike, updatedPaths: Seq[PathLike]): Unit
+}
+
 case class RefreshRequest(pkg: OPM.PackageImpl, path: PathLike, highPriority: Boolean)
 
 class Flusher(org: OPM.OrgImpl, parsedCache: Option[ParsedCache]) {

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/OPM.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/OPM.scala
@@ -188,6 +188,10 @@ object OPM extends TriHierarchy {
         false
     }
 
+    def setRefreshListener(rl: Option[RefreshListener]): Unit = {
+      flusher.setListener(rl)
+    }
+
     /** Queue a metadata refresh request */
     def queueMetadataRefresh(request: RefreshRequest): Unit = {
       flusher.queue(request)

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/PackageAPI.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/PackageAPI.scala
@@ -268,8 +268,13 @@ trait PackageAPI extends Package {
 
   private[nawforce] def refreshAll(paths: Array[PathLike]): Unit = {
     OrgInfo.current.withValue(org) {
-      val highPriority = paths.length == 1
-      org.queueMetadataRefresh(paths.map(path => RefreshRequest(this, path, highPriority)))
+      if (paths.length == 1) {
+        org.queueMetadataRefresh(RefreshRequest(this, paths.head, highPriority = true))
+      } else {
+        org.queueMetadataRefresh(
+          paths.map(path => RefreshRequest(this, path, highPriority = false))
+        )
+      }
     }
   }
 

--- a/jvm/src/test/scala/com/nawforce/apexlink/TestHelper.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/TestHelper.scala
@@ -15,7 +15,7 @@ package com.nawforce.apexlink
 
 import com.nawforce.apexlink.TestHelper.{CURSOR, locToString}
 import com.nawforce.apexlink.api._
-import com.nawforce.apexlink.org.{OPM, OrgInfo}
+import com.nawforce.apexlink.org.{OPM, OrgInfo, RefreshListener}
 import com.nawforce.apexlink.plugins.{Plugin, PluginsManager}
 import com.nawforce.apexlink.rpc.{LocationLink, TargetLocation}
 import com.nawforce.apexlink.types.apex.{ApexClassDeclaration, ApexFullDeclaration, FullDeclaration}


### PR DESCRIPTION
- [x] Snapshot release  - [5.7.0+4-29d29748-SNAPSHOT](https://s01.oss.sonatype.org/content/repositories/snapshots/io/github/apex-dev-tools/apex-ls_2.13/5.7.0+4-29d29748-SNAPSHOT/)

Adds a new Org API to set a sync listener for refresh, intended to be used in conjunction with some other mechanism e.g. RPC to post messages from server to client. Since it currently shares the same thread as flusher, it's not really suitable for "work".

Also identified two issues with indexer refreshing and cache flushing

- When using the indexer to report file changes, a high priority refresh (i.e. a single file change) was not being respected and the end result was a batched refresh + cache flush (`flusher.refreshAndFlush`) in all cases.
    - This is because there are two `Org.queueMetadataRefresh` methods, one accepting an `Iterable` that was being used instead of the other intended one when `requests.length = 1`

- When using `autoFlush = true`, a now fixed high priority refresh request (from above) would do the refresh step but now not flush to cache (until the next queued update / multi file change).
    - Instead of setting it to do this immediately again, set a flag for the flusher thread to pick up on its next check for dirty state. This way if other requests were queued while the thread is asleep, a flush would not happen unnecessarily.

