### PR TITLE
Hashing and finding opts

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/ConstructorMap.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/ConstructorMap.scala
@@ -28,8 +28,6 @@ final case class ConstructorMap(
   superConstructorsByParam: Option[ConstructorMap],
   errors: List[Issue]
 ) {
-  val deepHash: Int = td.map(_.deepHash).getOrElse(0)
-
   def allConstructors: ArraySeq[ConstructorDeclaration] = {
     val buffer = new mutable.ArrayBuffer[ConstructorDeclaration]()
     constructorsByParam.values.foreach(ctor => buffer.addAll(ctor))

--- a/jvm/src/main/scala/com/nawforce/apexlink/deps/ReferencingCollector.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/deps/ReferencingCollector.scala
@@ -117,7 +117,8 @@ object ReferencingCollector {
       .flatMap(_.thisTypeIdOpt)
       .flatMap(typeId =>
         typeId.module
-          .findPackageType(typeId.typeName, None)
+          .findType(typeId.typeName)
+          .toOption
           .collect { case td: ApexDeclaration => td }
       )
   }

--- a/jvm/src/main/scala/com/nawforce/apexlink/finding/TypeError.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/finding/TypeError.scala
@@ -38,6 +38,22 @@ final case class MissingType(_typeName: TypeName) extends TypeError(_typeName) {
   override def toString: String = throw new IllegalArgumentException
 }
 
+final case class InaccessibleType(_typeName: TypeName) extends TypeError(_typeName) {
+  def asIssue(location: PathLocation): Issue = {
+    new Issue(
+      location.path,
+      Diagnostic(
+        MISSING_CATEGORY,
+        location.location,
+        s"Type '$typeName' is not accessible from here"
+      )
+    )
+  }
+
+  // Protect against old way of using this
+  override def toString: String = throw new IllegalArgumentException
+}
+
 final case class WrongTypeArguments(_typeName: TypeName, expected: Integer)
     extends TypeError(_typeName) {
   def asIssue(location: PathLocation): Issue = {

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/ModuleFind.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/ModuleFind.scala
@@ -14,84 +14,158 @@
 
 package com.nawforce.apexlink.org
 
-import com.nawforce.apexlink.finding.TypeResolver
+import com.nawforce.apexlink.finding.{InaccessibleType, MissingType, TypeResolver}
 import com.nawforce.apexlink.finding.TypeResolver.TypeResponse
 import com.nawforce.apexlink.names.TypeNames
+import com.nawforce.apexlink.names.TypeNames.{InternalInterface, InternalObject, TypeNameUtils}
 import com.nawforce.apexlink.types.core.TypeDeclaration
-import com.nawforce.pkgforce.modifiers.GLOBAL_MODIFIER
-import com.nawforce.pkgforce.names.{EncodedName, Name, TypeName}
+import com.nawforce.pkgforce.names.{DotName, EncodedName, Name, TypeName}
 
+import scala.annotation.tailrec
+
+/** Provides type resolution utilities for modules, including searching for type declarations
+  * within the current module, its package, and dependencies.
+  *
+  * This trait is intended to be mixed into an `OPM.Module` and supplies methods for:
+  * - Resolving types by name, with or without context.
+  * - Handling nested and platform types.
+  * - Enforcing visibility and accessibility rules during type lookup.
+  *
+  * The main entry points are the `findType` methods, which delegate to internal helpers
+  * for package, module, and nested type resolution.
+  */
 trait ModuleFind {
   self: OPM.Module =>
 
-  /* Find a package/platform type. For general needs don't call this direct, use TypeRequest which will delegate here
-   * if needed. This is the fallback handling for the TypeFinder which performs local searching for types, so this is
-   * only useful if you know local searching is not required. */
+  /** Finds a type declaration for the given type name, using the specified context type as the origin.
+    *
+    * @param typeName The type name to search for.
+    * @param from     The originating type declaration for context.
+    * @return         Either the resolved TypeDeclaration, or an error if not found or inaccessible.
+    */
   def findType(typeName: TypeName, from: TypeDeclaration): TypeResponse = {
     findType(typeName, Some(from))
   }
 
+  /** Finds a type declaration for the given type name, without a specific context type.
+    * @param typeName The type name to search for.
+    * @return         Either the resolved TypeDeclaration, or an error if not found or inaccessible.
+    */
   def findType(typeName: TypeName): TypeResponse = {
     findType(typeName, None)
   }
 
+  /** Core type resolution logic for finding a type declaration by name, optionally using a context type.
+    *
+    * @param typeName The type name to search for.
+    * @param from     Optional context type declaration for platform type resolution.
+    * @return         Either the resolved TypeDeclaration, or an error if not found or inaccessible.
+    */
   private def findType(typeName: TypeName, from: Option[TypeDeclaration]): TypeResponse = {
-    if (namespace.nonEmpty) {
-      val td = findPackageType(typeName.withTail(TypeName(namespace.get)), from).map(Right(_))
-      if (td.nonEmpty)
-        return td.get
+    val targetType = TypeNames.aliasOrReturn(typeName)
+    if ((typeName ne InternalObject) && (typeName ne InternalInterface)) {
+
+      // Search for package type
+      findPackageType(targetType) match {
+        case Right(declaration)                         => return Right(declaration)
+        case Left(InaccessibleType(typeName: TypeName)) => return Left(InaccessibleType(typeName))
+        case Left(_)                                    => ()
+      }
     }
 
-    val td = findPackageType(typeName, from).map(Right(_))
-    if (td.nonEmpty)
-      return td.get
-
+    // Search for platform type
     // From may be used to locate type variable types so must be accurate even for a platform type request
     from
-      .map(TypeResolver.platformType(typeName, _))
+      .map(TypeResolver.platformType(targetType, _))
       .orElse(Some(TypeResolver.platformTypeOnly(typeName, this)))
       .get
   }
 
-  // Find locally, or fallback to a searching base packages
-  def findPackageType(
-    typeName: TypeName,
-    from: Option[TypeDeclaration],
-    inPackage: Boolean = true
-  ): Option[TypeDeclaration] = {
-    // Use aliased type name here so we don't mishandle an ambiguous typename when searching
-    val targetType = TypeNames.aliasOrReturn(typeName)
+  /** Finds a type declaration within the current package or its dependencies.
+    * - Returns `Left(InaccessibleType)` if the type is found but not visible.
+    * - Returns `Left(MissingType)` if the type cannot be found in any module.
+    *
+    * @param typeName The type name to search for.
+    * @return         Either the resolved TypeDeclaration, or an error if not found or inaccessible.
+    */
+  private def findPackageType(typeName: TypeName): TypeResponse = {
+    // As we may have many modules to search it's best to pre-generate typenames to match against first
+    var searchTypeNamesWithoutNamespace: List[(TypeName, Option[TypeName])] = Nil
+    var searchTypeNamesWithNamespace: List[(TypeName, Option[TypeName])]    = Nil
+    var target: Option[TypeName]                                            = Some(typeName)
+    var residual: Option[TypeName]                                          = None
+    while (target.nonEmpty) {
+      searchTypeNamesWithoutNamespace = (target.get, residual) :: searchTypeNamesWithoutNamespace
+      if (namespace.nonEmpty)
+        searchTypeNamesWithNamespace =
+          (target.get.withTail(TypeName(namespace.get)), residual) :: searchTypeNamesWithNamespace
+      residual = residual
+        .map(_.withTail(target.get.inner()))
+        .orElse(Some(TypeName(target.get.name, target.get.params, None)))
+      target = target.get.outer
+    }
+    val searchTypeNames =
+      searchTypeNamesWithNamespace.reverse ++ searchTypeNamesWithoutNamespace.reverse
 
-    findPackageTypeInternal(targetType, from, inPackage)
+    // Search over modules
+    var inPackage                        = true
+    var targetModule: Option[OPM.Module] = Some(this)
+    while (targetModule.nonEmpty) {
+      var targetTypeNames = searchTypeNames
+      while (targetTypeNames != Nil) {
+        val (searchTypeName, residual) = targetTypeNames.head
+        targetModule.get
+          .findModuleType(searchTypeName)
+          .foreach(declaration => {
+            // Found something, so terminate search
+            return if (!inPackage && !declaration.isExternallyVisible) {
+              Left(InaccessibleType(searchTypeName))
+            } else if (residual.nonEmpty) {
+              resolveNestedType(searchTypeName, inPackage, declaration, residual.get.asDotName)
+            } else {
+              Right(declaration)
+            }
+          })
+        targetTypeNames = targetTypeNames.tail
+      }
+      targetModule = targetModule.flatMap(_.nextModule)
+      inPackage = targetModule.exists(_.pkg == pkg)
+    }
+    Left(MissingType(typeName))
   }
 
-  private def findPackageTypeInternal(
-    typeName: TypeName,
-    from: Option[TypeDeclaration],
-    inPackage: Boolean
-  ): Option[TypeDeclaration] = {
-    // Might be an outer in this module
-    var declaration = findModuleType(typeName)
-    if (declaration.nonEmpty) {
-      if (inPackage || declaration.get.modifiers.contains(GLOBAL_MODIFIER))
-        return declaration
-      else
-        return None
+  /** Recursively resolves a nested type within a type declaration.
+    *
+    * @param searchTypeName The current (outer) type name being resolved.
+    * @param inPackage      True if searching within the same package, affecting visibility checks.
+    * @param declaration    The current type declaration to search for nested types.
+    * @param names          The remaining nested names to resolve, as a DotName.
+    * @return               Either the resolved nested TypeDeclaration, or an error if not found or inaccessible.
+    */
+  @tailrec
+  private def resolveNestedType(
+    searchTypeName: TypeName,
+    inPackage: Boolean,
+    declaration: TypeDeclaration,
+    names: DotName
+  ): TypeResponse = {
+    val typeName = TypeName(names.firstName, Nil, Some(searchTypeName))
+    declaration
+      .findNestedType(names.firstName) match {
+      case Some(declaration) if inPackage || declaration.isExternallyVisible =>
+        if (names.names.size == 1)
+          Right(declaration)
+        else resolveNestedType(typeName, inPackage, declaration, names.tail)
+      case Some(_) =>
+        Left(InaccessibleType(typeName))
+      case None =>
+        Left(MissingType(typeName))
     }
-
-    // Or maybe an inner
-    if (typeName.outer.nonEmpty) {
-      declaration = findPackageTypeInternal(typeName.outer.get, from, inPackage = inPackage)
-        .flatMap(_.findNestedType(typeName.name).filter(td => td.isExternallyVisible || inPackage))
-      if (declaration.nonEmpty)
-        return declaration
-    }
-
-    // Try base modules & packages of this module
-    nextModule.flatMap(next => next.findPackageType(typeName, from, next.pkg == pkg))
   }
 
-  /** Find a type just in this module. */
+  /** Find a type declaration searching within this module.
+    * - Returns `None` if the type is not found in this module.
+    */
   def findModuleType(typeName: TypeName): Option[TypeDeclaration] = {
     // Direct hit
     val declaration = types.get(typeName)

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/ModuleFind.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/ModuleFind.scala
@@ -90,22 +90,20 @@ trait ModuleFind {
     */
   private def findPackageType(typeName: TypeName): TypeResponse = {
     // As we may have many modules to search it's best to pre-generate typenames to match against first
-    var searchTypeNamesWithoutNamespace: List[(TypeName, Option[TypeName])] = Nil
-    var searchTypeNamesWithNamespace: List[(TypeName, Option[TypeName])]    = Nil
-    var target: Option[TypeName]                                            = Some(typeName)
-    var residual: Option[TypeName]                                          = None
+    var searchTypeNames: List[(TypeName, Option[TypeName])] = Nil
+    var target: Option[TypeName]                            = Some(typeName)
+    var residual: Option[TypeName]                          = None
     while (target.nonEmpty) {
-      searchTypeNamesWithoutNamespace = (target.get, residual) :: searchTypeNamesWithoutNamespace
       if (namespace.nonEmpty)
-        searchTypeNamesWithNamespace =
-          (target.get.withTail(TypeName(namespace.get)), residual) :: searchTypeNamesWithNamespace
+        searchTypeNames =
+          (target.get.withTail(TypeName(namespace.get)), residual) :: searchTypeNames
+      searchTypeNames = (target.get, residual) :: searchTypeNames
       residual = residual
         .map(_.withTail(target.get.inner()))
         .orElse(Some(TypeName(target.get.name, target.get.params, None)))
       target = target.get.outer
     }
-    val searchTypeNames =
-      searchTypeNamesWithNamespace.reverse ++ searchTypeNamesWithoutNamespace.reverse
+    searchTypeNames = searchTypeNames.reverse
 
     // Search over modules
     var inPackage                        = true

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/OrgTestClasses.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/OrgTestClasses.scala
@@ -72,13 +72,13 @@ trait OrgTestClasses {
 
   private def findTestClasses(paths: Array[String]): Array[ApexDeclaration] = {
     if (paths.isEmpty) {
-      getAllTestClasses()
+      getAllTestClasses
     } else {
       findTestClassesFromPaths(paths)
     }
   }
 
-  private def getAllTestClasses(): Array[ApexDeclaration] = {
+  private def getAllTestClasses: Array[ApexDeclaration] = {
     packages.view.flatMap(_.orderedModules.flatMap(_.testClasses.toSeq)).toArray
   }
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/OrgTestClasses.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/OrgTestClasses.scala
@@ -88,7 +88,8 @@ trait OrgTestClasses {
       .flatMap(path => {
         findPackageIdentifier(path).flatMap(typeId => {
           typeId.module
-            .findPackageType(typeId.typeName, None)
+            .findType(typeId.typeName)
+            .toOption
             .collect { case td: ApexDeclaration if td.inTest => td }
             .filter(_.outerTypeName.isEmpty)
         })
@@ -109,7 +110,8 @@ trait OrgTestClasses {
     val accum = mutable.Set[NodeInfo]()
     startingIds.foreach(typeId => {
       typeId.module
-        .findPackageType(typeId.typeName, None)
+        .findType(typeId.typeName)
+        .toOption
         .collect { case td: ApexDeclaration => td }
         .foreach(td =>
           (td +: td.nestedTypes).foreach(td => sourcesForType(td, primary = true, accum))

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/apex/FullDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/apex/FullDeclaration.scala
@@ -69,6 +69,10 @@ abstract class FullDeclaration(
     with ApexFullDeclaration {
 
   lazy val sourceHash: Int = source.code.hash
+  private lazy val contentHash = ParsedCache.classMetaHash(
+    source.path.parent.join(s"${typeName.name.toString}.cls-meta.xml"),
+    sourceHash
+  )
 
   override def paths: ArraySeq[PathLike] = ArraySeq(source.path)
 
@@ -122,10 +126,6 @@ abstract class FullDeclaration(
   override def flush(pc: ParsedCache, context: PackageContext): Unit = {
     if (!flushedToCache) {
       val diagnostics = module.pkg.org.issueManager.getDiagnostics(location.path).toArray
-      val contentHash = ParsedCache.classMetaHash(
-        source.path.parent.join(s"${typeName.name.toString}.cls-meta.xml"),
-        sourceHash
-      )
       pc.upsert(context, name.value, contentHash, writeBinary(ApexSummary(summary, diagnostics)))
       flushedToCache = true
     }

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/apex/TriggerDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/apex/TriggerDeclaration.scala
@@ -61,7 +61,7 @@ final case class TriggerDeclaration(
     with DependencyHolder {
 
   override val idLocation: Location      = nameId.location.location
-  override lazy val sourceHash: Int      = source.hash
+  override lazy val sourceHash: Int      = source.code.hash
   override def paths: ArraySeq[PathLike] = ArraySeq(location.path)
 
   override val moduleDeclaration: Option[OPM.Module] = Some(module)

--- a/jvm/src/main/scala/com/nawforce/runtime/parsers/Source.scala
+++ b/jvm/src/main/scala/com/nawforce/runtime/parsers/Source.scala
@@ -38,7 +38,6 @@ case class Source(
   startLine: Option[Int] = None,
   startColumn: Option[Int] = None
 ) {
-  val hash: Int = code.hash
 
   def extractSource(context: ParserRuleContext): Source = {
     val subdata = code.subdata(context.start.getStartIndex, context.stop.getStopIndex + 1)

--- a/jvm/src/test/scala/com/nawforce/apexlink/finding/TypeFindingTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/finding/TypeFindingTest.scala
@@ -159,7 +159,7 @@ class TypeFindingTest extends AnyFunSuite with TestHelper {
             |"packageDirectories": [{"path": "pkg2"}],
             |"plugins": {"dependencies": [{"namespace": "pkg1", "path": "pkg1"}]}
             |}""".stripMargin,
-        "pkg1/Dummy.cls" -> "global class Dummy {class Inner {}}",
+        "pkg1/Dummy.cls" -> "global class Dummy {global class Inner {}}",
         "pkg2/Use.cls"   -> "global class Use { {pkg1.Dummy.Inner value;}}"
       )
     ) { root: PathLike =>


### PR DESCRIPTION
This has two sets of optimisations, together they improve performance ~15% above previous release, recovering that lost by bugfix #342 and some more.

The hashing fix makes sure we defer hashing the metadata until the cache is being written, previously hashing was occurring during initial load. 

The finding fix optimises package type finding for the case where there are lots of package directories. We were using a recursive search through the modules, I have replaced that by a function that searches all modules and does some pre-computation of the TypeNames we will be looking for.

The branch is derived from #345 so that likely needs merging first to avoid conflicts.