### PR TITLE
Update build for central publishing

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -43,7 +43,7 @@ jobs:
           submodules: recursive
           repository: apex-dev-tools/apex-samples
           path: apex-samples
-          ref: v1.3.0
+          ref: v1.4.0
 
       - name: Set samples env
         run: echo "SAMPLES=$GITHUB_WORKSPACE/apex-samples" >> "$GITHUB_ENV"

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "npm"
           cache-dependency-path: js/npm/package-lock.json
 

--- a/.github/workflows/BuildCrossPlatform.yml
+++ b/.github/workflows/BuildCrossPlatform.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Build
         run: sbt build

--- a/.github/workflows/BuildWin.yml
+++ b/.github/workflows/BuildWin.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "npm"
           cache-dependency-path: js/npm/package-lock.json
 

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
 
       - name: Build

--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "npm"
           cache-dependency-path: js/npm/package-lock.json
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,11 @@ The Apex Language Server library provides a collection of tools to aid developme
 
 ### Installation
 
-Releases are available from [SonaType](https://s01.oss.sonatype.org). You will need to add the repository to your build tool.
+Releases are available from [Maven Central](https://central.sonatype.com/), included as a default resolver in maven and sbt.
 
 Scala:
 
   ```scala
-  // Add if not present
-  ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("releases")
-
   project.settings(
     // Replace %% with %%% to use ScalaJS build
     libraryDependencies += "io.github.apex-dev-tools" %% "apex-ls" % "X.X.X"
@@ -23,15 +20,6 @@ Scala:
 Maven:
 
   ```xml
-  <!-- In <repositories/> -->
-  <repository>
-    <id>oss.sonatype.org</id>
-    <url>https://s01.oss.sonatype.org/content/repositories/releases</url>
-    <releases>
-      <enabled>true</enabled>
-    </releases>
-  </repository>
-
   <!-- In <dependencies/> -->
   <dependency>
     <groupId>io.github.apex-dev-tools</groupId>

--- a/build.sbt
+++ b/build.sbt
@@ -19,11 +19,8 @@ ThisBuild / developers := List(
   )
 )
 ThisBuild / versionScheme          := Some("strict")
-ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
-ThisBuild / sonatypeRepository     := "https://s01.oss.sonatype.org/service/local"
 ThisBuild / resolvers += Resolver.mavenLocal
-ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("releases")
-ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
+ThisBuild / resolvers += Resolver.sonatypeCentralSnapshots
 
 lazy val build = taskKey[File]("Build artifacts")
 lazy val pack  = inputKey[Unit]("Publish specific local version")

--- a/js/npm/snapshots/system/SampleCheckSys.ts.snap
+++ b/js/npm/snapshots/system/SampleCheckSys.ts.snap
@@ -109,18 +109,20 @@ exports[`Check samples Sample: Apex-Opensource-Library 1`] = `
     ],
     [
       "force-app/commons/query/Query.cls",
-      "Warning: line 44 at 31-33: 'of' is currently a legal method name but is a reserved identifier in Apex so should be avoided",
-      "Warning: line 44 at 31-33: 'of' is currently a legal method name but is a reserved identifier in Apex so should be avoided",
+      "Warning: line 44 at 30-32: 'of' is currently a legal method name but is a reserved identifier in Apex so should be avoided",
+      "Warning: line 44 at 30-32: 'of' is currently a legal method name but is a reserved identifier in Apex so should be avoided",
+      "Warning: line 52 at 31-33: 'of' is currently a legal method name but is a reserved identifier in Apex so should be avoided",
+      "Warning: line 52 at 31-33: 'of' is currently a legal method name but is a reserved identifier in Apex so should be avoided",
     ],
     [
       "force-app/commons/query/QueryBuilder.cls",
-      "Warning: line 50 at 8-53: Local variable is hiding class field 'fields', see force-app/commons/query/QueryBuilder.cls: line 29 at 12-51",
-      "Warning: line 50 at 8-53: Local variable is hiding class field 'fields', see force-app/commons/query/QueryBuilder.cls: line 29 at 12-51",
+      "Warning: line 55 at 8-53: Local variable is hiding class field 'fields', see force-app/commons/query/QueryBuilder.cls: line 29 at 12-51",
+      "Warning: line 55 at 8-53: Local variable is hiding class field 'fields', see force-app/commons/query/QueryBuilder.cls: line 29 at 12-51",
     ],
     [
       "force-app/commons/query/QueryObject.cls",
-      "Warning: line 667 at 8-66: Local variable is hiding class field 'result', see force-app/commons/query/QueryResults.cls: line 34 at 14-28",
-      "Warning: line 667 at 8-66: Local variable is hiding class field 'result', see force-app/commons/query/QueryResults.cls: line 34 at 14-28",
+      "Warning: line 664 at 8-99: Local variable is hiding class field 'result', see force-app/commons/query/QueryResults.cls: line 34 at 14-28",
+      "Warning: line 664 at 8-99: Local variable is hiding class field 'result', see force-app/commons/query/QueryResults.cls: line 34 at 14-28",
     ],
     [
       "force-app/commons/query/QueryResults.cls",
@@ -128,8 +130,6 @@ exports[`Check samples Sample: Apex-Opensource-Library 1`] = `
       "Warning: line 109 at 8-61: Local variable is hiding class field 'result', see force-app/commons/query/QueryResults.cls: line 34 at 14-28",
       "Warning: line 117 at 8-38: Local variable is hiding class field 'result', see force-app/commons/query/QueryResults.cls: line 34 at 14-28",
       "Warning: line 117 at 8-38: Local variable is hiding class field 'result', see force-app/commons/query/QueryResults.cls: line 34 at 14-28",
-      "Warning: line 137 at 8-38: Local variable is hiding class field 'result', see force-app/commons/query/QueryResults.cls: line 34 at 14-28",
-      "Warning: line 137 at 8-38: Local variable is hiding class field 'result', see force-app/commons/query/QueryResults.cls: line 34 at 14-28",
     ],
     [
       "force-app/commons/query/cache/objects/QueryCache__mdt/QueryCache__mdt.object-meta.xml",
@@ -152,12 +152,10 @@ exports[`Check samples Sample: Apex-Opensource-Library 1`] = `
     ],
     [
       "sfdx-project.json",
-      "Warning: line 107 at 8: Dependency version '2.1.0.LATEST' for 'DatabaseService' is not compatible with '2.2.0.NEXT'",
       "Warning: line 23 at 8: Dependency version '1.0.0.LATEST' for 'Trigger Handler' is not compatible with '1.0.2.NEXT'",
       "Warning: line 45 at 8: Dependency version '1.0.0.LATEST' for 'Libra Shared' is not compatible with '1.0.1.NEXT'",
       "Warning: line 59 at 8: Dependency version '1.0.0.LATEST' for 'Libra Shared' is not compatible with '1.0.1.NEXT'",
-      "Warning: line 73 at 8: Dependency version '1.0.0.LATEST' for 'Libra Shared' is not compatible with '1.0.1.NEXT'",
-      "Warning: line 77 at 8: Dependency 'DatabaseService' must be defined in project before being referenced",
+      "Warning: line 97 at 8: Dependency version '2.1.0.LATEST' for 'DatabaseService' is not compatible with '2.3.1.NEXT'",
     ],
   ],
   "status": 4,
@@ -1281,7 +1279,7 @@ exports[`Check samples Sample: NebulaLogger 1`] = `
     ],
     [
       "nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls",
-      "Warning: line 1195 at 4-44: Local variable is hiding class field 'cachedOrganizationEnvironmentType', see nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls: line 23 at 17-58",
+      "Warning: line 1192 at 4-44: Local variable is hiding class field 'cachedOrganizationEnvironmentType', see nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls: line 23 at 17-58",
     ],
     [
       "nebula-logger/core/main/logger-engine/classes/Logger.cls",
@@ -1295,28 +1293,28 @@ exports[`Check samples Sample: NebulaLogger 1`] = `
       "Warning: line 595 at 21-30: 'exception' is currently a legal method name but is a reserved identifier in Apex so should be avoided",
     ],
     [
-      "nebula-logger/extra-tests/classes/name-shadowing/System/AuraHandledException.cls",
-      "Error: line 9 at 17-37: Exception class 'AuraHandledException' must extend another Exception class",
-    ],
-    [
-      "nebula-logger/extra-tests/classes/name-shadowing/System/CalloutException.cls",
-      "Error: line 9 at 17-33: Exception class 'CalloutException' must extend another Exception class",
-    ],
-    [
-      "nebula-logger/extra-tests/classes/name-shadowing/System/DmlException.cls",
-      "Error: line 9 at 17-29: Exception class 'DmlException' must extend another Exception class",
-    ],
-    [
-      "nebula-logger/extra-tests/classes/name-shadowing/System/IllegalArgumentException.cls",
-      "Error: line 9 at 17-41: Exception class 'IllegalArgumentException' must extend another Exception class",
-    ],
-    [
-      "nebula-logger/extra-tests/objects/LogEntryEvent__e/fields/SomeLogEntryField__c.field-meta.xml",
+      "nebula-logger/extra-tests/custom-field-mappings/objects/LogEntryEvent__e/fields/SomeLogEntryField__c.field-meta.xml",
       "Error: line 1: Components of type 'Schema.LogEntryEvent__e' are defined, but the required object-meta.xml file is missing",
     ],
     [
-      "nebula-logger/extra-tests/tests/LogEntryHandler_Tests_Flow.cls",
+      "nebula-logger/extra-tests/integration-tests/classes/LogEntryHandler_Tests_Flow.cls",
       "Missing: line 77 at 27-66: Unknown field 'TriggerObjectOrEvent' on SObject 'Schema.FlowDefinitionView'",
+    ],
+    [
+      "nebula-logger/extra-tests/name-shadowing/System/AuraHandledException.cls",
+      "Error: line 9 at 17-37: Exception class 'AuraHandledException' must extend another Exception class",
+    ],
+    [
+      "nebula-logger/extra-tests/name-shadowing/System/CalloutException.cls",
+      "Error: line 9 at 17-33: Exception class 'CalloutException' must extend another Exception class",
+    ],
+    [
+      "nebula-logger/extra-tests/name-shadowing/System/DmlException.cls",
+      "Error: line 9 at 17-29: Exception class 'DmlException' must extend another Exception class",
+    ],
+    [
+      "nebula-logger/extra-tests/name-shadowing/System/IllegalArgumentException.cls",
+      "Error: line 9 at 17-41: Exception class 'IllegalArgumentException' must extend another Exception class",
     ],
     [
       "nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveBuilder.cls",
@@ -1711,17 +1709,17 @@ exports[`Check samples Sample: apex-rollup 1`] = `
     [
       "rollup/core/classes/RollupAsyncProcessor.cls",
       "Error: line 391 at 23-41: Constructor is not visible: Rollup.<constructor>(Rollup.InvocationPoint)",
-      "Warning: line 621 at 6-56: Local variable is hiding class field 'recordIds', see rollup/core/classes/RollupAsyncProcessor.cls: line 27 at 18-40",
+      "Warning: line 622 at 6-56: Local variable is hiding class field 'recordIds', see rollup/core/classes/RollupAsyncProcessor.cls: line 27 at 18-40",
     ],
     [
       "rollup/core/classes/RollupCalcItemReplacer.cls",
-      "Warning: line 285 at 4-98: Local variable is hiding class field 'parentQueryFields', see rollup/core/classes/RollupCalcItemReplacer.cls: line 13 at 16-92",
+      "Warning: line 294 at 4-98: Local variable is hiding class field 'parentQueryFields', see rollup/core/classes/RollupCalcItemReplacer.cls: line 13 at 16-92",
     ],
     [
       "rollup/core/classes/RollupCalculator.cls",
       "Warning: line 1036 at 27-31: 'sort' is currently a legal method name but is a reserved identifier in Apex so should be avoided",
-      "Warning: line 1152 at 28-32: 'sort' is currently a legal method name but is a reserved identifier in Apex so should be avoided",
-      "Warning: line 1397 at 6-73: Local variable is hiding class field 'fieldNames', see rollup/core/classes/RollupCalculator.cls: line 1336 at 18-63",
+      "Warning: line 1153 at 28-32: 'sort' is currently a legal method name but is a reserved identifier in Apex so should be avoided",
+      "Warning: line 1398 at 6-73: Local variable is hiding class field 'fieldNames', see rollup/core/classes/RollupCalculator.cls: line 1337 at 18-63",
       "Warning: line 486 at 6-95: Local variable is hiding class field 'defaultVal', see rollup/core/classes/RollupCalculator.cls: line 13 at 18-36",
       "Warning: line 868 at 6-96: Local variable is hiding class field 'defaultVal', see rollup/core/classes/RollupCalculator.cls: line 13 at 18-36",
     ],
@@ -2123,13 +2121,6 @@ exports[`Check samples Sample: forcedotcom-enterprise-architecture 1`] = `
 }
 `;
 
-exports[`Check samples Sample: forcelog 1`] = `
-{
-  "logs": [],
-  "status": 0,
-}
-`;
-
 exports[`Check samples Sample: grid 1`] = `
 {
   "logs": [],
@@ -2210,7 +2201,7 @@ exports[`Check samples Sample: rflib 1`] = `
     ],
     [
       "rflib/main/default/classes/rflib_DefaultLogger.cls",
-      "Warning: line 328 at 8-109: Local variable is hiding class field 'logMessages', see rflib/main/default/classes/rflib_DefaultLogger.cls: line 52 at 18-43",
+      "Warning: line 340 at 8-109: Local variable is hiding class field 'logMessages', see rflib/main/default/classes/rflib_DefaultLogger.cls: line 54 at 18-43",
     ],
     [
       "rflib/main/default/classes/rflib_LogArchiveCleanup.cls",
@@ -2247,9 +2238,10 @@ exports[`Check samples Sample: rflib 1`] = `
     ],
     [
       "sfdx-project.json",
-      "Warning: line 21 at 8: Package dependency for 'RFLIB@4.1.0-1' ignored as metadata is not available for analysis.",
-      "Warning: line 35 at 8: Package dependency for 'RFLIB@4.1.0-1' ignored as metadata is not available for analysis.",
-      "Warning: line 38 at 8: Package dependency for 'RFLIB-FS@2.0.0-1' ignored as metadata is not available for analysis.",
+      "Warning: line 23 at 8: Package dependency for 'RFLIB@4.1.0-1' ignored as metadata is not available for analysis.",
+      "Warning: line 38 at 8: Package dependency for 'RFLIB@4.1.0-1' ignored as metadata is not available for analysis.",
+      "Warning: line 41 at 8: Package dependency for 'RFLIB-FS@2.0.0-1' ignored as metadata is not available for analysis.",
+      "Warning: line 56 at 8: Package dependency for 'RFLIB@10.0.0-1' ignored as metadata is not available for analysis.",
     ],
   ],
   "status": 4,

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeDeclarations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeDeclarations.scala
@@ -375,6 +375,14 @@ final case class EnumDeclaration(
         fakeId("hashCode"),
         FormalParameters.empty,
         Some(Block.empty)
+      ).withLocation(location),
+      new ApexMethodDeclaration(
+        thisType,
+        modifiers,
+        RelativeTypeName(typeContext, TypeNames.String),
+        fakeId("toString"),
+        FormalParameters.empty,
+        Some(Block.empty)
       ).withLocation(location)
     )
   }

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/SummaryTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/SummaryTest.scala
@@ -191,6 +191,16 @@ class SummaryTest extends AnyFunSuite with TestHelper {
             MethodSummary(
               idLocation,
               idLocation,
+              "toString",
+              ArraySeq(PUBLIC_MODIFIER),
+              TypeNames.String,
+              ArraySeq(),
+              hasBlock = true,
+              Array()
+            ),
+            MethodSummary(
+              idLocation,
+              idLocation,
               "valueOf",
               ArraySeq(PUBLIC_MODIFIER, STATIC_MODIFIER),
               dummyTypeName,
@@ -604,6 +614,16 @@ class SummaryTest extends AnyFunSuite with TestHelper {
               "ordinal",
               ArraySeq(PUBLIC_MODIFIER),
               TypeNames.Integer,
+              ArraySeq(),
+              hasBlock = true,
+              Array()
+            ),
+            MethodSummary(
+              idLocation,
+              idLocation,
+              "toString",
+              ArraySeq(PUBLIC_MODIFIER),
+              TypeNames.String,
               ArraySeq(),
               hasBlock = true,
               Array()

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.7
+sbt.version=1.11.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.18.2")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
-addSbtPlugin("com.github.sbt"     % "sbt-ci-release"           % "1.9.2")
+addSbtPlugin("com.github.sbt"     % "sbt-ci-release"           % "1.11.1")
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"             % "2.5.0")


### PR DESCRIPTION
- Updates `sbt` and `sbt-ci-release` to support new sonatype
  - It is now a bit simpler to use, the only optional addition being snapshots resolver.
- Updates build to node 22 and samples 1.4.0

Discovered while updating snapshots that another `toString` issue popped up, for custom enums. It was the only method missing from the TypeDeclarations compared to the list in `PlatformTypeDeclaration`. Added it in too.
