### PR TITLE
Fix SObject map assignment validation (Issue #340)

### DIFF
--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/OperationsTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/OperationsTest.scala
@@ -55,6 +55,14 @@ class OperationsTest extends AnyFunSuite with TestHelper {
     happyTypeDeclaration("public class Dummy {{List<Account> a; a = new List<sObject>(); }}")
   }
 
+  test("SObject Map assignment should fail (Issue #340)") {
+    typeDeclaration("public class Dummy {{Map<Id, SObject> m1; Map<Id, Account> m2 = m1;}}")
+    assert(
+      dummyIssues ==
+        "Error: line 1 at 59-66: Incompatible types in assignment, from 'System.Map<System.Id, System.SObject>' to 'System.Map<System.Id, Schema.Account>'\n"
+    )
+  }
+
   test("Alternative not equal") {
     happyTypeDeclaration("public class Dummy {{Boolean a; a = 1 <> 2; }}")
   }

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/ReturnTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/ReturnTest.scala
@@ -93,7 +93,10 @@ class ReturnTest extends AnyFunSuite with TestHelper {
     typeDeclaration(
       "public class Dummy { Map<Id, Account> fn(){ return new Map<Id, SObject>(); } }"
     )
-    assert(dummyIssues.isEmpty)
+    assert(
+      dummyIssues ==
+        "Error: line 1 at 44-74: Incompatible return type, 'System.Map<System.Id, System.SObject>' is not assignable to 'System.Map<System.Id, Schema.Account>'\n"
+    )
   }
 
   test("Return QueryLocator as Iterable") {


### PR DESCRIPTION
## Summary

Fixes #340 by implementing correct SObject narrowing validation for Map types to match Salesforce behavior.

## Problem

The Apex Language Server was incorrectly allowing SObject narrowing in Map assignments like:
```apex
Map<Id, SObject> m1;
Map<Id, Account> m2 = m1; // Should be illegal but was allowed
```

Salesforce prohibits this assignment as an "Illegal assignment from Map<Id,SObject> to Map<Id,Account>", but the language server was allowing it due to incorrect SObject narrowing rules for Map collections.

## Solution

Updated `AssignableSupport.scala` to implement collection-type-specific SObject narrowing rules:

- **Lists/Sets**: ✅ Allow SObject narrowing (`List<SObject>` → `List<Account>`)
- **Maps**: ❌ Prohibit SObject narrowing (`Map<Id,SObject>` → `Map<Id,Account>` now fails)
- **Other generics**: Use standard parameter-by-parameter checking

### Key Changes

1. **Removed Maps from special SObject narrowing cases** - Only List/Set collections get special SObject narrowing treatment
2. **Added Map-specific parameter validation** - Maps use `narrowSObjects = false` to prevent SObject narrowing in fallback logic
3. **Refactored for readability** - Split complex boolean logic into focused helper methods with clear documentation

### Code Structure Improvements

- `hasAssignableParams()` - Main entry point with clear two-step flow
- `hasSpecialSObjectNarrowing()` - Handles List/Set special cases
- `checkParameterPairAssignability()` - Handles parameter-by-parameter validation with Map restrictions

## Test Plan

### ✅ New Tests Added

- **Assignment context**: `Map<Id, SObject> m1; Map<Id, Account> m2 = m1;` now correctly fails
- **Return context**: `Map<Id, Account> fn(){ return new Map<Id, SObject>(); }` now correctly fails

### ✅ Existing Functionality Preserved

- **List SObject narrowing**: `List<Account> a; a = new List<sObject>();` still works
- **All existing tests pass**: No regressions in the 2000+ test suite

### ✅ Error Messages

```
Error: line 1 at 59-66: Incompatible types in assignment, from 'System.Map<System.Id, System.SObject>' to 'System.Map<System.Id, Schema.Account>'
```

## Validation

- ✅ All tests pass (2000+ tests)
- ✅ Code formatting (`sbt scalafmtAll`)
- ✅ No regressions in SObject narrowing for Lists/Sets
- ✅ Map SObject narrowing correctly prohibited in both assignment and return contexts

This change aligns the Apex Language Server's type validation with Salesforce's actual runtime behavior for Map assignments.

🤖 Generated with [Claude Code](https://claude.ai/code)