### PR TITLE
feat: add validation for break/continue statements outside loops

### DIFF
--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/BreakContinueTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/BreakContinueTest.scala
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2024 FinancialForce.com, inc. All rights reserved.
+ */
+
+package com.nawforce.apexlink.cst
+
+import com.nawforce.apexlink.TestHelper
+import org.scalatest.funsuite.AnyFunSuite
+
+class BreakContinueTest extends AnyFunSuite with TestHelper {
+
+  test("break statement outside loop") {
+    typeDeclaration("public class Dummy { void fn() { break; } }")
+    assert(dummyIssues == "Error: line 1 at 33-39: Break statement must be in loop\n")
+  }
+
+  test("continue statement outside loop") {
+    typeDeclaration("public class Dummy { void fn() { continue; } }")
+    assert(dummyIssues == "Error: line 1 at 33-42: Continue statement must be in loop\n")
+  }
+
+  test("break statement in if block outside loop") {
+    typeDeclaration("public class Dummy { void fn() { if (true) { break; } } }")
+    assert(dummyIssues == "Error: line 1 at 45-51: Break statement must be in loop\n")
+  }
+
+  test("continue statement in if block outside loop") {
+    typeDeclaration("public class Dummy { void fn() { if (true) { continue; } } }")
+    assert(dummyIssues == "Error: line 1 at 45-54: Continue statement must be in loop\n")
+  }
+
+  test("break statement in switch outside loop") {
+    typeDeclaration("""
+      |public class Dummy { 
+      |  void fn() { 
+      |    Integer i = 1;
+      |    switch on i {
+      |      when 0 { break; }
+      |      when else {}
+      |    }
+      |  } 
+      |}""".stripMargin)
+    assert(dummyIssues == "Error: line 6 at 15-21: Break statement must be in loop\n")
+  }
+
+  test("continue statement in switch outside loop") {
+    typeDeclaration("""
+      |public class Dummy { 
+      |  void fn() { 
+      |    Integer i = 1;
+      |    switch on i {
+      |      when 0 { continue; }
+      |      when else {}
+      |    }
+      |  } 
+      |}""".stripMargin)
+    assert(dummyIssues == "Error: line 6 at 15-24: Continue statement must be in loop\n")
+  }
+
+  test("break statement in try-catch outside loop") {
+    typeDeclaration("""
+      |public class Dummy { 
+      |  void fn() { 
+      |    try {
+      |      break;
+      |    } catch (Exception e) {}
+      |  } 
+      |}""".stripMargin)
+    assert(dummyIssues == "Error: line 5 at 6-12: Break statement must be in loop\n")
+  }
+
+  test("continue statement in try-catch outside loop") {
+    typeDeclaration("""
+      |public class Dummy { 
+      |  void fn() { 
+      |    try {
+      |      continue;
+      |    } catch (Exception e) {}
+      |  } 
+      |}""".stripMargin)
+    assert(dummyIssues == "Error: line 5 at 6-15: Continue statement must be in loop\n")
+  }
+
+  test("break statement in while loop should be valid") {
+    happyTypeDeclaration("public class Dummy { void fn() { while (true) { break; } } }")
+  }
+
+  test("continue statement in while loop should be valid") {
+    happyTypeDeclaration("public class Dummy { void fn() { while (true) { continue; } } }")
+  }
+
+  test("break statement in while loop without block should be valid") {
+    happyTypeDeclaration("public class Dummy { void fn() { while (true) break; } }")
+  }
+
+  test("continue statement in while loop without block should be valid") {
+    happyTypeDeclaration("public class Dummy { void fn() { while (true) continue; } }")
+  }
+
+  test("break statement in for loop should be valid") {
+    happyTypeDeclaration(
+      "public class Dummy { void fn() { for (Integer i = 0; i < 10; i++) { break; } } }"
+    )
+  }
+
+  test("continue statement in for loop should be valid") {
+    happyTypeDeclaration(
+      "public class Dummy { void fn() { for (Integer i = 0; i < 10; i++) { continue; } } }"
+    )
+  }
+
+  test("break statement in for-each loop should be valid") {
+    happyTypeDeclaration(
+      "public class Dummy { void fn() { for (Integer i : new List<Integer>()) { break; } } }"
+    )
+  }
+
+  test("continue statement in for-each loop should be valid") {
+    happyTypeDeclaration(
+      "public class Dummy { void fn() { for (Integer i : new List<Integer>()) { continue; } } }"
+    )
+  }
+
+  test("break statement in do-while loop should be valid") {
+    happyTypeDeclaration("public class Dummy { void fn() { do { break; } while (true); } }")
+  }
+
+  test("continue statement in do-while loop should be valid") {
+    happyTypeDeclaration("public class Dummy { void fn() { do { continue; } while (true); } }")
+  }
+
+  test("break statement in nested loops should be valid") {
+    happyTypeDeclaration("""
+      |public class Dummy { 
+      |  void fn() { 
+      |    while (true) {
+      |      for (Integer i = 0; i < 10; i++) {
+      |        break;
+      |      }
+      |    }
+      |  } 
+      |}""".stripMargin)
+  }
+
+  test("continue statement in nested loops should be valid") {
+    happyTypeDeclaration("""
+      |public class Dummy { 
+      |  void fn() { 
+      |    while (true) {
+      |      for (Integer i = 0; i < 10; i++) {
+      |        continue;
+      |      }
+      |    }
+      |  } 
+      |}""".stripMargin)
+  }
+
+  test("break statement in if block inside loop should be valid") {
+    happyTypeDeclaration("""
+      |public class Dummy { 
+      |  void fn() { 
+      |    while (true) {
+      |      if (true) {
+      |        break;
+      |      }
+      |    }
+      |  } 
+      |}""".stripMargin)
+  }
+
+  test("continue statement in if block inside loop should be valid") {
+    happyTypeDeclaration("""
+      |public class Dummy { 
+      |  void fn() { 
+      |    while (true) {
+      |      if (true) {
+      |        continue;
+      |      }
+      |    }
+      |  } 
+      |}""".stripMargin)
+  }
+
+  test("multiple break and continue violations") {
+    typeDeclaration("""
+      |public class Dummy { 
+      |  void fn() { 
+      |    break;
+      |    continue;
+      |  } 
+      |}""".stripMargin)
+    assert(
+      dummyIssues ==
+        "Error: line 4 at 4-10: Break statement must be in loop\nError: line 5 at 4-13: Unreachable block or statement\nError: line 5 at 4-13: Continue statement must be in loop\n"
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Add validation to ensure `break` and `continue` statements are only used within loop contexts
- Support all loop types: `while`, `do-while`, `for`, and `for-each` loops
- Generate proper error messages matching Salesforce behavior
- Handle edge cases like single-statement while loops

## Implementation Details
- Add `inLoop` flag and `withInLoop` method to `BlockVerifyContext`
- Update loop statements (`ForStatement`, `WhileStatement`, `DoWhileStatement`) to mark their contexts as in-loop
- Add validation logic in `BreakStatement` and `ContinueStatement` classes
- Use mutation-based approach for `while`/`do-while` to handle single statements safely

## Test Coverage
- 23 comprehensive tests covering all scenarios
- Invalid usage: break/continue outside loops (methods, if blocks, switch, try-catch)
- Valid usage: all loop types including nested loops and complex control structures
- Edge cases: while loops with single statements (no blocks)

## Error Messages
- `"Break statement must be in loop"`
- `"Continue statement must be in loop"`

Resolves #378