### PR TITLE
Scala version update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.Report
 
 import scala.sys.process._
 
-ThisBuild / scalaVersion         := "2.13.10"
+ThisBuild / scalaVersion         := "2.13.16"
 ThisBuild / description          := "Salesforce Apex static analysis toolkit"
 ThisBuild / organization         := "io.github.apex-dev-tools"
 ThisBuild / organizationHomepage := Some(url("https://github.com/apex-dev-tools/apex-ls"))

--- a/js/npm/package-lock.json
+++ b/js/npm/package-lock.json
@@ -1544,10 +1544,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.3
+sbt.version=1.10.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.12.0")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
-addSbtPlugin("com.github.sbt"     % "sbt-ci-release"           % "1.5.11")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.18.2")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
+addSbtPlugin("com.github.sbt"     % "sbt-ci-release"           % "1.9.2")
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"             % "2.5.0")


### PR DESCRIPTION
Update scala, sbt and some of the plugins. Decided not to do `scalafmt` and the build plugin, there are major updates hidden in patch releases like dropping JDK 8 support. There doesn't seem to be a nice version that matches with 3.9.0.

Also cleared an npm audit warning.