### PR TITLE
test: add interface method overload validation test for GitHub issue …

### DIFF
--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/ImplementsTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/ImplementsTest.scala
@@ -164,4 +164,22 @@ class ImplementsTest extends AnyFunSuite with TestHelper {
     )
     assert(dummyIssues == "")
   }
+
+  test("Interface method overload validation - GitHub issue #329") {
+    typeDeclarations(
+      Map(
+        "TestInterface.cls" -> "public interface TestInterface { Boolean isEnabled(String param); }",
+        "Implementation.cls" ->
+          """
+          |public class Implementation implements TestInterface {
+          |  public Boolean isEnabled(String param) { return true; }
+          |  private Boolean isEnabled(List<String> params) { return false; }
+          |  private Boolean isEnabled(Integer count) { return false; }
+          |}
+          |""".stripMargin
+      )
+    )
+    assert(dummyIssues.isEmpty)
+  }
+
 }


### PR DESCRIPTION
…#329

Verify that private methods with different signatures than interface methods do not trigger false positive interface implementation errors. This confirms the fix for issue #329 where the language server incorrectly flagged valid method overloading as interface implementation violations.