### PR TITLE
Fix completion handling of visibility

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -20,6 +20,8 @@ jobs:
           java-version: 8
           cache: "sbt"
 
+      - uses: sbt/setup-sbt@v1
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/BuildCrossPlatform.yml
+++ b/.github/workflows/BuildCrossPlatform.yml
@@ -27,6 +27,8 @@ jobs:
           distribution: "temurin"
           java-version: ${{ matrix.java_version }}
 
+      - uses: sbt/setup-sbt@v1
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/BuildWin.yml
+++ b/.github/workflows/BuildWin.yml
@@ -18,6 +18,8 @@ jobs:
           java-version: 8
           cache: "sbt"
 
+      - uses: sbt/setup-sbt@v1
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -35,6 +35,8 @@ jobs:
           distribution: "temurin"
           java-version: 8
 
+      - uses: sbt/setup-sbt@v1
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -16,6 +16,8 @@ jobs:
           java-version: 8
           cache: "sbt"
 
+      - uses: sbt/setup-sbt@v1
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
@@ -340,9 +340,7 @@ final case class ApexFieldDeclaration(
 
   override def idLocation: Location = id.location.location
 
-  override val name: Name = id.name
-  private val visibility: Option[Modifier] =
-    _modifiers.modifiers.find(ApexModifiers.visibilityModifiers.contains)
+  override val name: Name                   = id.name
   override val readAccess: Modifier         = visibility.getOrElse(PRIVATE_MODIFIER)
   override val writeAccess: Modifier        = readAccess
   override val children: ArraySeq[ApexNode] = ArraySeq.empty

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Properties.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Properties.scala
@@ -57,8 +57,6 @@ final case class ApexPropertyDeclaration(
       case _                      => None
     }.headOption
 
-  private val visibility: Option[Modifier] =
-    _modifiers.modifiers.find(m => ApexModifiers.visibilityModifiers.contains(m))
   override val readAccess: Modifier =
     getter
       .flatMap(_.modifiers.modifiers.headOption)

--- a/jvm/src/main/scala/com/nawforce/apexlink/plugins/UnusedPlugin.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/plugins/UnusedPlugin.scala
@@ -162,7 +162,7 @@ class UnusedPlugin(td: DependentType) extends Plugin(td) {
         return false
 
       // Don't promote for global as these are implicitly used
-      if (td.visibility == GLOBAL_MODIFIER)
+      if (td.visibility.getOrElse(PRIVATE_MODIFIER) == GLOBAL_MODIFIER)
         return false
 
       // Exclude reporting on empty outers, that is just a bit harsh

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/apex/FullDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/apex/FullDeclaration.scala
@@ -181,7 +181,7 @@ abstract class FullDeclaration(
         OrgInfo.logError(id.location, s"Parent type '${superClass.get.asDotName}' must be a class")
       } else if (
         !inTest &&
-        superClassDeclaration.visibility == PRIVATE_MODIFIER &&
+        superClassDeclaration.visibility.getOrElse(PRIVATE_MODIFIER) == PRIVATE_MODIFIER &&
         superClassDeclaration.outermostTypeDeclaration != outermostTypeDeclaration
       ) {
         // Private is OK with Outer extends Inner, Inner extends Inner or Test classes

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/synthetic/CustomFieldDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/synthetic/CustomFieldDeclaration.scala
@@ -30,8 +30,7 @@ abstract class CustomField(
   override val modifiers: ArraySeq[Modifier] = CustomField.getModifiers(asStatic)
   override val readAccess: Modifier          = PUBLIC_MODIFIER
   override val writeAccess: Modifier         = PUBLIC_MODIFIER
-  override def isStatic: Boolean             = asStatic
-  override def isPrivate: Boolean            = false
+  override val isStatic: Boolean             = asStatic
 }
 
 object CustomField {

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/synthetic/CustomMethodDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/synthetic/CustomMethodDeclaration.scala
@@ -38,7 +38,7 @@ final case class CustomMethodDeclaration(
 
   override val modifiers: ArraySeq[Modifier] = CustomMethodDeclaration.getModifiers(asStatic)
   override val hasBlock: Boolean             = false
-  override lazy val isStatic: Boolean        = asStatic
+  override val isStatic: Boolean             = asStatic
 
   def summary: MethodSummary = {
     MethodSummary(

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/PropertyTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/PropertyTest.scala
@@ -16,7 +16,6 @@ package com.nawforce.apexlink.cst
 
 import com.nawforce.apexlink.TestHelper
 import com.nawforce.apexlink.types.apex.ApexClassDeclaration
-import com.nawforce.apexlink.types.core.TypeDeclaration
 import com.nawforce.pkgforce.modifiers._
 import com.nawforce.pkgforce.names.Name
 import org.scalatest.funsuite.AnyFunSuite
@@ -101,9 +100,9 @@ class PropertyTest extends AnyFunSuite with TestHelper {
     )
   }
 
-  test("Default property access private") {
+  test("Default property access empty") {
     val property = typeDeclaration("public class Dummy {String foo{get; set;}}").fields.head
-    assert(property.modifiers == ArraySeq(PRIVATE_MODIFIER))
+    assert(property.modifiers == ArraySeq())
     assert(property.readAccess == PRIVATE_MODIFIER)
     assert(property.writeAccess == property.readAccess)
     assert(!hasIssues)
@@ -237,7 +236,7 @@ class PropertyTest extends AnyFunSuite with TestHelper {
 
   test("Static property") {
     val property = typeDeclaration("public class Dummy {static String foo{get; set;}}").fields.head
-    assert(property.modifiers == ArraySeq(PRIVATE_MODIFIER, STATIC_MODIFIER))
+    assert(property.modifiers == ArraySeq(STATIC_MODIFIER))
     assert(property.readAccess == PRIVATE_MODIFIER)
     assert(property.writeAccess == property.readAccess)
     assert(!hasIssues)
@@ -245,7 +244,7 @@ class PropertyTest extends AnyFunSuite with TestHelper {
 
   test("Final property") {
     val property = typeDeclaration("public class Dummy {final String foo{get; set;}}").fields.head
-    assert(property.modifiers == ArraySeq(PRIVATE_MODIFIER, FINAL_MODIFIER))
+    assert(property.modifiers == ArraySeq(FINAL_MODIFIER))
     assert(property.readAccess == PRIVATE_MODIFIER)
     assert(property.writeAccess == property.readAccess)
     assert(!hasIssues)
@@ -295,7 +294,7 @@ class PropertyTest extends AnyFunSuite with TestHelper {
   test("AuraEnabled property") {
     val property =
       typeDeclaration("public class Dummy {@AuraEnabled String foo{get; set;}}").fields.head
-    assert(property.modifiers == ArraySeq(PRIVATE_MODIFIER, AURA_ENABLED_ANNOTATION))
+    assert(property.modifiers == ArraySeq(AURA_ENABLED_ANNOTATION))
     assert(property.readAccess == PRIVATE_MODIFIER)
     assert(property.writeAccess == property.readAccess)
     assert(!hasIssues)
@@ -304,7 +303,7 @@ class PropertyTest extends AnyFunSuite with TestHelper {
   test("Deprecated property") {
     val property =
       typeDeclaration("public class Dummy {@Deprecated String foo{get; set;}}").fields.head
-    assert(property.modifiers == ArraySeq(PRIVATE_MODIFIER, DEPRECATED_ANNOTATION))
+    assert(property.modifiers == ArraySeq(DEPRECATED_ANNOTATION))
     assert(property.readAccess == PRIVATE_MODIFIER)
     assert(property.writeAccess == property.readAccess)
     assert(!hasIssues)
@@ -313,7 +312,7 @@ class PropertyTest extends AnyFunSuite with TestHelper {
   test("InvocableVariable property") {
     val property =
       typeDeclaration("public class Dummy {@InvocableVariable String foo{get; set;}}").fields.head
-    assert(property.modifiers == ArraySeq(PRIVATE_MODIFIER, INVOCABLE_VARIABLE_ANNOTATION))
+    assert(property.modifiers == ArraySeq(INVOCABLE_VARIABLE_ANNOTATION))
     assert(property.readAccess == PRIVATE_MODIFIER)
     assert(property.writeAccess == property.readAccess)
     assert(!hasIssues)
@@ -322,7 +321,7 @@ class PropertyTest extends AnyFunSuite with TestHelper {
   test("TestVisible property") {
     val property =
       typeDeclaration("public class Dummy {@TestVisible String foo{get; set;}}").fields.head
-    assert(property.modifiers == ArraySeq(PRIVATE_MODIFIER, TEST_VISIBLE_ANNOTATION))
+    assert(property.modifiers == ArraySeq(TEST_VISIBLE_ANNOTATION))
     assert(property.readAccess == PRIVATE_MODIFIER)
     assert(property.writeAccess == property.readAccess)
     assert(!hasIssues)
@@ -333,7 +332,7 @@ class PropertyTest extends AnyFunSuite with TestHelper {
       typeDeclaration(
         "public class Dummy {@SuppressWarnings('PMD') String foo{get; set;}}"
       ).fields.head
-    assert(property.modifiers == ArraySeq(PRIVATE_MODIFIER, SUPPRESS_WARNINGS_ANNOTATION_PMD))
+    assert(property.modifiers == ArraySeq(SUPPRESS_WARNINGS_ANNOTATION_PMD))
     assert(property.readAccess == PRIVATE_MODIFIER)
     assert(property.writeAccess == property.readAccess)
     assert(!hasIssues)
@@ -342,7 +341,7 @@ class PropertyTest extends AnyFunSuite with TestHelper {
   test("Bad annotation property") {
     val property =
       typeDeclaration("public class Dummy {@TestSetup String foo{get; set;}}").fields.head
-    assert(property.modifiers == ArraySeq(PRIVATE_MODIFIER))
+    assert(property.modifiers == ArraySeq())
     assert(property.readAccess == PRIVATE_MODIFIER)
     assert(property.writeAccess == property.readAccess)
     assert(
@@ -356,7 +355,7 @@ class PropertyTest extends AnyFunSuite with TestHelper {
       typeDeclaration(
         "public class Dummy {@TestVisible @TestVisible String foo{get; set;}}"
       ).fields.head
-    assert(property.modifiers == ArraySeq(PRIVATE_MODIFIER, TEST_VISIBLE_ANNOTATION))
+    assert(property.modifiers == ArraySeq(TEST_VISIBLE_ANNOTATION))
     assert(property.readAccess == PRIVATE_MODIFIER)
     assert(property.writeAccess == property.readAccess)
     assert(

--- a/jvm/src/test/scala/com/nawforce/apexlink/pkg/CompletionProviderTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/pkg/CompletionProviderTest.scala
@@ -22,21 +22,47 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class CompletionProviderTest extends AnyFunSuite with TestHelper {
 
+  private val bodyContent = """
+                          |global void methodGlobal(){}
+                          |public String methodA(){}
+                          |public String methodB(String a, String b){}
+                          |protected void methodProtected(){}
+                          |private String methodPrivate(){}
+                          |Integer methodImplicitPrivate(){}
+                          |
+                          |global static void methodGlobalStatic(){}
+                          |public static String methodStatic(){}
+                          |private static String methodStaticPrivate(){}
+                          |static Integer methodStaticImplicitPrivate(){}
+                          |
+                          |global String myGlobalField;
+                          |public String myField;
+                          |protected String myProtectedField;
+                          |private String myPrivateField;
+                          |String myImplicitPrivateField;
+                          |
+                          |global static String myGlobalStaticField;
+                          |public static String myStaticField;
+                          |private static String myPrivateStaticField;
+                          |static String myImplicitPrivateStaticField;
+                          |
+                          |global class MyGlobalInner{};
+                          |public class MyInner{};
+                          |private interface MyPrivateInner{};
+                          |interface MyImplicitPrivateInner{};
+                          |""".stripMargin.replaceAll("\r\n", "\n")
+
+  private val dummyContent = s"""global virtual class Dummy {
+                           |$bodyContent
+                           |}""".stripMargin.replaceAll("\r\n", "\n")
+
   test("Internal Completion") {
     FileSystemHelper.run(Map()) { root: PathLike =>
       val org  = createOrg(root)
       val path = root.join("Completion.cls")
       val content =
-        """public class Dummy { public void someMethod() {m}
-            |public String methodA(){}
-            |public String methodB(String a, String b){}
-            |public static String methodStatic(){}
-            |private String methodPrivate(){}
-            |public String myField;
-            |public static String myStaticField;
-            |private String myPrivateField;
-            |public class MyInner{};
-            |private interface MyPrivateInner{};
+        s"""public virtual class Dummy { public void someMethod() {m}
+            |$bodyContent
             |}""".stripMargin.replaceAll("\r\n", "\n")
       val offset      = content.split('\n').head.length - 1
       val completions = org.getCompletionItemsInternal(path, line = 1, offset, content)
@@ -46,27 +72,69 @@ class CompletionProviderTest extends AnyFunSuite with TestHelper {
           .filterNot(_.kind == "Keyword")
           .toSet ==
           Set(
+            CompletionItemLink("methodGlobal()", "Method", "global void methodGlobal()"),
             CompletionItemLink(
               "methodB(a, b)",
               "Method",
               "public System.String methodB(System.String a, System.String b)"
             ),
             CompletionItemLink("methodA()", "Method", "public System.String methodA()"),
+            CompletionItemLink("methodProtected()", "Method", "protected void methodProtected()"),
             CompletionItemLink(
               "methodPrivate()",
               "Method",
               "private System.String methodPrivate()"
             ),
             CompletionItemLink(
+              "methodImplicitPrivate()",
+              "Method",
+              "System.Integer methodImplicitPrivate()"
+            ),
+            CompletionItemLink(
+              "methodGlobalStatic()",
+              "Method",
+              "global static void methodGlobalStatic()"
+            ),
+            CompletionItemLink(
               "methodStatic()",
               "Method",
               "public static System.String methodStatic()"
             ),
+            CompletionItemLink(
+              "methodStaticPrivate()",
+              "Method",
+              "private static System.String methodStaticPrivate()"
+            ),
+            CompletionItemLink(
+              "methodStaticImplicitPrivate()",
+              "Method",
+              "static System.Integer methodStaticImplicitPrivate()"
+            ),
+            CompletionItemLink("myGlobalField", "Field", "global String myGlobalField"),
             CompletionItemLink("myField", "Field", "public String myField"),
-            CompletionItemLink("myStaticField", "Field", "public static String myStaticField"),
+            CompletionItemLink("myProtectedField", "Field", "protected String myProtectedField"),
             CompletionItemLink("myPrivateField", "Field", "private String myPrivateField"),
+            CompletionItemLink("myImplicitPrivateField", "Field", "String myImplicitPrivateField"),
+            CompletionItemLink(
+              "myGlobalStaticField",
+              "Field",
+              "global static String myGlobalStaticField"
+            ),
+            CompletionItemLink("myStaticField", "Field", "public static String myStaticField"),
+            CompletionItemLink(
+              "myPrivateStaticField",
+              "Field",
+              "private static String myPrivateStaticField"
+            ),
+            CompletionItemLink(
+              "myImplicitPrivateStaticField",
+              "Field",
+              "static String myImplicitPrivateStaticField"
+            ),
+            CompletionItemLink("MyGlobalInner", "Class", "global"),
             CompletionItemLink("MyInner", "Class", "public"),
-            CompletionItemLink("MyPrivateInner", "Interface", "private")
+            CompletionItemLink("MyPrivateInner", "Interface", "private"),
+            CompletionItemLink("MyImplicitPrivateInner", "Interface", "")
           )
       )
     }
@@ -77,16 +145,8 @@ class CompletionProviderTest extends AnyFunSuite with TestHelper {
       val org  = createOrg(root)
       val path = root.join("Completion.cls")
       val content =
-        """public class Dummy { public void someMethod() {m}
-            |public String methodA(){}
-            |public String methodB(String a, String b){}
-            |public static String methodStatic(){}
-            |private String methodPrivate(){}
-            |public String myField;
-            |public static String myStaticField;
-            |private String myPrivateField;
-            |public class MyInner{};
-            |private interface MyPrivateInner{};
+        s"""public virtual class Dummy { public void someMethod() {m}
+            |$bodyContent
             |}""".stripMargin.replaceAll("\r\n", "\n")
       val offset      = content.split('\n').head.length - 1
       val completions = org.getCompletionItemsInternal(path, line = 1, offset, content)
@@ -96,49 +156,76 @@ class CompletionProviderTest extends AnyFunSuite with TestHelper {
           .filterNot(_.kind == "Keyword")
           .toSet ==
           Set(
+            CompletionItemLink("methodGlobal()", "Method", "global void methodGlobal()"),
             CompletionItemLink(
               "methodB(a, b)",
               "Method",
               "public System.String methodB(System.String a, System.String b)"
             ),
             CompletionItemLink("methodA()", "Method", "public System.String methodA()"),
+            CompletionItemLink("methodProtected()", "Method", "protected void methodProtected()"),
             CompletionItemLink(
               "methodPrivate()",
               "Method",
               "private System.String methodPrivate()"
             ),
             CompletionItemLink(
+              "methodImplicitPrivate()",
+              "Method",
+              "System.Integer methodImplicitPrivate()"
+            ),
+            CompletionItemLink(
+              "methodGlobalStatic()",
+              "Method",
+              "global static void methodGlobalStatic()"
+            ),
+            CompletionItemLink(
               "methodStatic()",
               "Method",
               "public static System.String methodStatic()"
             ),
+            CompletionItemLink(
+              "methodStaticPrivate()",
+              "Method",
+              "private static System.String methodStaticPrivate()"
+            ),
+            CompletionItemLink(
+              "methodStaticImplicitPrivate()",
+              "Method",
+              "static System.Integer methodStaticImplicitPrivate()"
+            ),
+            CompletionItemLink("myGlobalField", "Field", "global String myGlobalField"),
             CompletionItemLink("myField", "Field", "public String myField"),
-            CompletionItemLink("myStaticField", "Field", "public static String myStaticField"),
+            CompletionItemLink("myProtectedField", "Field", "protected String myProtectedField"),
             CompletionItemLink("myPrivateField", "Field", "private String myPrivateField"),
+            CompletionItemLink("myImplicitPrivateField", "Field", "String myImplicitPrivateField"),
+            CompletionItemLink(
+              "myGlobalStaticField",
+              "Field",
+              "global static String myGlobalStaticField"
+            ),
+            CompletionItemLink("myStaticField", "Field", "public static String myStaticField"),
+            CompletionItemLink(
+              "myPrivateStaticField",
+              "Field",
+              "private static String myPrivateStaticField"
+            ),
+            CompletionItemLink(
+              "myImplicitPrivateStaticField",
+              "Field",
+              "static String myImplicitPrivateStaticField"
+            ),
+            CompletionItemLink("MyGlobalInner", "Class", "global"),
             CompletionItemLink("MyInner", "Class", "public"),
-            CompletionItemLink("MyPrivateInner", "Interface", "private")
+            CompletionItemLink("MyPrivateInner", "Interface", "private"),
+            CompletionItemLink("MyImplicitPrivateInner", "Interface", "")
           )
       )
     }
   }
 
   test("Instance Completions") {
-    FileSystemHelper.run(
-      Map(
-        "Dummy.cls" ->
-          """public class Dummy {
-          |public String methodA(){}
-          |public String methodB(String a, String b){}
-          |public static String methodStatic(){}
-          |private String methodPrivate(){}
-          |public String myField;
-          |public static String myStaticField;
-          |private String myPrivateField;
-          |public class MyInner{};
-          |private interface MyPrivateInner{};
-          |}""".stripMargin
-      )
-    ) { root: PathLike =>
+    FileSystemHelper.run(Map("Dummy.cls" -> dummyContent)) { root: PathLike =>
       val org     = createOrg(root)
       val path    = root.join("Completion.cls")
       val content = "public class Completion { public Completion() {String a = new Dummy().m"
@@ -147,35 +234,49 @@ class CompletionProviderTest extends AnyFunSuite with TestHelper {
           .getCompletionItemsInternal(path, line = 1, offset = content.length, content)
           .toSet ==
           Set(
+            CompletionItemLink("methodGlobal()", "Method", "global void methodGlobal()"),
             CompletionItemLink(
               "methodB(a, b)",
               "Method",
               "public System.String methodB(System.String a, System.String b)"
             ),
             CompletionItemLink("methodA()", "Method", "public System.String methodA()"),
+            CompletionItemLink("myGlobalField", "Field", "global String myGlobalField"),
             CompletionItemLink("myField", "Field", "public String myField")
           )
       )
     }
   }
 
-  test("Static Completions") {
-    FileSystemHelper.run(
-      Map(
-        "Dummy.cls" ->
-          """public class Dummy {
-          |public String methodA(){}
-          |public String methodB(String a, String b){}
-          |public static String methodStatic(){}
-          |private String methodPrivate(){}
-          |public String myField;
-          |public static String myStaticField;
-          |private String myPrivateField;
-          |public class MyInner{};
-          |private interface MyPrivateInner{};
-          |}""".stripMargin
+  test("Instance Completions (extending)") {
+    FileSystemHelper.run(Map("Dummy.cls" -> dummyContent)) { root: PathLike =>
+      val org  = createOrg(root)
+      val path = root.join("Completion.cls")
+      val content =
+        "public class Completion extends Dummy { public Completion() {String a = new Dummy().m"
+      assert(
+        org
+          .getCompletionItemsInternal(path, line = 1, offset = content.length, content)
+          .toSet ==
+          Set(
+            CompletionItemLink("methodGlobal()", "Method", "global void methodGlobal()"),
+            CompletionItemLink(
+              "methodB(a, b)",
+              "Method",
+              "public System.String methodB(System.String a, System.String b)"
+            ),
+            CompletionItemLink("methodA()", "Method", "public System.String methodA()"),
+            CompletionItemLink("methodProtected()", "Method", "protected void methodProtected()"),
+            CompletionItemLink("myGlobalField", "Field", "global String myGlobalField"),
+            CompletionItemLink("myField", "Field", "public String myField"),
+            CompletionItemLink("myProtectedField", "Field", "protected String myProtectedField")
+          )
       )
-    ) { root: PathLike =>
+    }
+  }
+
+  test("Static Completions") {
+    FileSystemHelper.run(Map("Dummy.cls" -> dummyContent)) { root: PathLike =>
       val org     = createOrg(root)
       val path    = root.join("Completion.cls")
       val content = "public class Completion { public Completion() {String a = Dummy.m"
@@ -185,11 +286,22 @@ class CompletionProviderTest extends AnyFunSuite with TestHelper {
           .toSet ==
           Set(
             CompletionItemLink(
+              "methodGlobalStatic()",
+              "Method",
+              "global static void methodGlobalStatic()"
+            ),
+            CompletionItemLink(
               "methodStatic()",
               "Method",
               "public static System.String methodStatic()"
             ),
+            CompletionItemLink(
+              "myGlobalStaticField",
+              "Field",
+              "global static String myGlobalStaticField"
+            ),
             CompletionItemLink("myStaticField", "Field", "public static String myStaticField"),
+            CompletionItemLink("MyGlobalInner", "Class", "global"),
             CompletionItemLink("MyInner", "Class", "public")
           )
       )
@@ -197,22 +309,7 @@ class CompletionProviderTest extends AnyFunSuite with TestHelper {
   }
 
   test("Instance Completions (in statement)") {
-    FileSystemHelper.run(
-      Map(
-        "Dummy.cls" ->
-          """public class Dummy {
-          |public String methodA(){}
-          |public String methodB(String a, String b){}
-          |public static String methodStatic(){}
-          |private String methodPrivate(){}
-          |public String myField;
-          |public static String myStaticField;
-          |private String myPrivateField;
-          |public class MyInner{};
-          |private interface MyPrivateInner{};
-          |}""".stripMargin
-      )
-    ) { root: PathLike =>
+    FileSystemHelper.run(Map("Dummy.cls" -> dummyContent)) { root: PathLike =>
       val org     = createOrg(root)
       val path    = root.join("Completion.cls")
       val content = "public class Completion { public Completion() {Dummy a; if ( a.m"
@@ -221,12 +318,14 @@ class CompletionProviderTest extends AnyFunSuite with TestHelper {
           .getCompletionItemsInternal(path, line = 1, offset = content.length, content)
           .toSet ==
           Set(
+            CompletionItemLink("methodGlobal()", "Method", "global void methodGlobal()"),
             CompletionItemLink(
               "methodB(a, b)",
               "Method",
               "public System.String methodB(System.String a, System.String b)"
             ),
             CompletionItemLink("methodA()", "Method", "public System.String methodA()"),
+            CompletionItemLink("myGlobalField", "Field", "global String myGlobalField"),
             CompletionItemLink("myField", "Field", "public String myField")
           )
       )
@@ -234,22 +333,7 @@ class CompletionProviderTest extends AnyFunSuite with TestHelper {
   }
 
   test("Instance Completions (no context)") {
-    FileSystemHelper.run(
-      Map(
-        "Dummy.cls" ->
-          """public class Dummy {
-          |public String methodA(){}
-          |public String methodB(String a, String b){}
-          |public static String methodStatic(){}
-          |private String methodPrivate(){}
-          |public String myField;
-          |public static String myStaticField;
-          |private String myPrivateField;
-          |public class MyInner{};
-          |private interface MyPrivateInner{};
-          |}""".stripMargin
-      )
-    ) { root: PathLike =>
+    FileSystemHelper.run(Map("Dummy.cls" -> dummyContent)) { root: PathLike =>
       val org     = createOrg(root)
       val path    = root.join("Completion.cls")
       val content = "public class Completion { public Completion() {String a = new Dummy()."
@@ -258,6 +342,7 @@ class CompletionProviderTest extends AnyFunSuite with TestHelper {
           .getCompletionItemsInternal(path, line = 1, offset = content.length, content)
           .toSet ==
           Set(
+            CompletionItemLink("methodGlobal()", "Method", "global void methodGlobal()"),
             CompletionItemLink("methodA()", "Method", "public System.String methodA()"),
             CompletionItemLink(
               "methodB(a, b)",
@@ -272,6 +357,7 @@ class CompletionProviderTest extends AnyFunSuite with TestHelper {
               "Method",
               "public virtual System.Boolean equals(Object other)"
             ),
+            CompletionItemLink("myGlobalField", "Field", "global String myGlobalField"),
             CompletionItemLink("myField", "Field", "public String myField")
           )
       )
@@ -662,22 +748,7 @@ class CompletionProviderTest extends AnyFunSuite with TestHelper {
   }
 
   test("Triggers Static Completions") {
-    FileSystemHelper.run(
-      Map(
-        "Dummy.cls" ->
-          """public class Dummy {
-          |public String methodA(){}
-          |public String methodB(String a, String b){}
-          |public static String methodStatic(){}
-          |private String methodPrivate(){}
-          |public String myField;
-          |public static String myStaticField;
-          |private String myPrivateField;
-          |public class MyInner{};
-          |private interface MyPrivateInner{};
-          |}""".stripMargin
-      )
-    ) { root: PathLike =>
+    FileSystemHelper.run(Map("Dummy.cls" -> dummyContent)) { root: PathLike =>
       val org     = createOrg(root)
       val path    = root.join("Completion.trigger")
       val content = "trigger Completion on Account(before insert) { Dummy.m"
@@ -687,11 +758,22 @@ class CompletionProviderTest extends AnyFunSuite with TestHelper {
           .toSet ==
           Set(
             CompletionItemLink(
+              "methodGlobalStatic()",
+              "Method",
+              "global static void methodGlobalStatic()"
+            ),
+            CompletionItemLink(
               "methodStatic()",
               "Method",
               "public static System.String methodStatic()"
             ),
+            CompletionItemLink(
+              "myGlobalStaticField",
+              "Field",
+              "global static String myGlobalStaticField"
+            ),
             CompletionItemLink("myStaticField", "Field", "public static String myStaticField"),
+            CompletionItemLink("MyGlobalInner", "Class", "global"),
             CompletionItemLink("MyInner", "Class", "public")
           )
       )

--- a/shared/src/main/scala/com/nawforce/pkgforce/modifiers/FieldModifiers.scala
+++ b/shared/src/main/scala/com/nawforce/pkgforce/modifiers/FieldModifiers.scala
@@ -87,8 +87,6 @@ object FieldModifiers {
       ) {
         logger.logError(idContext, "Webservice fields must be global")
         GLOBAL_MODIFIER +: mods.diff(visibilityModifiers)
-      } else if (mods.intersect(visibilityModifiers).isEmpty) {
-        PRIVATE_MODIFIER +: mods
       } else {
         mods
       }

--- a/shared/src/main/scala/com/nawforce/pkgforce/modifiers/Modifier.scala
+++ b/shared/src/main/scala/com/nawforce/pkgforce/modifiers/Modifier.scala
@@ -27,8 +27,8 @@ import scala.collection.compat.immutable.ArraySeq
 
 sealed abstract class Modifier(
   final val name: String,
-  val order: Integer = 0,
-  val methodOrder: Integer = 0
+  val order: Int = 0,
+  val methodOrder: Int = 0
 ) {
   override def toString: String = name
 }

--- a/shared/src/test/scala/com/nawforce/pkgforce/modifiers/FieldModifierTest.scala
+++ b/shared/src/test/scala/com/nawforce/pkgforce/modifiers/FieldModifierTest.scala
@@ -71,8 +71,8 @@ class FieldModifierTest extends AnyFunSuite {
     }
   }
 
-  test("Default field access private") {
-    assert(legalFieldAccess(ArraySeq(), ArraySeq(PRIVATE_MODIFIER)))
+  test("Default field access empty") {
+    assert(legalFieldAccess(ArraySeq(), ArraySeq()))
   }
 
   test("Private field") {
@@ -105,9 +105,7 @@ class FieldModifierTest extends AnyFunSuite {
   }
 
   test("Transient field") {
-    assert(
-      legalFieldAccess(ArraySeq(TRANSIENT_MODIFIER), ArraySeq(PRIVATE_MODIFIER, TRANSIENT_MODIFIER))
-    )
+    assert(legalFieldAccess(ArraySeq(TRANSIENT_MODIFIER), ArraySeq(TRANSIENT_MODIFIER)))
   }
 
   test("Transient public field") {
@@ -120,7 +118,7 @@ class FieldModifierTest extends AnyFunSuite {
   }
 
   test("Static field") {
-    assert(legalFieldAccess(ArraySeq(STATIC_MODIFIER), ArraySeq(PRIVATE_MODIFIER, STATIC_MODIFIER)))
+    assert(legalFieldAccess(ArraySeq(STATIC_MODIFIER), ArraySeq(STATIC_MODIFIER)))
   }
 
   test("Static public field") {
@@ -133,7 +131,7 @@ class FieldModifierTest extends AnyFunSuite {
   }
 
   test("Final field") {
-    assert(legalFieldAccess(ArraySeq(FINAL_MODIFIER), ArraySeq(PRIVATE_MODIFIER, FINAL_MODIFIER)))
+    assert(legalFieldAccess(ArraySeq(FINAL_MODIFIER), ArraySeq(FINAL_MODIFIER)))
   }
 
   test("Final public field") {
@@ -154,46 +152,31 @@ class FieldModifierTest extends AnyFunSuite {
   }
 
   test("AuraEnabled field") {
-    assert(
-      legalFieldAccess(
-        ArraySeq(AURA_ENABLED_ANNOTATION),
-        ArraySeq(PRIVATE_MODIFIER, AURA_ENABLED_ANNOTATION)
-      )
-    )
+    assert(legalFieldAccess(ArraySeq(AURA_ENABLED_ANNOTATION), ArraySeq(AURA_ENABLED_ANNOTATION)))
   }
 
   test("Deprecated field") {
-    assert(
-      legalFieldAccess(
-        ArraySeq(DEPRECATED_ANNOTATION),
-        ArraySeq(PRIVATE_MODIFIER, DEPRECATED_ANNOTATION)
-      )
-    )
+    assert(legalFieldAccess(ArraySeq(DEPRECATED_ANNOTATION), ArraySeq(DEPRECATED_ANNOTATION)))
   }
 
   test("InvocableVariable field") {
     assert(
       legalFieldAccess(
         ArraySeq(INVOCABLE_VARIABLE_ANNOTATION),
-        ArraySeq(PRIVATE_MODIFIER, INVOCABLE_VARIABLE_ANNOTATION)
+        ArraySeq(INVOCABLE_VARIABLE_ANNOTATION)
       )
     )
   }
 
   test("TestVisible field") {
-    assert(
-      legalFieldAccess(
-        ArraySeq(TEST_VISIBLE_ANNOTATION),
-        ArraySeq(PRIVATE_MODIFIER, TEST_VISIBLE_ANNOTATION)
-      )
-    )
+    assert(legalFieldAccess(ArraySeq(TEST_VISIBLE_ANNOTATION), ArraySeq(TEST_VISIBLE_ANNOTATION)))
   }
 
   test("SuppressWarnings PMD field") {
     assert(
       legalFieldAccess(
         ArraySeq(SUPPRESS_WARNINGS_ANNOTATION_PMD),
-        ArraySeq(PRIVATE_MODIFIER, SUPPRESS_WARNINGS_ANNOTATION_PMD)
+        ArraySeq(SUPPRESS_WARNINGS_ANNOTATION_PMD)
       )
     )
   }
@@ -202,7 +185,7 @@ class FieldModifierTest extends AnyFunSuite {
     assert(
       legalFieldAccess(
         ArraySeq(SUPPRESS_WARNINGS_ANNOTATION_UNUSED),
-        ArraySeq(PRIVATE_MODIFIER, SUPPRESS_WARNINGS_ANNOTATION_UNUSED)
+        ArraySeq(SUPPRESS_WARNINGS_ANNOTATION_UNUSED)
       )
     )
   }
@@ -296,7 +279,7 @@ class FieldModifierTest extends AnyFunSuite {
   }
 
   test("Inner Default field access private") {
-    assert(innerLegalFieldAccess(ArraySeq(), ArraySeq(PRIVATE_MODIFIER)))
+    assert(innerLegalFieldAccess(ArraySeq(), ArraySeq()))
   }
 
   test("Inner Private field") {
@@ -329,12 +312,7 @@ class FieldModifierTest extends AnyFunSuite {
   }
 
   test("Inner Transient field") {
-    assert(
-      innerLegalFieldAccess(
-        ArraySeq(TRANSIENT_MODIFIER),
-        ArraySeq(PRIVATE_MODIFIER, TRANSIENT_MODIFIER)
-      )
-    )
+    assert(innerLegalFieldAccess(ArraySeq(TRANSIENT_MODIFIER), ArraySeq(TRANSIENT_MODIFIER)))
   }
 
   test("Inner Transient public field") {
@@ -360,13 +338,10 @@ class FieldModifierTest extends AnyFunSuite {
         )
       )
     )
-
   }
 
   test("Inner Final field") {
-    assert(
-      innerLegalFieldAccess(ArraySeq(FINAL_MODIFIER), ArraySeq(PRIVATE_MODIFIER, FINAL_MODIFIER))
-    )
+    assert(innerLegalFieldAccess(ArraySeq(FINAL_MODIFIER), ArraySeq(FINAL_MODIFIER)))
   }
 
   test("Inner Final public field") {
@@ -384,37 +359,26 @@ class FieldModifierTest extends AnyFunSuite {
 
   test("Inner AuraEnabled field") {
     assert(
-      innerLegalFieldAccess(
-        ArraySeq(AURA_ENABLED_ANNOTATION),
-        ArraySeq(PRIVATE_MODIFIER, AURA_ENABLED_ANNOTATION)
-      )
+      innerLegalFieldAccess(ArraySeq(AURA_ENABLED_ANNOTATION), ArraySeq(AURA_ENABLED_ANNOTATION))
     )
   }
 
   test("Inner Deprecated field") {
-    assert(
-      innerLegalFieldAccess(
-        ArraySeq(DEPRECATED_ANNOTATION),
-        ArraySeq(PRIVATE_MODIFIER, DEPRECATED_ANNOTATION)
-      )
-    )
+    assert(innerLegalFieldAccess(ArraySeq(DEPRECATED_ANNOTATION), ArraySeq(DEPRECATED_ANNOTATION)))
   }
 
   test("Inner InvocableVariable field") {
     assert(
       innerLegalFieldAccess(
         ArraySeq(INVOCABLE_VARIABLE_ANNOTATION),
-        ArraySeq(PRIVATE_MODIFIER, INVOCABLE_VARIABLE_ANNOTATION)
+        ArraySeq(INVOCABLE_VARIABLE_ANNOTATION)
       )
     )
   }
 
   test("Inner TestVisible field") {
     assert(
-      innerLegalFieldAccess(
-        ArraySeq(TEST_VISIBLE_ANNOTATION),
-        ArraySeq(PRIVATE_MODIFIER, TEST_VISIBLE_ANNOTATION)
-      )
+      innerLegalFieldAccess(ArraySeq(TEST_VISIBLE_ANNOTATION), ArraySeq(TEST_VISIBLE_ANNOTATION))
     )
   }
 
@@ -422,7 +386,7 @@ class FieldModifierTest extends AnyFunSuite {
     assert(
       innerLegalFieldAccess(
         ArraySeq(SUPPRESS_WARNINGS_ANNOTATION_PMD),
-        ArraySeq(PRIVATE_MODIFIER, SUPPRESS_WARNINGS_ANNOTATION_PMD)
+        ArraySeq(SUPPRESS_WARNINGS_ANNOTATION_PMD)
       )
     )
   }
@@ -431,7 +395,7 @@ class FieldModifierTest extends AnyFunSuite {
     assert(
       innerLegalFieldAccess(
         ArraySeq(SUPPRESS_WARNINGS_ANNOTATION_UNUSED),
-        ArraySeq(PRIVATE_MODIFIER, SUPPRESS_WARNINGS_ANNOTATION_UNUSED)
+        ArraySeq(SUPPRESS_WARNINGS_ANNOTATION_UNUSED)
       )
     )
   }


### PR DESCRIPTION
This should fix completion handling to include globals and where appropriate protected body declarations. 

Much of the change is due to aligning the `visibility` handling so it returns an Option to allow modelling of implicit private declarations in a consistent way.