### PR TITLE
Add agent guides for apex-ls and MCP subproject

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Apex Language Server Agent Guide
+
+## Scope
+This guide applies to all changes in the repository unless a more specific `AGENTS.md` exists deeper in the tree.
+
+## Project Overview
+- Scala cross-build project targeting JVM and Scala.js platforms.
+- Requires Java 17+ for development while published artifacts remain Java 8 compatible.
+- Contains an `mcp/` sub-project that builds a Java 17 MCP server (see `mcp/AGENTS.md`).
+
+## Development Expectations
+- Prefer small, composable functions and follow the existing domain terminology.
+- Avoid unnecessary refactors or comment noise; rely on self-explanatory code.
+- Keep new dependencies minimal and justified.
+
+## Formatting & Linting
+- Run `sbt scalafmtAll` after modifying Scala sources.
+- Format Markdown or JSON when editing them (use existing style as reference).
+
+## Testing
+- Run `sbt test` for Scala/JVM/JS changes when feasible.
+- Document any skipped or partial test coverage in the PR if full test suite is impractical.
+
+## Git & PR Etiquette
+- Use Conventional Commit messages (e.g., `feat:`, `fix:`, `chore:`).
+- Summaries should focus on user-facing impact and avoid mentioning AI assistants.
+- Ensure PR descriptions include the commands/tests that were run.
+
+## Additional References
+- `.claude/CLAUDE.md` for architecture and command quick reference.
+- `.claude/GUIDELINES.md` for detailed coding guidelines and best practices.
+- `.claude/MODULES.md` for the planned modularization structure (informational).

--- a/mcp/AGENTS.md
+++ b/mcp/AGENTS.md
@@ -1,0 +1,28 @@
+# MCP Subproject Agent Guide
+
+## Scope
+This guide applies to all files inside the `mcp/` directory and overrides instructions from parent `AGENTS.md` when conflicts arise.
+
+## Project Notes
+- Java 17+ is required for development and runtime.
+- Depends on the parent Apex Language Server build artifacts; ensure the root project is built (`sbt build`) before running MCP builds.
+
+## Formatting & Style
+- Run `sbt javafmt` after modifying Java sources.
+- Keep MCP tool and bridge code consistent with existing naming patterns (`ApexLsBridge`, `SfdxCodeDiagnosticsTool`, etc.).
+
+## Testing & Build Commands
+- Run `sbt test` for changes impacting MCP logic when feasible.
+- Use targeted suites for focused updates:
+  - `sbt "testOnly io.github.apexdevtools.apexls.mcp.bridge.*"`
+  - `sbt "testOnly io.github.apexdevtools.apexls.mcp.tools.*"`
+  - `sbt "testOnly io.github.apexdevtools.apexls.mcp.system.*"`
+- Build artifacts with `sbt buildStandalone` when verifying distribution packaging.
+
+## Operational Guidance
+- MCP bridge operations must remain asynchronous and handle workspace caching carefully.
+- Tools should validate inputs, surface clear MCP errors, and return JSON-compatible payloads.
+- Preserve STDOUT/STDERR separation so MCP protocol traffic is not polluted by logs.
+
+## References
+- `mcp/.claude/CLAUDE.md` for detailed architecture, workflow, and troubleshooting notes.


### PR DESCRIPTION
## Summary
- add top-level AGENTS.md outlining formatting, testing, and workflow expectations
- add MCP-specific AGENTS.md with Java formatting, testing, and operational guidance

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e105af4754832385a3c4149ae09fd8