### PR TITLE
Support direct SObject refs on definition provider

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/types/apex/ApexDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/apex/ApexDeclaration.scala
@@ -232,7 +232,7 @@ trait ApexFullDeclaration extends ApexDeclaration {
   def findDeclarationFromSourceReference(
     searchTerm: String,
     location: Location
-  ): Option[ApexDeclaration]
+  ): Option[TypeDeclaration with Locatable]
 }
 
 /** Apex defined trigger of either full or summary type */

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/apex/FullDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/apex/FullDeclaration.scala
@@ -27,7 +27,7 @@ import com.nawforce.pkgforce.documents._
 import com.nawforce.pkgforce.modifiers._
 import com.nawforce.pkgforce.names.{Name, Names, TypeIdentifier, TypeName}
 import com.nawforce.pkgforce.parsers.{ApexNode, CLASS_NATURE, INTERFACE_NATURE, Nature}
-import com.nawforce.pkgforce.path.{Location, PathLike}
+import com.nawforce.pkgforce.path.{Locatable, Location, PathLike}
 import com.nawforce.runtime.parsers.{CodeParser, Source, SourceData}
 import io.github.apexdevtools.apexparser.ApexParser.TypeDeclarationContext
 import upickle.default.writeBinary
@@ -273,11 +273,11 @@ abstract class FullDeclaration(
     bodyDeclarations.foreach(_.collectDependencies(dependsOn))
   }
 
-  /** Locate an ApexDeclaration for the passed typeName that was extracted from location. */
+  /** Locate a TypeDeclaration for the passed typeName that was extracted from location. */
   override def findDeclarationFromSourceReference(
     searchTerm: String,
     location: Location
-  ): Option[ApexDeclaration] = {
+  ): Option[TypeDeclaration with Locatable] = {
 
     /** Find the outer or inner class that contains the passed cursor position */
     def findEnclosingClass(line: Int, offset: Int): Option[FullDeclaration] = {
@@ -295,7 +295,7 @@ abstract class FullDeclaration(
     TypeName(searchTerm).toOption match {
       case Some(typeName: TypeName) =>
         findEnclosingClass(location.startLine, location.startPosition).flatMap(td => {
-          TypeResolver(typeName, td).toOption.collect { case td: ApexDeclaration => td }
+          TypeResolver(typeName, td).toOption.collect { case td: Locatable => td }
         })
       case _ => None
     }

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/apex/TriggerDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/apex/TriggerDeclaration.scala
@@ -26,7 +26,7 @@ import com.nawforce.pkgforce.diagnostics.LoggerOps
 import com.nawforce.pkgforce.modifiers.{Modifier, ModifierOps}
 import com.nawforce.pkgforce.names.{Name, Names, TypeName}
 import com.nawforce.pkgforce.parsers.{Nature, TRIGGER_NATURE}
-import com.nawforce.pkgforce.path.{Location, PathLike}
+import com.nawforce.pkgforce.path.{Locatable, Location, PathLike}
 import com.nawforce.runtime.parsers.{CodeParser, Source, SourceData}
 import io.github.apexdevtools.apexparser.ApexParser.{
   TriggerBlockMemberContext,
@@ -171,14 +171,14 @@ final case class TriggerDeclaration(
     )
   }
 
-  /** Locate an ApexDeclaration for the passed typeName that was extracted from location. */
+  /** Locate a TypeDeclaration for the passed typeName that was extracted from location. */
   override def findDeclarationFromSourceReference(
     searchTerm: String,
     location: Location
-  ): Option[ApexDeclaration] = {
+  ): Option[TypeDeclaration with Locatable] = {
     TypeName(searchTerm).toOption match {
       case Some(typeName: TypeName) =>
-        TypeResolver(typeName, this).toOption.collect { case td: ApexClassDeclaration => td }
+        TypeResolver(typeName, this).toOption.collect { case td: Locatable => td }
       case _ => None
     }
   }

--- a/jvm/src/test/scala/com/nawforce/apexlink/TestHelper.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/TestHelper.scala
@@ -352,8 +352,11 @@ object TestHelper {
     if (loc.startLine == loc.endLine) {
       return lines(loc.startLine - 1).substring(loc.startCharOffset(), loc.endCharOffset())
     }
+
+    // may be Location.all/Int.MaxValue
+    val endLine = if (loc.endLine > lines.length) lines.length else loc.endLine
     lines(loc.startLine - 1).substring(loc.startPosition, lines(loc.startLine - 1).length) + lines(
-      loc.endLine - 1
+      endLine - 1
     ).substring(0, loc.endPosition)
   }
 }


### PR DESCRIPTION
Before this PR - it is only possible to get to an sobject file by executing definition provider on a validated ref like `... MyObject__c.SObjectType;`

Now you can use the type name like `MyObject__c record;`/`List<MyObject__c>` as well.

The change I made makes it more generic and shares the existing logic it used when resolved from a validation. So if there were any other holes these might be fixed too.