### PR TITLE
Remove caching from getting references

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
@@ -17,7 +17,6 @@ package com.nawforce.apexlink.cst
 import com.nawforce.apexlink.finding.{RelativeTypeContext, RelativeTypeName}
 import com.nawforce.apexlink.memory.SkinnySet
 import com.nawforce.apexlink.names.TypeNames
-import com.nawforce.apexlink.org.Referenceable
 import com.nawforce.apexlink.types.apex.{
   ApexBlockLike,
   ApexConstructorLike,
@@ -239,8 +238,7 @@ class ApexMethodDeclaration(
   override val parameters: ArraySeq[FormalParameter],
   val block: Option[Block]
 ) extends ClassBodyDeclaration(_modifiers)
-    with ApexMethodLike
-    with Referenceable {
+    with ApexMethodLike {
 
   override def idLocation: Location = id.location.location
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
@@ -66,7 +66,8 @@ case class ExprContext(
   *
   * @param locatable position of code that generated this context to support introspection
   */
-class VoidExprContext(locatable: Option[Locatable]) extends ExprContext(None, None, locatable) {
+private class VoidExprContext(locatable: Option[Locatable])
+    extends ExprContext(None, None, locatable) {
   override def isVoid = true
 }
 
@@ -86,7 +87,7 @@ object ExprContext {
     new ExprContext(isStatic, Some(declaration))
   }
 
-  /* We allow flex here on the locatable type as it a cross cutting concern of many sorts of things */
+  /* We allow flex here on the locatable type as it a cross-cutting concern of many sorts of things */
   def apply(
     isStatic: Option[Boolean],
     declaration: Option[TypeDeclaration],
@@ -363,7 +364,7 @@ final case class DotExpressionWithId(expression: Expression, safeNavigation: Boo
     } else {
       TypeResolver(TypeName(id.name), context.module).toOption match {
         // It might be a static reference to an outer class that failed normal analysis due to class name shadowing
-        // This occurs where say A has an inner of B and in C with an inner of A we reference 'A.B' which is valid.
+        // This occurs where say A has an inner of B and in C with an inner of A, we reference 'A.B' which is valid.
         case Some(td: ApexClassDeclaration) => verifyShadowedStatic(td, context)
         case _                              => None
       }
@@ -497,7 +498,7 @@ final case class DotExpressionWithMethod(
               .getOrElse(ExprContext.empty)
           }
         } else {
-          // When we can't find method we should still verify args for dependency side-effects
+          // When we can't find method we should still verify args for dependency side effects
           target.map(target => target.arguments.map(_.verify(input, context)))
           ExprContext.empty
         }
@@ -603,7 +604,7 @@ final case class MethodCallWithId(target: Id, arguments: ArraySeq[Expression]) e
         cachedMethod = Some(method)
         context.addDependency(method)
         method match {
-          case ref: Referenceable => ref.addLocation(location)
+          case ref: Referenceable => ref.addReferencingLocation(location)
           case _                  =>
         }
         if (method.typeName != TypeNames.Void) {

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/ImplementationProvider.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/ImplementationProvider.scala
@@ -89,7 +89,7 @@ trait ImplementationProvider extends SourceOps {
     searchContext match {
       case Some(method: ApexMethodLike) =>
         method
-          .collectMethods()
+          .collectRelatedReferencable()
           .filterNot(_ eq method)
           .map(m =>
             LocationLink(

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/ReferenceProvider.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/ReferenceProvider.scala
@@ -11,62 +11,133 @@ import com.nawforce.apexlink.types.apex.{
   ApexClassDeclaration,
   ApexFullDeclaration,
   FullDeclaration,
-  PreReValidatable,
   SummaryDeclaration
 }
-import com.nawforce.apexlink.types.core.{Dependent, TypeDeclaration, TypeId}
+import com.nawforce.apexlink.types.core.{Dependent, DependentType, TypeDeclaration, TypeId}
 import com.nawforce.pkgforce.path.{PathLike, PathLocation}
 
-import scala.reflect.ClassTag
-import scala.util.hashing.MurmurHash3
+import scala.collection.mutable
 
-trait Referenceable extends PreReValidatable {
+/** This trait is used to mark a class as being referenceable. It is used in conjunction with
+  * ReferenceProvider to find all the locations that reference something in Apex code,
+  * currently only method references (aka method calls) are supported.
+  *
+  * @see ReferenceProvider
+  */
+trait Referenceable {
   this: Dependent =>
-  private var referenceLocations: SkinnySet[PathLocation] = new SkinnySet()
-  private var cache: (Int, Set[TargetLocation])           = (0, Set.empty)
 
-  override def preReValidate(): Unit = {
-    super.preReValidate()
-    referenceLocations = new SkinnySet()
-  }
+  /** Referencable must be able to provide a TypeId for the containing type to support revalidation. */
+  val thisTypeId: TypeId
 
-  def getTargetLocations: Array[TargetLocation] = {
-    referenceLocations.toSet
-      .map(ref => TargetLocation(ref.path.toString, ref.location))
-      .toArray
-  }
+  /** Temporary storage for locations referencing this Referenceable, null default to space save. */
+  private var referenceLocations: SkinnySet[TargetLocation] = _
 
-  def addLocation(pathLocation: PathLocation): Unit = {
-    referenceLocations.add(pathLocation)
-  }
-
-  def findReferences(): Set[TargetLocation] = {
-    val hashCode = hash()
-    if (hashCode != cache._1)
-      cache = (hashCode, collectReferences())
-    cache._2
-  }
-
-  def doesNeedReValidation(): Boolean = {
-    hash() != cache._1
-  }
-
-  /** This represents a high level view of all the types that hold a reference to this object.
-    * Returns the types that needs can be revalidated to build up the more specific reference
-    * locations.
+  /** Add a reference location to the list of references for this specific Referencable. Adding
+    * references is gated so that we can control when references are collected. This must be
+    * called from some part of the validation logic to establish the references.
     */
-  def getReferenceHolderTypeIds: Set[TypeId]
+  def addReferencingLocation(referencingLocation: PathLocation): Unit = {
+    if (Referenceable.allowReferenceCollection) {
+      if (referenceLocations == null) {
+        referenceLocations = new SkinnySet[TargetLocation]()
+      }
+      referenceLocations.add(
+        TargetLocation(referencingLocation.path.toString, referencingLocation.location)
+      )
+      Referenceable.addReference(this)
+    }
+  }
 
-  /** Returns the detailed reference locations
+  /** Collect all the referenceable elements that are related to this class. Override this
+    * to expand the reference search, such as for method overloading.
     */
-  protected def collectReferences(): Set[TargetLocation]
+  def collectRelatedReferencable(): Set[_ <: Referenceable] = Set[Referenceable](this)
 
-  private def hash(): Int = {
-    MurmurHash3.arrayHash(
-      getReferenceHolderTypeIds.toArray
-        .flatMap(id => id.toTypeDeclaration[ApexClassDeclaration])
-        .map(_.deepHash)
-    )
+  /** Collect all reference locations for this Referencable. The basic approach here
+    * is to collect references to things during a revalidation pass. The ReferenceProvider
+    * uses this.
+    */
+  def getCurrentReferences(
+    line: Int,
+    offset: Int,
+    refresh: Seq[PathLike] => Unit
+  ): Set[TargetLocation] = {
+
+    try {
+      Referenceable.allowReferenceCollection = true
+
+      // Re-validate to remove summary types and build up the references
+      // We used to cache here but as we expand the number of Referenceable things that
+      // would cause some memory bloat, this will be slower but hopefully OK
+      refresh(
+        collectHolderTypeIds(collectRelatedReferencable())
+          .flatMap(_.toTypeDeclaration[ApexClassDeclaration])
+          .map(_.paths.head)
+          .toSeq
+      )
+
+      // Find the target Referencable as it may have been replaced during the refresh
+      thisTypeId
+        .toTypeDeclaration[FullDeclaration]
+        .flatMap(_.getBodyDeclarationFromLocation(line, offset))
+        .map(_._2)
+        .flatMap({
+          case newRef: Referenceable =>
+            // Now gather the created references as the result
+            Some(newRef.collectRelatedReferencable().flatMap(_.getReferencingLocations))
+          case _ => Some(Set[TargetLocation]())
+        })
+        .getOrElse(Set.empty)
+
+    } finally {
+      Referenceable.allowReferenceCollection = false
+      Referenceable.clearReferences()
+    }
+  }
+
+  /** Collects all the dependency holder classes for the passed Referencable set */
+  private def collectHolderTypeIds(referenceable: Set[_ <: Referenceable]): Set[TypeId] = {
+    referenceable
+      .map(_.thisTypeId)
+      .flatMap(id => id.toTypeDeclaration[DependentType])
+      .flatMap(td => {
+        (td.outermostTypeDeclaration match {
+          case d: DependentType => d.getTypeDependencyHolders.toSet
+          case _                => Set.empty[TypeId]
+        }) ++ Set(td.outerTypeId)
+      })
+  }
+
+  /** Get all accumulated referencing locations. */
+  private def getReferencingLocations: Set[TargetLocation] = {
+    if (referenceLocations == null) {
+      Set.empty
+    } else {
+      referenceLocations.toSet
+    }
+  }
+}
+
+object Referenceable {
+
+  /** Gate controlling if reference collection is enabled. */
+  private var allowReferenceCollection: Boolean = false
+
+  /** Set of all references that have recorded reference locations so we can
+    * clear them after processing.
+    */
+  private val collectedReferences: mutable.Set[Referenceable] = mutable.Set.empty
+
+  /** Add a Referenceable that has recorded a reference location */
+  private def addReference(ref: Referenceable): Unit = {
+    collectedReferences.add(ref)
+  }
+
+  /** Clear all Referenceable that are known to have some reference locations */
+  private def clearReferences(): Unit = {
+    collectedReferences.foreach(_.referenceLocations = null)
+    collectedReferences.clear()
   }
 }
 
@@ -88,7 +159,7 @@ trait ReferenceProvider extends SourceOps {
     if (expr.nonEmpty && expr.get.locatable.isEmpty)
       return emptyTargetLocations
 
-    expr
+    val locationOpt = expr
       .flatMap(_.locatable)
       .orElse({
         sourceTd match {
@@ -97,12 +168,22 @@ trait ReferenceProvider extends SourceOps {
               .map(_._2)
         }
       })
+
+    locationOpt
       .flatMap({
         case ref: Referenceable =>
-          // ReValidate any references so that ReferenceLocations can be built up
-          if (ref.doesNeedReValidation())
-            reValidate(ref.getReferenceHolderTypeIds)
-          Some(ref.findReferences().toArray)
+          val targetLocation = locationOpt.get.location.location
+          Some(
+            ref
+              .getCurrentReferences(
+                targetLocation.startLine,
+                targetLocation.startPosition,
+                (paths: Seq[PathLike]) => {
+                  refreshBatched(paths.map(path => RefreshRequest(this, path, highPriority = true)))
+                }
+              )
+              .toArray
+          )
         case _ => None
       })
       .getOrElse(emptyTargetLocations)

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/ReferenceProvider.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/ReferenceProvider.scala
@@ -146,9 +146,9 @@ trait ReferenceProvider extends SourceOps {
 
   def getReferences(path: PathLike, line: Int, offset: Int): Array[TargetLocation] = {
     val sourceTd = loadTypeFromModule(path) match {
-      case Some(sm: SummaryDeclaration) =>
-        reValidate(Set(sm.typeId) ++ sm.getTypeDependencyHolders.toSet)
-        // Reload the source after summary type has been validated so we can get the full type
+      case Some(_: SummaryDeclaration) =>
+        // Refresh the summary type to get the full type
+        refreshBatched(Seq(RefreshRequest(this, path, highPriority = true)))
         loadTypeFromModule(path).getOrElse(return emptyTargetLocations)
       case Some(td) => td
       case None     => return emptyTargetLocations

--- a/jvm/src/test/scala/com/nawforce/apexlink/pkg/ImplementationProviderTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/pkg/ImplementationProviderTest.scala
@@ -22,11 +22,13 @@ class ImplementationProviderTest extends AnyFunSuite with TestHelper {
     )
     FileSystemHelper.run(source) { root: PathLike =>
       val org = createHappyOrg(root)
+      val result = org.unmanaged
+        .getImplementation(root.join("Foo.cls"), line = 1, offset = contentAndCursorPos._2, None)
+        .map(LocationLinkString(root, contentAndCursorPos._1, _))
       assert(
-        org.unmanaged
-          .getImplementation(root.join("Foo.cls"), line = 1, offset = contentAndCursorPos._2, None)
-          .map(LocationLinkString(root, contentAndCursorPos._1, _)) sameElements
-          Array(
+        result.length == 2 &&
+          result.toSet ==
+          Set(
             LocationLinkString("goToMethod", path"/Dummy.cls", "void goToMethod(){}", "goToMethod"),
             LocationLinkString(
               "goToMethod",
@@ -54,11 +56,13 @@ class ImplementationProviderTest extends AnyFunSuite with TestHelper {
       )
     ) { root: PathLike =>
       val org = createHappyOrg(root)
+      val result = org.unmanaged
+        .getImplementation(root.join("Foo.cls"), line = 1, offset = contentAndCursorPos._2, None)
+        .map(LocationLinkString(root, contentAndCursorPos._1, _))
+      assert(result.length == 2)
       assert(
-        org.unmanaged
-          .getImplementation(root.join("Foo.cls"), line = 1, offset = contentAndCursorPos._2, None)
-          .map(LocationLinkString(root, contentAndCursorPos._1, _))
-          sameElements Array(
+        result.toSet ==
+          Set(
             LocationLinkString("concrete", path"/Dummy.cls", "void concrete(){}", "concrete"),
             LocationLinkString("concrete", path"/Bar.cls", "void concrete(){}", "concrete")
           )
@@ -77,13 +81,14 @@ class ImplementationProviderTest extends AnyFunSuite with TestHelper {
     )
     FileSystemHelper.run(source) { root: PathLike =>
       val org = createHappyOrg(root)
-      val actual = org.unmanaged
+      val result = org.unmanaged
         .getImplementation(root.join("Foo.cls"), line = 1, offset = contentAndCursorPos._2, None)
         .map(LocationLinkString(root, contentAndCursorPos._1, _))
       assert(
-        actual sameElements Array(
-          LocationLinkString("goToMethod", path"/Dummy.cls", "void goToMethod(){}", "goToMethod")
-        )
+        result sameElements
+          Array(
+            LocationLinkString("goToMethod", path"/Dummy.cls", "void goToMethod(){}", "goToMethod")
+          )
       )
     }
   }
@@ -103,11 +108,13 @@ class ImplementationProviderTest extends AnyFunSuite with TestHelper {
       )
     ) { root: PathLike =>
       val org = createHappyOrg(root)
+      val result = org.unmanaged
+        .getImplementation(root.join("Foo.cls"), line = 1, offset = contentAndCursorPos._2, None)
+        .map(LocationLinkString(root, contentAndCursorPos._1, _))
+      assert(result.length == 3)
       assert(
-        org.unmanaged
-          .getImplementation(root.join("Foo.cls"), line = 1, offset = contentAndCursorPos._2, None)
-          .map(LocationLinkString(root, contentAndCursorPos._1, _)) sameElements
-          Array(
+        result.toSet ==
+          Set(
             LocationLinkString("Foo", path"/Bar.cls", bar, "Bar"),
             LocationLinkString("Foo", path"/DummyTwo.cls", dummyTwo, "DummyTwo"),
             LocationLinkString("Foo", path"/Dummy.cls", dummy, "Dummy")
@@ -131,14 +138,15 @@ class ImplementationProviderTest extends AnyFunSuite with TestHelper {
       )
     ) { root: PathLike =>
       val org = createHappyOrg(root)
+      val result = org.unmanaged
+        .getImplementation(root.join("Foo.cls"), line = 1, offset = contentAndCursorPos._2, None)
+        .map(LocationLinkString(root, contentAndCursorPos._1, _))
+      assert(result.length == 2)
       assert(
-        org.unmanaged
-          .getImplementation(root.join("Foo.cls"), line = 1, offset = contentAndCursorPos._2, None)
-          .map(LocationLinkString(root, contentAndCursorPos._1, _)) sameElements
-          Array(
-            LocationLinkString("Foo", path"/DummyTwo.cls", dummyTwo, "DummyTwo"),
-            LocationLinkString("Foo", path"/Dummy.cls", dummy, "Dummy")
-          )
+        result.toSet == Set(
+          LocationLinkString("Foo", path"/DummyTwo.cls", dummyTwo, "DummyTwo"),
+          LocationLinkString("Foo", path"/Dummy.cls", dummy, "Dummy")
+        )
       )
     }
   }
@@ -151,23 +159,18 @@ class ImplementationProviderTest extends AnyFunSuite with TestHelper {
     FileSystemHelper.run(Map("Foo.cls" -> contentAndCursorPos._1, "Dummy.cls" -> dummy)) {
       root: PathLike =>
         val org = createHappyOrg(root)
+        val result = org.unmanaged
+          .getImplementation(root.join("Foo.cls"), line = 1, offset = contentAndCursorPos._2, None)
+          .map(LocationLinkString(root, contentAndCursorPos._1, _))
         assert(
-          org.unmanaged
-            .getImplementation(
-              root.join("Foo.cls"),
-              line = 1,
-              offset = contentAndCursorPos._2,
-              None
+          result sameElements Array(
+            LocationLinkString(
+              "Foo",
+              path"/Dummy.cls",
+              "class InnerClass implements Foo { public void goToMethod(){}}",
+              "InnerClass"
             )
-            .map(LocationLinkString(root, contentAndCursorPos._1, _)) sameElements
-            Array(
-              LocationLinkString(
-                "Foo",
-                path"/Dummy.cls",
-                "class InnerClass implements Foo { public void goToMethod(){}}",
-                "InnerClass"
-              )
-            )
+          )
         )
     }
   }
@@ -180,15 +183,11 @@ class ImplementationProviderTest extends AnyFunSuite with TestHelper {
     FileSystemHelper.run(Map("Foo.cls" -> contentAndCursorPos._1, "Dummy.cls" -> dummy)) {
       root: PathLike =>
         val org = createHappyOrg(root)
+        val result = org.unmanaged
+          .getImplementation(root.join("Foo.cls"), line = 1, offset = contentAndCursorPos._2, None)
+          .map(LocationLinkString(root, contentAndCursorPos._1, _))
         assert(
-          org.unmanaged
-            .getImplementation(
-              root.join("Foo.cls"),
-              line = 1,
-              offset = contentAndCursorPos._2,
-              None
-            )
-            .map(LocationLinkString(root, contentAndCursorPos._1, _))
+          result
             sameElements
               Array(
                 LocationLinkString(


### PR DESCRIPTION
This is refactor of how we find method references. It removes caching from the approach which will make it slower to run but means we are not using memory for storing references. The thought is that with this approach we can expand the number of types of things we can provide references for without much concern on the overheads. 

On a stress tests, finding references for fflib_SObjectSelector.selectSObjectsById it took around 25s to complete, but more typically it runs in 2-3 seconds. 