### PR TITLE
Fix ghosted sObject describe field references 

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
@@ -459,15 +459,13 @@ final case class DotExpressionWithId(expression: Expression, safeNavigation: Boo
     }
 
     // Field is missing
-    if (inputType.isSObject || inputType.isInstanceOf[RecordSetDeclaration]) {
-      // For SObject or RecordSet being used as an SObject, ignore if we not have a
-      // complete type or the field is using a ghosted namespace
-      if (inputType.isComplete && !context.module.isGhostedFieldName(name)) {
+    // ignore if we not have a complete type or the field is using a ghosted namespace
+    if (inputType.isComplete && !context.module.isGhostedFieldName(name)) {
+      if (inputType.isSObject || inputType.isInstanceOf[RecordSetDeclaration]) {
         context.log(IssueOps.unknownFieldOnSObject(location, name, inputType.typeName))
+      } else {
+        context.log(IssueOps.unknownFieldOrType(location, name, inputType.typeName))
       }
-    } else if (inputType.isComplete) {
-      // For other types, if complete we should error
-      context.log(IssueOps.unknownFieldOrType(location, name, inputType.typeName))
     }
     ExprContext.empty
   }

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/schema/SchemaSObjectType.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/schema/SchemaSObjectType.scala
@@ -314,8 +314,7 @@ final case class SObjectFields(baseType: TypeName, module: OPM.Module)
       .get(name)
       .orElse(ghostedSobjectFields.get(name))
       .orElse({
-        val typeName = EncodedName(name).asTypeName
-        if (module.isGhostedType(typeName)) {
+        if (module.isGhostedType(baseType) || module.isGhostedType(EncodedName(name).asTypeName)) {
           ghostedSobjectFields.put(name, CustomFieldDeclaration(name, TypeNames.SObjectField, None))
         }
         ghostedSobjectFields.get(name)

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/schema/SchemaSObjectType.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/schema/SchemaSObjectType.scala
@@ -27,7 +27,7 @@ import com.nawforce.apexlink.types.core.{
 }
 import com.nawforce.apexlink.types.platform.{PlatformTypeDeclaration, PlatformTypes}
 import com.nawforce.apexlink.types.synthetic.{CustomFieldDeclaration, CustomMethodDeclaration}
-import com.nawforce.pkgforce.modifiers.{GLOBAL_MODIFIER, Modifier}
+import com.nawforce.pkgforce.modifiers.Modifier
 import com.nawforce.pkgforce.names.{EncodedName, Name, Names, TypeName}
 import com.nawforce.pkgforce.path.PathLike
 
@@ -234,8 +234,11 @@ final case class SObjectTypeFields(sobjectName: Name, module: OPM.Module)
       .get(name)
       .orElse(ghostedSobjectFields.get(name))
       .orElse({
-        val typeName = EncodedName(name).asTypeName
-        if (module.isGhostedType(typeName)) {
+        // sObject or the field is ghosted
+        if (
+          module.isGhostedType(typeName.params.head) || module
+            .isGhostedType(EncodedName(name).asTypeName)
+        ) {
           ghostedSobjectFields
             .put(name, CustomFieldDeclaration(name, TypeNames.DescribeFieldResult, None))
         }

--- a/jvm/src/test/scala/com/nawforce/apexlink/pkg/GhostPackageTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/pkg/GhostPackageTest.scala
@@ -317,4 +317,40 @@ class GhostPackageTest extends AnyFunSuite with TestHelper {
       assert(packagedClass("pkg", "Dummy").get.dependencies().isEmpty)
     }
   }
+
+  test("Ghost package with custom object and standard sobjectype field") {
+    FileSystemHelper.run(
+      Map(
+        "sfdx-project.json" ->
+          """{
+            |"namespace": "pkg",
+            |"packageDirectories": [{"path": "pkg"}],
+            |"plugins": {"dependencies": [{"namespace": "ghosted"}]}
+            |}""".stripMargin,
+        "pkg/Dummy.cls" -> "public class Dummy { void func() { String name = Schema.SObjectType.ghosted__myObject__c.Fields.Name.name; } }"
+      )
+    ) { root: PathLike =>
+      createOrg(root)
+      assert(packagedClass("pkg", "Dummy").get.dependencies().isEmpty)
+      assert(!hasIssues)
+    }
+  }
+
+  test("Ghost package with custom object and standard sobjectfield") {
+    FileSystemHelper.run(
+      Map(
+        "sfdx-project.json" ->
+          """{
+            |"namespace": "pkg",
+            |"packageDirectories": [{"path": "pkg"}],
+            |"plugins": {"dependencies": [{"namespace": "ghosted"}]}
+            |}""".stripMargin,
+        "pkg/Dummy.cls" -> "public class Dummy { void func() { Schema.ghosted__myObject__c.Fields.Name.getDescribe(); } }"
+      )
+    ) { root: PathLike =>
+      createOrg(root)
+      assert(packagedClass("pkg", "Dummy").get.dependencies().isEmpty)
+      assert(!hasIssues)
+    }
+  }
 }


### PR DESCRIPTION
fixes #315 

Bit tricky to visualise, will need to do some live testing as well. Per the docs, we can have refs like `Schema.namespace__MyObject.Fields...`, `Schema.sObjectType.namespace__MyObject.Fields...` which can then reference all kinds of other fields both standard and also ghosted ones. Outputs `SObjectField`s and `DescribeFieldResult`s types at the end.

Because more than ghosted fields can be referenced, we need to also check if object is ghosted. Otherwise you get errors on every missing standard field.

The `SchemaSObjectType` type is not picked up when something is ref as `Schema.` because it picks `System.Schema` platform type instead. So needed to adjust the `DotExpressionWithId` to be able to recognise that the field can be ghosted even when not directly an `SObject` type. Small change with the ignore logic.