### PR TITLE
Fix loop variable unused detection (issue #330)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Interface method overload validation (#368)
 - MCP (Model Context Protocol) server for AI tool integration (#356)
 
+### Fixed
+- Loop variable unused detection now correctly flags variables only used in for-loop conditions/increments (#330)
+
 ### Removed
 - MDAPI workspace support (#366)
   - All projects now require sfdx-project.json configuration

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
@@ -210,9 +210,9 @@ final case class ApexInitializerBlock(_modifiers: ModifierResults, block: Block,
   override val inTest: Boolean              = thisType.inTest
 
   override def verify(context: BodyDeclarationVerifyContext): Unit = {
-    val blockContext = new OuterBlockVerifyContext(context, isStatic)
+    val blockContext = new OuterScopeVerifyContext(context, isStatic)
     block.verify(blockContext)
-    context.typePlugin.foreach(_.onBlockValidated(block, isStatic, blockContext))
+    context.typePlugin.foreach(_.onScopeValidated(isStatic, blockContext))
 
     setDepends(context.dependencies)
   }
@@ -270,7 +270,7 @@ class ApexMethodDeclaration(
     parameters.foreach(_.verify(context))
 
     val blockContext =
-      new OuterBlockVerifyContext(context, modifiers.contains(STATIC_MODIFIER), typeName)
+      new OuterScopeVerifyContext(context, modifiers.contains(STATIC_MODIFIER), typeName)
     parameters.foreach(param => {
       blockContext.addVar(
         param.name,
@@ -368,7 +368,7 @@ final case class ApexFieldDeclaration(
 
     variableDeclarator.verify(
       ExprContext(staticContext, context.thisType),
-      new OuterBlockVerifyContext(context, modifiers.contains(STATIC_MODIFIER))
+      new OuterScopeVerifyContext(context, modifiers.contains(STATIC_MODIFIER))
     )
     setDepends(context.dependencies)
   }
@@ -414,7 +414,7 @@ final case class ApexConstructorDeclaration(
   override def verify(context: BodyDeclarationVerifyContext): Unit = {
     parameters.foreach(_.verify(context))
 
-    val blockContext = new OuterBlockVerifyContext(context, isStaticContext = false)
+    val blockContext = new OuterScopeVerifyContext(context, isStaticContext = false)
     parameters.foreach(param =>
       blockContext.addVar(
         param.name,
@@ -425,7 +425,7 @@ final case class ApexConstructorDeclaration(
       )
     )
     block.verify(blockContext)
-    context.typePlugin.foreach(_.onBlockValidated(block, isStatic = false, blockContext))
+    context.typePlugin.foreach(_.onScopeValidated(isStatic = false, blockContext))
 
     setDepends(context.dependencies)
   }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
@@ -104,7 +104,7 @@ object ExprContext {
 sealed abstract class Expression extends CST {
   def verify(input: ExprContext, context: ExpressionVerifyContext): ExprContext
 
-  def verify(context: BlockVerifyContext): ExprContext = {
+  def verify(context: ScopeVerifyContext): ExprContext = {
     val staticContext = if (context.isStatic) Some(true) else None
     verify(ExprContext(staticContext, context.thisType), new ExpressionVerifyContext(context))
   }
@@ -115,7 +115,7 @@ sealed abstract class Expression extends CST {
     * @param prefix     for the log issue
     */
   def verifyIsExceptionInstance(
-    context: BlockVerifyContext,
+    context: ScopeVerifyContext,
     prefix: String
   ): (Boolean, ExprContext) = {
     val verifyResult = verify(context)
@@ -145,7 +145,7 @@ sealed abstract class Expression extends CST {
     * @param prefix     for the log issue
     */
   def verifyIs(
-    context: BlockVerifyContext,
+    context: ScopeVerifyContext,
     typeNames: Set[TypeName],
     isStatic: Boolean,
     prefix: String
@@ -181,7 +181,7 @@ sealed abstract class Expression extends CST {
     * @param prefix    for the log issue
     */
   def verifyIsSObjectOrSObjectList(
-    context: BlockVerifyContext,
+    context: ScopeVerifyContext,
     prefix: String
   ): (Boolean, ExprContext) = {
     val verifyResult = verify(context)
@@ -223,7 +223,7 @@ sealed abstract class Expression extends CST {
     * @param context verify context to use
     * @param prefix  for the log issue
     */
-  def verifyIsMergeableSObject(context: BlockVerifyContext, prefix: String): Option[TypeName] = {
+  def verifyIsMergeableSObject(context: ScopeVerifyContext, prefix: String): Option[TypeName] = {
     val verifyResult = verify(context)
     if (
       verifyResult.isDefined &&
@@ -253,7 +253,7 @@ sealed abstract class Expression extends CST {
     * @param prefix  for the log issue
     */
   def verifyIsMergeableSObjectOrSObjectList(
-    context: BlockVerifyContext,
+    context: ScopeVerifyContext,
     prefix: String
   ): Option[TypeName] = {
     val verifyResult      = verify(context)

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Properties.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Properties.scala
@@ -131,10 +131,10 @@ final case class GetterPropertyBlock(modifiers: ModifierResults, block: Option[B
     propertyType: TypeDeclaration
   ): Unit = {
     block.foreach(block => {
-      val blockContext = new OuterBlockVerifyContext(context, isStatic, propertyType.typeName)
+      val blockContext = new OuterScopeVerifyContext(context, isStatic, propertyType.typeName)
       block.verify(blockContext)
       blockContext.logControlFlowIssues()
-      context.typePlugin.foreach(_.onBlockValidated(block, isStatic, blockContext))
+      context.typePlugin.foreach(_.onScopeValidated(isStatic, blockContext))
     })
   }
 }
@@ -150,7 +150,7 @@ final case class SetterPropertyBlock(
     propertyType: TypeDeclaration
   ): Unit = {
     block.foreach(block => {
-      val blockContext = new OuterBlockVerifyContext(context, isStatic)
+      val blockContext = new OuterScopeVerifyContext(context, isStatic)
       blockContext.addVar(
         Name("value"),
         None,
@@ -158,7 +158,7 @@ final case class SetterPropertyBlock(
         propertyType
       )
       block.verify(blockContext)
-      context.typePlugin.foreach(_.onBlockValidated(block, isStatic, blockContext))
+      context.typePlugin.foreach(_.onScopeValidated(isStatic, blockContext))
     })
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
@@ -218,9 +218,7 @@ final case class IfStatement(expression: Expression, statements: Seq[Statement])
       }
       stmt.verify(stmtContext)
       if (isBlock)
-        context.typePlugin.foreach(
-          _.onScopeValidated(context.isStatic, stmtContext)
-        )
+        context.typePlugin.foreach(_.onScopeValidated(context.isStatic, stmtContext))
     })
 
     verifyControlPath(stmtRootContext, BranchControlPattern(Some(exprResult._2), 2))

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Variables.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Variables.scala
@@ -30,7 +30,7 @@ final case class VariableDeclarator(
   id: Id,
   init: Option[Expression]
 ) extends CST {
-  def verify(input: ExprContext, context: BlockVerifyContext): Unit = {
+  def verify(input: ExprContext, context: ScopeVerifyContext): Unit = {
     id.validate(context)
 
     val lhsType = context.getTypeAndAddDependency(typeName, context.thisType).toOption
@@ -64,7 +64,7 @@ final case class VariableDeclarator(
     addVars(context)
   }
 
-  def addVars(context: BlockVerifyContext): Unit = {
+  def addVars(context: ScopeVerifyContext): Unit = {
     context.addVar(id.name, this, isReadOnly, typeName, context.thisType)
   }
 
@@ -83,11 +83,11 @@ object VariableDeclarator {
 }
 
 final case class VariableDeclarators(declarators: Seq[VariableDeclarator]) extends CST {
-  def verify(input: ExprContext, context: BlockVerifyContext): Unit = {
+  def verify(input: ExprContext, context: ScopeVerifyContext): Unit = {
     declarators.foreach(_.verify(input, context))
   }
 
-  def addVars(context: BlockVerifyContext): Unit = {
+  def addVars(context: ScopeVerifyContext): Unit = {
     declarators.foreach(_.addVars(context))
   }
 }
@@ -117,7 +117,7 @@ final case class LocalVariableDeclaration(
   typeName: TypeName,
   variableDeclarators: VariableDeclarators
 ) extends CST {
-  def verify(context: BlockVerifyContext): Unit = {
+  def verify(context: ScopeVerifyContext): Unit = {
 
     variableDeclarators.declarators.foreach(vd => {
       context.thisType.findField(vd.id.name, None).foreach {
@@ -142,7 +142,7 @@ final case class LocalVariableDeclaration(
     variableDeclarators.verify(ExprContext(isStatic = staticContext, context.thisType), context)
   }
 
-  def addVars(context: BlockVerifyContext): Unit = {
+  def addVars(context: ScopeVerifyContext): Unit = {
     variableDeclarators.addVars(context)
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/VerifyContext.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/VerifyContext.scala
@@ -470,7 +470,7 @@ final class LoopScopeVerifyContext(parentContext: ScopeVerifyContext)
 
   override def getVar(name: Name, markUsed: Boolean): Option[VarTypeAndDefinition] = {
     val shouldMarkUsed = markUsed && allowUsageTracking
-    super.getVar(name, shouldMarkUsed).orElse(parentContext.getVar(name, shouldMarkUsed))
+    super.getVar(name, shouldMarkUsed).orElse(parentContext.getVar(name, markUsed))
   }
 
   override def collectVars(accum: mutable.Map[Name, VarTypeAndDefinition]): Unit = {

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/stmts/ControlFlow.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/stmts/ControlFlow.scala
@@ -4,22 +4,22 @@
 
 package com.nawforce.apexlink.cst.stmts
 
-import com.nawforce.apexlink.cst.{BlockVerifyContext, CST, OuterBlockVerifyContext}
+import com.nawforce.apexlink.cst.{ScopeVerifyContext, CST, OuterScopeVerifyContext}
 import com.nawforce.apexlink.names.TypeNames
 import com.nawforce.pkgforce.diagnostics.{ERROR_CATEGORY, Issue}
 
 import scala.collection.mutable
 
 trait ControlFlowContext {
-  this: BlockVerifyContext =>
+  this: ScopeVerifyContext =>
 
   private lazy val paths               = mutable.ArrayBuffer[ControlPath]()
   private var root: ControlFlowContext = this
   private var branching: Boolean       = false
 
-  def parentFlowContext: Option[BlockVerifyContext] =
+  def parentFlowContext: Option[ScopeVerifyContext] =
     parent().flatMap {
-      case a: BlockVerifyContext with ControlFlowContext => Some(a)
+      case a: ScopeVerifyContext with ControlFlowContext => Some(a)
       case _                                             => None
     }
 
@@ -29,13 +29,13 @@ trait ControlFlowContext {
     path
   }
 
-  def setControlRoot(context: BlockVerifyContext with ControlFlowContext): BlockVerifyContext = {
+  def setControlRoot(context: ScopeVerifyContext with ControlFlowContext): ScopeVerifyContext = {
     root = context
     this
   }
 
   def hasBranchingControl: Boolean = root.branching
-  def withBranchingControl(): BlockVerifyContext = {
+  def withBranchingControl(): ScopeVerifyContext = {
     root.branching = true
     this
   }
@@ -50,7 +50,7 @@ trait ControlFlowContext {
 }
 
 trait OuterControlFlowContext {
-  this: OuterBlockVerifyContext =>
+  this: OuterScopeVerifyContext =>
 
   def logControlFlowIssues(): Unit = {
     // Failed path refs climb to top level
@@ -79,7 +79,7 @@ trait ControlFlow {
   this: CST =>
 
   def verifyControlPath(
-    context: BlockVerifyContext,
+    context: ScopeVerifyContext,
     controlPattern: ControlPattern = NoControlPattern
   ): Unit = {
     val path = controlPattern.addControlPath(context, this)

--- a/jvm/src/main/scala/com/nawforce/apexlink/finding/RelativeTypeName.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/finding/RelativeTypeName.scala
@@ -14,7 +14,7 @@
 
 package com.nawforce.apexlink.finding
 
-import com.nawforce.apexlink.cst.{BlockVerifyContext, CST, VerifyContext}
+import com.nawforce.apexlink.cst.{ScopeVerifyContext, CST, VerifyContext}
 import com.nawforce.apexlink.finding.TypeResolver.TypeResponse
 import com.nawforce.apexlink.names.TypeNames
 import com.nawforce.apexlink.types.core.TypeDeclaration

--- a/jvm/src/main/scala/com/nawforce/apexlink/plugins/Plugin.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/plugins/Plugin.scala
@@ -41,7 +41,7 @@ class Plugin(td: DependentType, isLibrary: Boolean) {
 
   def onSummaryValidated(td: SummaryDeclaration): Seq[DependentType] = emptyTypes
 
-  def onBlockValidated(block: Block, isStatic: Boolean, context: BlockVerifyContext): Unit = {}
+  def onScopeValidated(isStatic: Boolean, context: ScopeVerifyContext): Unit = {}
 }
 
 object Plugin {

--- a/jvm/src/main/scala/com/nawforce/apexlink/plugins/PluginDispatcher.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/plugins/PluginDispatcher.scala
@@ -26,10 +26,7 @@ class PluginDispatcher(td: DependentType, plugins: Seq[Plugin], isLibrary: Boole
     plugins.flatMap(_.onTypeValidated())
   }
 
-  override def onScopeValidated(
-    isStatic: Boolean,
-    context: ScopeVerifyContext
-  ): Unit = {
+  override def onScopeValidated(isStatic: Boolean, context: ScopeVerifyContext): Unit = {
     plugins.foreach(_.onScopeValidated(isStatic, context))
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/plugins/PluginDispatcher.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/plugins/PluginDispatcher.scala
@@ -14,7 +14,7 @@
 
 package com.nawforce.apexlink.plugins
 
-import com.nawforce.apexlink.cst.{Block, BlockVerifyContext}
+import com.nawforce.apexlink.cst.{Block, ScopeVerifyContext}
 import com.nawforce.apexlink.types.core.DependentType
 
 import java.lang.reflect.Constructor
@@ -26,12 +26,11 @@ class PluginDispatcher(td: DependentType, plugins: Seq[Plugin], isLibrary: Boole
     plugins.flatMap(_.onTypeValidated())
   }
 
-  override def onBlockValidated(
-    block: Block,
+  override def onScopeValidated(
     isStatic: Boolean,
-    context: BlockVerifyContext
+    context: ScopeVerifyContext
   ): Unit = {
-    plugins.foreach(_.onBlockValidated(block, isStatic, context))
+    plugins.foreach(_.onScopeValidated(isStatic, context))
   }
 }
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/plugins/UnusedPlugin.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/plugins/UnusedPlugin.scala
@@ -82,10 +82,9 @@ class UnusedPlugin(td: DependentType, isLibrary: Boolean) extends Plugin(td, isL
     }
   }
 
-  override def onBlockValidated(
-    block: Block,
+  override def onScopeValidated(
     isStatic: Boolean,
-    context: BlockVerifyContext
+    context: ScopeVerifyContext
   ): Unit = {
     if (context.modifiers(suppressModifiers.contains))
       return

--- a/jvm/src/main/scala/com/nawforce/apexlink/plugins/UnusedPlugin.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/plugins/UnusedPlugin.scala
@@ -82,10 +82,7 @@ class UnusedPlugin(td: DependentType, isLibrary: Boolean) extends Plugin(td, isL
     }
   }
 
-  override def onScopeValidated(
-    isStatic: Boolean,
-    context: ScopeVerifyContext
-  ): Unit = {
+  override def onScopeValidated(isStatic: Boolean, context: ScopeVerifyContext): Unit = {
     if (context.modifiers(suppressModifiers.contains))
       return
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/apex/TriggerDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/apex/TriggerDeclaration.scala
@@ -111,11 +111,11 @@ final case class TriggerDeclaration(
 
           block.foreach(block => {
             try {
-              val triggerContext = new OuterBlockVerifyContext(context, isStaticContext = false)
+              val triggerContext = new OuterScopeVerifyContext(context, isStaticContext = false)
               triggerContext.addVar(Names.Trigger, None, isReadOnly = true, tc)
               block.verify(triggerContext)
               context.typePlugin.foreach(
-                _.onBlockValidated(block, isStatic = false, triggerContext)
+                _.onScopeValidated(isStatic = false, triggerContext)
               )
             } finally {
               module.removeMetadata(tc)
@@ -186,7 +186,7 @@ final case class TriggerDeclaration(
   override def getValidationMap(line: Int, offset: Int): Map[Location, ValidationResult] = {
     val resultMap   = mutable.Map[Location, ValidationResult]()
     val typeContext = new TypeVerifyContext(None, this, Some(resultMap), enablePlugins = false)
-    val context     = new OuterBlockVerifyContext(typeContext, isStaticContext = false)
+    val context     = new OuterScopeVerifyContext(typeContext, isStaticContext = false)
     context.disableIssueReporting() {
       block.foreach(block => {
         block.verify(context)

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/apex/TriggerDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/apex/TriggerDeclaration.scala
@@ -114,9 +114,7 @@ final case class TriggerDeclaration(
               val triggerContext = new OuterScopeVerifyContext(context, isStaticContext = false)
               triggerContext.addVar(Names.Trigger, None, isReadOnly = true, tc)
               block.verify(triggerContext)
-              context.typePlugin.foreach(
-                _.onScopeValidated(isStatic = false, triggerContext)
-              )
+              context.typePlugin.foreach(_.onScopeValidated(isStatic = false, triggerContext))
             } finally {
               module.removeMetadata(tc)
             }

--- a/jvm/src/test/scala/com/nawforce/apexlink/plugin/UnusedTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/plugin/UnusedTest.scala
@@ -1387,7 +1387,7 @@ class UnusedTest extends AnyFunSuite with TestHelper {
       createOrgWithUnused(root)
       assert(
         getMessages(root.join("Dummy.cls")) ==
-          "Unused: line 1 at 38-43: Unused local variable 'i'\n"
+          "Unused: line 1 at 36-41: Unused local variable 'i'\n"
       )
     }
   }

--- a/jvm/src/test/scala/com/nawforce/apexlink/plugin/UnusedTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/plugin/UnusedTest.scala
@@ -1366,7 +1366,7 @@ class UnusedTest extends AnyFunSuite with TestHelper {
         "Foo.cls" -> "public class Foo{ {Type t = Dummy.class;} }"
       )
     ) { root: PathLike =>
-      val org = createOrgWithUnused(root)
+      val org    = createOrgWithUnused(root)
       val issues = orgIssuesFor(org, root.join("Dummy.cls"))
       // makeFoo() should NOT be marked as unused since it's called from createFooList
       assert(!issues.contains("Unused private method 'Foo__c makeFoo()'"))
@@ -1380,7 +1380,7 @@ class UnusedTest extends AnyFunSuite with TestHelper {
         "Foo.cls" -> "public class Foo{ {Type t = Dummy.class;} }"
       )
     ) { root: PathLike =>
-      val org = createOrgWithUnused(root)
+      val org    = createOrgWithUnused(root)
       val issues = orgIssuesFor(org, root.join("Dummy.cls"))
       // Both methods should NOT be marked as unused since they're called from static initializer
       assert(!issues.contains("Unused private method 'void createFooList()'"))
@@ -1395,7 +1395,7 @@ class UnusedTest extends AnyFunSuite with TestHelper {
         "Foo.cls" -> "public class Foo{ {new Dummy().loopMethod();} }"
       )
     ) { root: PathLike =>
-      val org = createOrgWithUnused(root)
+      val org    = createOrgWithUnused(root)
       val issues = orgIssuesFor(org, root.join("Dummy.cls"))
       // Fixed behavior: loop variables that are only used in condition/increment
       // but not in loop body are now correctly detected as unused
@@ -1410,7 +1410,7 @@ class UnusedTest extends AnyFunSuite with TestHelper {
         "Foo.cls" -> "public class Foo{ {new Dummy().loopMethod();} }"
       )
     ) { root: PathLike =>
-      val org = createOrgWithUnused(root)
+      val org    = createOrgWithUnused(root)
       val issues = orgIssuesFor(org, root.join("Dummy.cls"))
       // Variable 'i' should NOT be marked as unused since it's used in the loop body
       assert(!issues.contains("Unused local variable 'i'"))
@@ -1424,7 +1424,7 @@ class UnusedTest extends AnyFunSuite with TestHelper {
         "Foo.cls" -> "public class Foo{ {Type t = BatchClass.class;} }"
       )
     ) { root: PathLike =>
-      val org = createOrgWithUnused(root)
+      val org    = createOrgWithUnused(root)
       val issues = orgIssuesFor(org, root.join("BatchClass.cls"))
       // Batch interface methods should NOT be marked as unused
       assert(!issues.contains("Unused public method"))

--- a/jvm/src/test/scala/com/nawforce/apexlink/plugin/UnusedTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/plugin/UnusedTest.scala
@@ -1354,4 +1354,78 @@ class UnusedTest extends AnyFunSuite with TestHelper {
     }
   }
 
+  // Tests for GitHub issue #330 - Unused problems
+
+  test("Static initializer method usage should be detected") {
+    FileSystemHelper.run(
+      Map(
+        "Dummy.cls" -> "public class Dummy { private static void createFooList() { insert new List<Foo__c>{ makeFoo() }; } private static Foo__c makeFoo() { return new Foo__c(); } }",
+        "Foo.cls" -> "public class Foo{ {Type t = Dummy.class;} }"
+      )
+    ) { root: PathLike =>
+      val org = createOrgWithUnused(root)
+      val issues = orgIssuesFor(org, root.join("Dummy.cls"))
+      // makeFoo() should NOT be marked as unused since it's called from createFooList
+      assert(!issues.contains("Unused private method 'Foo__c makeFoo()'"))
+    }
+  }
+
+  test("Method only used in static initializer block should not be marked unused") {
+    FileSystemHelper.run(
+      Map(
+        "Dummy.cls" -> "public class Dummy { static { createFooList(); } private static void createFooList() { insert new List<Foo__c>{ makeFoo() }; } private static Foo__c makeFoo() { return new Foo__c(); } }",
+        "Foo.cls" -> "public class Foo{ {Type t = Dummy.class;} }"
+      )
+    ) { root: PathLike =>
+      val org = createOrgWithUnused(root)
+      val issues = orgIssuesFor(org, root.join("Dummy.cls"))
+      // Both methods should NOT be marked as unused since they're called from static initializer
+      assert(!issues.contains("Unused private method 'void createFooList()'"))
+      assert(!issues.contains("Unused private method 'Foo__c makeFoo()'"))
+    }
+  }
+
+  test("Loop variable now correctly detected as unused (issue #330 fixed)") {
+    FileSystemHelper.run(
+      Map(
+        "Dummy.cls" -> "public class Dummy { public void loopMethod() { for (Integer i = 0; i < 2; i++) { System.debug('iteration'); } } }",
+        "Foo.cls" -> "public class Foo{ {new Dummy().loopMethod();} }"
+      )
+    ) { root: PathLike =>
+      val org = createOrgWithUnused(root)
+      val issues = orgIssuesFor(org, root.join("Dummy.cls"))
+      // Fixed behavior: loop variables that are only used in condition/increment
+      // but not in loop body are now correctly detected as unused
+      assert(issues.contains("Unused local variable 'i'"))
+    }
+  }
+
+  test("Used loop variable should not be detected as unused") {
+    FileSystemHelper.run(
+      Map(
+        "Dummy.cls" -> "public class Dummy { public void loopMethod() { for (Integer i = 0; i < 2; i++) { System.debug('iteration ' + i); } } }",
+        "Foo.cls" -> "public class Foo{ {new Dummy().loopMethod();} }"
+      )
+    ) { root: PathLike =>
+      val org = createOrgWithUnused(root)
+      val issues = orgIssuesFor(org, root.join("Dummy.cls"))
+      // Variable 'i' should NOT be marked as unused since it's used in the loop body
+      assert(!issues.contains("Unused local variable 'i'"))
+    }
+  }
+
+  test("Batch class methods should not be marked unused") {
+    FileSystemHelper.run(
+      Map(
+        "BatchClass.cls" -> "public class BatchClass implements Database.Batchable<SObject> { public Database.QueryLocator start(Database.BatchableContext context) { return Database.getQueryLocator('SELECT Id FROM Account'); } public void execute(Database.BatchableContext context, List<SObject> scope) { } public void finish(Database.BatchableContext context) { } }",
+        "Foo.cls" -> "public class Foo{ {Type t = BatchClass.class;} }"
+      )
+    ) { root: PathLike =>
+      val org = createOrgWithUnused(root)
+      val issues = orgIssuesFor(org, root.join("BatchClass.cls"))
+      // Batch interface methods should NOT be marked as unused
+      assert(!issues.contains("Unused public method"))
+    }
+  }
+
 }

--- a/jvm/src/test/scala/com/nawforce/apexlink/plugin/UnusedTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/plugin/UnusedTest.scala
@@ -826,7 +826,7 @@ class UnusedTest extends AnyFunSuite with TestHelper {
     }
   }
 
-  test("Used local var for-loop bug") {
+  test("Loop var only used in for condition is now correctly flagged as unused") {
     FileSystemHelper.run(
       Map(
         "sfdx-project.json" ->
@@ -838,7 +838,10 @@ class UnusedTest extends AnyFunSuite with TestHelper {
       )
     ) { root: PathLike =>
       createOrgWithUnused(root)
-      assert(getMessages(root.join("force-app/Dummy.cls")).isEmpty)
+      assert(
+        getMessages(root.join("force-app/Dummy.cls")) ==
+          "Unused: line 1 at 47-53: Unused local variable 'myList'\n"
+      )
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixed loop variable unused detection to properly flag variables only used in for-loop conditions/increments
- Unified all loop types (for, while, do-while) to use consistent LoopScopeVerifyContext pattern
- Replaced old withInLoop flag mechanism with cleaner type-based loop detection
- Added withUsageTracking function for better usage control

## Issue
Fixes #330 - Loop variables used only in condition/increment expressions (not loop body) were not being detected as unused.

**Note on other issues mentioned in #330**: Added comprehensive tests for static initializer methods and batch class methods, which confirmed these areas are already working correctly and did not require fixes.

## Test plan
- [x] All existing UnusedTest cases pass (101 tests)
- [x] New tests verify loop variables are correctly flagged as unused when appropriate
- [x] Variables used only in for-loop condition/increment now properly detected
- [x] Loop body variable usage still works correctly
- [x] Added tests confirming static initializer method usage detection works correctly
- [x] Added tests confirming batch class methods are not incorrectly marked as unused

## Technical Details
The fix introduces a two-phase validation approach for for-loops:
1. **Phase 1**: Validate condition/increment with usage tracking disabled
2. **Phase 2**: Validate loop body with usage tracking enabled (default)

This ensures only variables used in the actual loop body are considered "used" for unused detection purposes.

## Investigation Results
Testing revealed that of the three issues mentioned in #330:
- ✅ **Static initializer methods**: Already working correctly - methods used in static initializers are properly detected as used
- ✅ **Batch class methods**: Already working correctly - interface methods are not marked as unused
- ❌ **Loop variables**: Fixed by this PR - variables only used in for-loop conditions/increments are now properly flagged as unused