### PR TITLE
Type references

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
@@ -271,7 +271,15 @@ class ApexMethodDeclaration(
 
     val blockContext =
       new OuterBlockVerifyContext(context, modifiers.contains(STATIC_MODIFIER), typeName)
-    parameters.foreach(param => param.addVar(blockContext))
+    parameters.foreach(param => {
+      blockContext.addVar(
+        param.name,
+        param.id,
+        param.modifiers.modifiers.contains(FINAL_MODIFIER),
+        param.typeName,
+        context.thisType
+      )
+    })
     block.foreach(block => {
       block.verify(blockContext)
     })
@@ -412,7 +420,8 @@ final case class ApexConstructorDeclaration(
         param.name,
         param.id,
         param.modifiers.modifiers.contains(FINAL_MODIFIER),
-        param.typeName
+        param.typeName,
+        context.thisType
       )
     )
     block.verify(blockContext)
@@ -454,10 +463,6 @@ final case class FormalParameter(
   override val name: Name = id.name
 
   override def typeName: TypeName = relativeTypeName.typeName
-
-  def addVar(context: BlockVerifyContext): Unit = {
-    relativeTypeName.addVar(id, id.name, modifiers.modifiers.contains(FINAL_MODIFIER), context)
-  }
 
   def verify(context: BodyDeclarationVerifyContext): Unit = {
     id.validate(context)

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Literals.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Literals.scala
@@ -98,10 +98,8 @@ final case class BoundStringLiteral(bound: Set[Name]) extends Literal {
         context.thisType
           .findField(bound, None)
           .map(field => {
-            field match {
-              case ref: Referenceable => ref.addReferencingLocation(location)
-              case _                  =>
-            }
+            Referenceable
+              .addReferencingLocation(context.thisType, field, location, context.thisType)
             context.addDependency(field)
           })
       }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
@@ -81,6 +81,8 @@ final case class TypeReferencePrimary(typeName: TypeName) extends Primary {
       val td = context.getTypeAndAddDependency(targetTypeName, context.thisType).toOption
       if (td.isEmpty)
         context.missingType(location, typeName)
+      else
+        Referenceable.addReferencingLocation(td.get, location, context.thisType)
     }
     ExprContext(isStatic = Some(false), Some(PlatformTypes.typeType))
   }
@@ -147,10 +149,7 @@ final case class IdPrimary(id: Id) extends Primary {
     cachedClassFieldDeclaration = field
 
     if (field.nonEmpty && isAccessible(td, field.get, staticContext)) {
-      field.get match {
-        case ref: Referenceable => ref.addReferencingLocation(location)
-        case _                  =>
-      }
+      Referenceable.addReferencingLocation(field.get, location, context.thisType)
       context.addDependency(field.get)
       Some(
         context

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
@@ -292,7 +292,7 @@ final case class EnhancedForControl(typeName: TypeName, id: Id, expression: Expr
 
   /** Add vars introduced by the control to a context */
   override def addVars(context: BlockVerifyContext): Unit = {
-    context.addVar(id.name, this, isReadOnly = false, typeName)
+    context.addVar(id.name, this, isReadOnly = false, typeName, context.thisType)
   }
 
   override def verify(context: BlockVerifyContext): Unit = {

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Variables.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Variables.scala
@@ -15,6 +15,7 @@
 package com.nawforce.apexlink.cst
 
 import com.nawforce.apexlink.cst.AssignableSupport.isAssignableDeclaration
+import com.nawforce.apexlink.org.Referenceable
 import com.nawforce.pkgforce.diagnostics.{Diagnostic, ERROR_CATEGORY, Issue, WARNING_CATEGORY}
 import com.nawforce.pkgforce.modifiers.{ApexModifiers, FINAL_MODIFIER, ModifierResults}
 import com.nawforce.pkgforce.names.TypeName
@@ -33,6 +34,7 @@ final case class VariableDeclarator(
     id.validate(context)
 
     val lhsType = context.getTypeAndAddDependency(typeName, context.thisType).toOption
+    lhsType.foreach(td => Referenceable.addReferencingLocation(td, location, context.thisType))
 
     val exprContext = new ExpressionVerifyContext(context)
     init.foreach(rhs => {
@@ -63,7 +65,7 @@ final case class VariableDeclarator(
   }
 
   def addVars(context: BlockVerifyContext): Unit = {
-    context.addVar(id.name, this, isReadOnly, typeName)
+    context.addVar(id.name, this, isReadOnly, typeName, context.thisType)
   }
 
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/stmts/Switch.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/stmts/Switch.scala
@@ -146,10 +146,12 @@ final case class WhenLiteralsValue(literals: Seq[WhenLiteral]) extends WhenValue
       case iv: WhenIdLiteral =>
         val field = typeDeclaration.findField(iv.id.name, Some(true))
         field.foreach(field => {
-          field match {
-            case ref: Referenceable => ref.addReferencingLocation(iv.location)
-            case _                  =>
-          }
+          Referenceable.addReferencingLocation(
+            typeDeclaration,
+            field,
+            iv.location,
+            context.thisType
+          )
           context.addDependency(field)
         })
         if (field.isEmpty) {
@@ -186,7 +188,7 @@ final case class WhenSObjectValue(typeName: TypeName, id: Id) extends WhenValue 
   }
 
   override def verify(context: BlockVerifyContext): Unit = {
-    context.addVar(id.name, id, isReadOnly = false, typeName)
+    context.addVar(id.name, id, isReadOnly = false, typeName, context.thisType)
   }
 }
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/finding/RelativeTypeName.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/finding/RelativeTypeName.scala
@@ -111,29 +111,6 @@ final case class RelativeTypeName(typeContext: RelativeTypeContext, relativeType
     }
   }
 
-  /** Helper for introducing formal parameters into a block context. */
-  def addVar(
-    definition: CST,
-    name: Name,
-    isReadyOnly: Boolean,
-    context: BlockVerifyContext
-  ): Unit = {
-    typeContext.resolve(relativeTypeName) match {
-      case Some(Right(td)) =>
-        context.addVar(name, Some(definition), isReadyOnly, td)
-        context.addDependency(td)
-      case _ =>
-        Option(definition.location)
-          .foreach(location => context.missingType(location, relativeTypeName))
-        context.addVar(
-          name,
-          None,
-          isReadyOnly,
-          typeContext.contextTypeDeclaration.moduleDeclaration.get.any
-        )
-    }
-  }
-
   /** Helper for obtaining the nature of the outer type. */
   def outerNature: Nature = typeContext.contextTypeDeclaration.nature
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/names/TypeNames.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/names/TypeNames.scala
@@ -370,6 +370,11 @@ object TypeNames extends InternCache[TypeName] {
       }
     }
 
+    def isMap: Boolean =
+      typeName.name == Names.Map$ && typeName.outer.contains(
+        TypeNames.System
+      ) && typeName.params.size == 2
+
     def isSet: Boolean =
       typeName.name == Names.Set$ && typeName.outer.contains(
         TypeNames.System

--- a/jvm/src/main/scala/com/nawforce/apexlink/opcst/TypeDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/opcst/TypeDeclaration.scala
@@ -548,7 +548,10 @@ private[opcst] object OutlineParserClassBodyDeclaration {
     typeName: TypeName,
     isReadOnly: Boolean
   ): VariableDeclarator = {
-    VariableDeclarator(typeName, isReadOnly, OutlineParserId.construct(id, source.path), None)
+    val vd =
+      VariableDeclarator(typeName, isReadOnly, OutlineParserId.construct(id, source.path), None)
+    stampLocation(vd, extendLocation(id.location, startLineOffset = -1), source.path)
+    vd
   }
 
   private def constructVariableDeclarator(

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/ReferenceProvider.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/ReferenceProvider.scala
@@ -3,18 +3,15 @@
  */
 package com.nawforce.apexlink.org
 
-import com.nawforce.apexlink.cst.ExprContext
+import com.nawforce.apexlink.finding.TypeResolver
 import com.nawforce.apexlink.memory.SkinnySet
+import com.nawforce.apexlink.names.TypeNames.TypeNameUtils
 import com.nawforce.apexlink.org.ReferenceProvider.emptyTargetLocations
 import com.nawforce.apexlink.rpc.TargetLocation
-import com.nawforce.apexlink.types.apex.{
-  ApexClassDeclaration,
-  ApexFullDeclaration,
-  FullDeclaration,
-  SummaryDeclaration
-}
+import com.nawforce.apexlink.types.apex.{ApexClassDeclaration, FullDeclaration}
 import com.nawforce.apexlink.types.core.{Dependent, DependentType, TypeDeclaration, TypeId}
-import com.nawforce.pkgforce.path.{PathLike, PathLocation}
+import com.nawforce.pkgforce.path.{IdLocatable, PathLike, PathLocation}
+import com.nawforce.apexlink.types.platform.GenericPlatformTypeDeclaration
 
 import scala.collection.mutable
 
@@ -24,7 +21,7 @@ import scala.collection.mutable
   *
   * @see ReferenceProvider
   */
-trait Referenceable {
+trait Referenceable extends IdLocatable {
   this: Dependent =>
 
   /** Referencable must be able to provide a TypeId for the containing type to support revalidation. */
@@ -58,11 +55,7 @@ trait Referenceable {
     * is to collect references to things during a revalidation pass. The ReferenceProvider
     * uses this.
     */
-  def getCurrentReferences(
-    line: Int,
-    offset: Int,
-    refresh: Seq[PathLike] => Unit
-  ): Set[TargetLocation] = {
+  def getCurrentReferences(refresh: Seq[PathLike] => Unit): Set[TargetLocation] = {
 
     try {
       Referenceable.allowReferenceCollection = true
@@ -80,8 +73,13 @@ trait Referenceable {
       // Find the target Referencable as it may have been replaced during the refresh
       thisTypeId
         .toTypeDeclaration[FullDeclaration]
-        .flatMap(_.getBodyDeclarationFromLocation(line, offset))
-        .map(_._2)
+        .flatMap(td => {
+          if (td.idLocation.contains(idLocation.startLine, idLocation.startPosition))
+            Some(td)
+          else
+            td.getBodyDeclarationFromLocation(idLocation.startLine, idLocation.startPosition)
+              .map(_._2)
+        })
         .flatMap({
           case newRef: Referenceable =>
             // Now gather the created references as the result
@@ -129,6 +127,41 @@ object Referenceable {
     */
   private val collectedReferences: mutable.Set[Referenceable] = mutable.Set.empty
 
+  /** Helper to add a reference location for something which may be a Referenceable */
+  def addReferencingLocation(
+    referenceable: Any,
+    location: PathLocation,
+    from: TypeDeclaration
+  ): Unit = {
+
+    referenceable match {
+      case td: GenericPlatformTypeDeclaration if td.typeName.isList || td.typeName.isSet =>
+        TypeResolver(td.typeName.params.head, from).toOption.foreach(td =>
+          Referenceable.addReferencingLocation(td, location, from)
+        )
+      case td: GenericPlatformTypeDeclaration if td.typeName.isMap =>
+        TypeResolver(td.typeName.params.head, from).toOption.foreach(td =>
+          Referenceable.addReferencingLocation(td, location, from)
+        )
+        TypeResolver(td.typeName.params.last, from).toOption.foreach(td =>
+          Referenceable.addReferencingLocation(td, location, from)
+        )
+      case ref: Referenceable => ref.addReferencingLocation(location)
+      case _                  => ()
+    }
+  }
+
+  /** Helper to add a reference location for a pair which may be Referenceable */
+  def addReferencingLocation(
+    referenceDeclaration: TypeDeclaration,
+    referenceable: Any,
+    location: PathLocation,
+    from: TypeDeclaration
+  ): Unit = {
+    addReferencingLocation(referenceDeclaration, location, from)
+    addReferencingLocation(referenceable, location, from)
+  }
+
   /** Add a Referenceable that has recorded a reference location */
   private def addReference(ref: Referenceable): Unit = {
     collectedReferences.add(ref)
@@ -145,64 +178,14 @@ trait ReferenceProvider extends SourceOps {
   this: OPM.PackageImpl =>
 
   def getReferences(path: PathLike, line: Int, offset: Int): Array[TargetLocation] = {
-    val sourceTd = loadTypeFromModule(path) match {
-      case Some(_: SummaryDeclaration) =>
-        // Refresh the summary type to get the full type
-        refreshBatched(Seq(RefreshRequest(this, path, highPriority = true)))
-        loadTypeFromModule(path).getOrElse(return emptyTargetLocations)
-      case Some(td) => td
-      case None     => return emptyTargetLocations
-    }
-
-    val expr = getExpressionFromValidation(sourceTd, line, offset)
-
-    if (expr.nonEmpty && expr.get.locatable.isEmpty)
-      return emptyTargetLocations
-
-    val locationOpt = expr
-      .flatMap(_.locatable)
-      .orElse({
-        sourceTd match {
-          case fd: FullDeclaration =>
-            fd.getBodyDeclarationFromLocation(line, offset)
-              .map(_._2)
-        }
-      })
-
-    locationOpt
-      .flatMap({
-        case ref: Referenceable =>
-          val targetLocation = locationOpt.get.location.location
-          Some(
-            ref
-              .getCurrentReferences(
-                targetLocation.startLine,
-                targetLocation.startPosition,
-                (paths: Seq[PathLike]) => {
-                  refreshBatched(paths.map(path => RefreshRequest(this, path, highPriority = true)))
-                }
-              )
-              .toArray
-          )
-        case _ => None
-      })
+    loadTypeFromModule(path)
+      .collect({ case td: ApexClassDeclaration => td })
+      .flatMap(_.findReferenceableFromLocation(line, offset))
+      .map(_.getCurrentReferences((paths: Seq[PathLike]) => {
+        refreshBatched(paths.map(path => RefreshRequest(this, path, highPriority = true)))
+      }).toArray)
       .getOrElse(emptyTargetLocations)
   }
-
-  private def getExpressionFromValidation(
-    td: TypeDeclaration,
-    line: Int,
-    offset: Int
-  ): Option[ExprContext] = {
-    td match {
-      case td: ApexFullDeclaration =>
-        val result = locateFromValidation(td, line, offset)
-        result._2.map(loc => result._1(loc).result)
-      case _ => None
-    }
-
-  }
-
 }
 
 object ReferenceProvider {

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/ReferenceProvider.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/ReferenceProvider.scala
@@ -12,6 +12,7 @@ import com.nawforce.apexlink.types.apex.{ApexClassDeclaration, FullDeclaration}
 import com.nawforce.apexlink.types.core.{Dependent, DependentType, TypeDeclaration, TypeId}
 import com.nawforce.pkgforce.path.{IdLocatable, PathLike, PathLocation}
 import com.nawforce.apexlink.types.platform.GenericPlatformTypeDeclaration
+import com.nawforce.pkgforce.diagnostics.LoggerOps
 
 import scala.collection.mutable
 
@@ -38,6 +39,11 @@ trait Referenceable extends IdLocatable {
     if (Referenceable.allowReferenceCollection) {
       if (referenceLocations == null) {
         referenceLocations = new SkinnySet[TargetLocation]()
+      }
+      if (referencingLocation.path == null) {
+        LoggerOps.debug(
+          s"Referenceable.addReferencingLocation: No referencing path provided to $this, location: $referencingLocation"
+        )
       }
       referenceLocations.add(
         TargetLocation(referencingLocation.path.toString, referencingLocation.location)

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/core/TypeDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/core/TypeDeclaration.scala
@@ -222,7 +222,7 @@ trait Parameters {
   }
 }
 
-trait ConstructorDeclaration extends DependencyHolder with Parameters {
+trait ConstructorDeclaration extends DependencyHolder with Dependent with Parameters {
   val modifiers: ArraySeq[Modifier]
 
   def visibility: Modifier =


### PR DESCRIPTION
This builds on #345 

The target has been simplified so that we only use declaration location, rather than allowing trigging from any reference. We can add that back as a fallback if needed but this is simpler and so quicker.

I have added support for constructor & Type references as discussed. The decision on what to and not to include for Types is a bit arbitrary but approximates to finding where you needed to specify the type name in code. There are a couple of good use cases for this, finding where custom exceptions are created even if there is no constructor and finding all locations an enum/interface is in use. For classes its probably betters to focus on field, property, constructor & method reference finding buy there will be exceptions. 

In reporting references sometimes the Location is a bit off ideal but that's typically because we don't have an ideal Location to use. I was thinking we could release as is and see if there is feedback on specific cases and improve piecemeal rather than speculatively take the extra overheads without knowing what is of most value.