### PR TITLE
Fix unused issue suppression for blocks/local variables

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/plugins/UnusedPlugin.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/plugins/UnusedPlugin.scala
@@ -42,7 +42,10 @@ class UnusedPlugin(td: DependentType) extends Plugin(td) {
   override def onInterfaceValidated(td: InterfaceDeclaration): Seq[DependentType] = reportUnused(td)
 
   private def reportUnused(td: FullDeclaration): Seq[DependentType] = {
-    if (td.outerTypeName.isEmpty) {
+    // Ignore if suppressed, or inner type (handled by unusedIssues)
+    if (td.modifiers.exists(suppressModifiers.contains) || td.outerTypeName.isDefined) {
+      Seq.empty
+    } else {
       // Only update if we don't have errors, to reduce noise
       val existingIssues = td.paths.flatMap(td.module.pkg.org.issues.issuesForFileInternal)
       val hasErrors =
@@ -65,8 +68,6 @@ class UnusedPlugin(td: DependentType) extends Plugin(td) {
         .map(_.outermostTypeDeclaration)
         .collect { case dt: DependentType => dt }
         .toSeq
-    } else {
-      Seq.empty
     }
   }
 
@@ -109,13 +110,11 @@ class UnusedPlugin(td: DependentType) extends Plugin(td) {
       if (td.isPageController)
         return ArraySeq.empty
 
-      // Ignore if suppressed
-      if (td.modifiers.exists(suppressModifiers.contains))
-        return ArraySeq.empty
-
       // Get body declaration issues, we exclude initializers as they are really part of the type
       val issues =
-        td.nestedTypes.flatMap(ad => ad.unusedIssues) ++
+        td.nestedTypes.flatMap(ad => {
+          if (ad.modifiers.exists(suppressModifiers.contains)) ArraySeq.empty else ad.unusedIssues
+        }) ++
           td.unusedFields ++
           td.unusedMethods
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/plugins/UnusedPlugin.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/plugins/UnusedPlugin.scala
@@ -76,6 +76,9 @@ class UnusedPlugin(td: DependentType) extends Plugin(td) {
     isStatic: Boolean,
     context: BlockVerifyContext
   ): Unit = {
+    if (context.modifiers(suppressModifiers.contains))
+      return
+
     context.declaredVars
       .filter(localVar =>
         !context.referencedVars.contains(localVar._1) && localVar._2.definition.nonEmpty

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/SuppressWarningsTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/SuppressWarningsTest.scala
@@ -168,6 +168,34 @@ class SuppressWarningsTest extends AnyFunSuite with TestHelper {
     }
   }
 
+  test("Unused local variable suppress") {
+    FileSystemHelper.run(
+      Map(
+        "Dummy.cls" -> "@SuppressWarnings('Unused') public class Dummy { void foo() { String bar = ''; } }",
+        "Foo.cls" -> "public class Foo { { Dummy d = new Dummy(); d.foo(); } }"
+      )
+    ) { root: PathLike =>
+      createOrgWithUnused(root)
+      withOrg(org => {
+        assert(org.issueManager.issuesForFile(root.join("Dummy.cls").toString).isEmpty)
+      })
+    }
+  }
+
+  test("Unused local variable suppress (on method)") {
+    FileSystemHelper.run(
+      Map(
+        "Dummy.cls" -> "public class Dummy { @SuppressWarnings('Unused') void foo() { String bar = ''; } }",
+        "Foo.cls" -> "public class Foo { { Dummy d = new Dummy(); d.foo(); } }"
+      )
+    ) { root: PathLike =>
+      createOrgWithUnused(root)
+      withOrg(org => {
+        assert(org.issueManager.issuesForFile(root.join("Dummy.cls").toString).isEmpty)
+      })
+    }
+  }
+
   test("Unused method suppress PMD") {
     FileSystemHelper.run(
       Map(
@@ -245,6 +273,34 @@ class SuppressWarningsTest extends AnyFunSuite with TestHelper {
         withOrg(org => {
           assert(org.issueManager.issuesForFile(root.join("Dummy.cls").toString).isEmpty)
         })
+    }
+  }
+
+  test("Unused local variable suppress PMD") {
+    FileSystemHelper.run(
+      Map(
+        "Dummy.cls" -> "@SuppressWarnings('PMD') public class Dummy { void foo() { String bar = ''; } }",
+        "Foo.cls" -> "public class Foo { { Dummy d = new Dummy(); d.foo(); } }"
+      )
+    ) { root: PathLike =>
+      createOrgWithUnused(root)
+      withOrg(org => {
+        assert(org.issueManager.issuesForFile(root.join("Dummy.cls").toString).isEmpty)
+      })
+    }
+  }
+
+  test("Unused local variable suppress (on method) PMD") {
+    FileSystemHelper.run(
+      Map(
+        "Dummy.cls" -> "public class Dummy { @SuppressWarnings('PMD') void foo() { String bar = ''; } }",
+        "Foo.cls" -> "public class Foo { { Dummy d = new Dummy(); d.foo(); } }"
+      )
+    ) { root: PathLike =>
+      createOrgWithUnused(root)
+      withOrg(org => {
+        assert(org.issueManager.issuesForFile(root.join("Dummy.cls").toString).isEmpty)
+      })
     }
   }
 

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/SuppressWarningsTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/SuppressWarningsTest.scala
@@ -15,11 +15,17 @@
 package com.nawforce.apexlink.cst
 
 import com.nawforce.apexlink.TestHelper
+import com.nawforce.apexlink.org.OPM
+import com.nawforce.apexlink.plugins.UnusedPlugin
 import com.nawforce.pkgforce.path.PathLike
 import com.nawforce.runtime.FileSystemHelper
 import org.scalatest.funsuite.AnyFunSuite
 
 class SuppressWarningsTest extends AnyFunSuite with TestHelper {
+
+  def createOrgWithUnused(root: PathLike): OPM.OrgImpl = {
+    createOrgWithPlugin(root, classOf[UnusedPlugin])
+  }
 
   test("Suppress disabled") {
     typeDeclaration("public class Dummy {class Inner {Integer b; List<Inner> a; {b = a[null].b;}}}")
@@ -89,7 +95,7 @@ class SuppressWarningsTest extends AnyFunSuite with TestHelper {
         "Foo.cls"   -> "public class Foo { {Type t = Dummy.class;} }"
       )
     ) { root: PathLike =>
-      createOrg(root)
+      createOrgWithUnused(root)
       withOrg(org => {
         assert(org.issueManager.issuesForFile(root.join("Dummy.cls").toString).isEmpty)
       })
@@ -103,7 +109,7 @@ class SuppressWarningsTest extends AnyFunSuite with TestHelper {
         "Foo.cls"   -> "public class Foo { {Type t = Dummy.class;} }"
       )
     ) { root: PathLike =>
-      createOrg(root)
+      createOrgWithUnused(root)
       withOrg(org => {
         assert(org.issueManager.issuesForFile(root.join("Dummy.cls").toString).isEmpty)
       })
@@ -117,7 +123,7 @@ class SuppressWarningsTest extends AnyFunSuite with TestHelper {
         "Foo.cls"   -> "public class Foo { {Type t = Dummy.class;} }"
       )
     ) { root: PathLike =>
-      createOrg(root)
+      createOrgWithUnused(root)
       withOrg(org => {
         assert(org.issueManager.issuesForFile(root.join("Dummy.cls").toString).isEmpty)
       })
@@ -131,7 +137,7 @@ class SuppressWarningsTest extends AnyFunSuite with TestHelper {
         "Foo.cls"   -> "public class Foo { {Type t = Dummy.class;} }"
       )
     ) { root: PathLike =>
-      createOrg(root)
+      createOrgWithUnused(root)
       withOrg(org => {
         assert(org.issueManager.issuesForFile(root.join("Dummy.cls").toString).isEmpty)
       })
@@ -145,7 +151,7 @@ class SuppressWarningsTest extends AnyFunSuite with TestHelper {
         "Foo.cls"   -> "public class Foo { {Type t = Dummy.class;} }"
       )
     ) { root: PathLike =>
-      createOrg(root)
+      createOrgWithUnused(root)
       withOrg(org => {
         assert(org.issueManager.issuesForFile(root.join("Dummy.cls").toString).isEmpty)
       })
@@ -155,7 +161,7 @@ class SuppressWarningsTest extends AnyFunSuite with TestHelper {
   test("Unused outer class suppress") {
     FileSystemHelper.run(Map("Dummy.cls" -> "@SuppressWarnings('Unused') public class Dummy {}")) {
       root: PathLike =>
-        createOrg(root)
+        createOrgWithUnused(root)
         withOrg(org => {
           assert(org.issueManager.issuesForFile(root.join("Dummy.cls").toString).isEmpty)
         })
@@ -169,7 +175,7 @@ class SuppressWarningsTest extends AnyFunSuite with TestHelper {
         "Foo.cls"   -> "public class Foo { {Type t = Dummy.class;} }"
       )
     ) { root: PathLike =>
-      createOrg(root)
+      createOrgWithUnused(root)
       withOrg(org => {
         assert(org.issueManager.issuesForFile(root.join("Dummy.cls").toString).isEmpty)
       })
@@ -183,7 +189,7 @@ class SuppressWarningsTest extends AnyFunSuite with TestHelper {
         "Foo.cls"   -> "public class Foo { {Type t = Dummy.class;} }"
       )
     ) { root: PathLike =>
-      createOrg(root)
+      createOrgWithUnused(root)
       withOrg(org => {
         assert(org.issueManager.issuesForFile(root.join("Dummy.cls").toString).isEmpty)
       })
@@ -197,7 +203,7 @@ class SuppressWarningsTest extends AnyFunSuite with TestHelper {
         "Foo.cls"   -> "public class Foo { {Type t = Dummy.class;} }"
       )
     ) { root: PathLike =>
-      createOrg(root)
+      createOrgWithUnused(root)
       withOrg(org => {
         assert(org.issueManager.issuesForFile(root.join("Dummy.cls").toString).isEmpty)
       })
@@ -211,7 +217,7 @@ class SuppressWarningsTest extends AnyFunSuite with TestHelper {
         "Foo.cls"   -> "public class Foo { {Type t = Dummy.class;} }"
       )
     ) { root: PathLike =>
-      createOrg(root)
+      createOrgWithUnused(root)
       withOrg(org => {
         assert(org.issueManager.issuesForFile(root.join("Dummy.cls").toString).isEmpty)
       })
@@ -225,7 +231,7 @@ class SuppressWarningsTest extends AnyFunSuite with TestHelper {
         "Foo.cls"   -> "public class Foo { {Type t = Dummy.class;} }"
       )
     ) { root: PathLike =>
-      createOrg(root)
+      createOrgWithUnused(root)
       withOrg(org => {
         assert(org.issueManager.issuesForFile(root.join("Dummy.cls").toString).isEmpty)
       })
@@ -235,7 +241,7 @@ class SuppressWarningsTest extends AnyFunSuite with TestHelper {
   test("Unused outer class suppress PMD") {
     FileSystemHelper.run(Map("Dummy.cls" -> "@SuppressWarnings('PMD') public class Dummy {}")) {
       root: PathLike =>
-        createOrg(root)
+        createOrgWithUnused(root)
         withOrg(org => {
           assert(org.issueManager.issuesForFile(root.join("Dummy.cls").toString).isEmpty)
         })


### PR DESCRIPTION
fixes #353 

`SuppressWarnings('Unused')` is now checked in `onBlockValidated` (in addition to `'PMD'` which worked before from `suppressIssues`).

The tests were not using the plugin so never produced issues to suppress, those are fixed now too.