### PR TITLE
fix: install npm modules before Scala.js tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,9 +25,10 @@ ThisBuild / resolvers += Resolver.sonatypeCentralSnapshots
 // Java 17 development with Java 8 runtime compatibility
 ThisBuild / javacOptions ++= Seq("-source", "8", "-target", "8")
 
-lazy val build = taskKey[File]("Build artifacts")
-lazy val pack  = inputKey[Unit]("Publish specific local version")
-lazy val Dev   = config("dev") extend Compile
+lazy val build      = taskKey[File]("Build artifacts")
+lazy val pack       = inputKey[Unit]("Publish specific local version")
+lazy val npmInstall = taskKey[Unit]("Install Node modules for Scala.js tasks")
+lazy val Dev        = config("dev") extend Compile
 
 // Don't publish root
 publish / skip := true
@@ -74,6 +75,10 @@ lazy val apexls = crossProject(JSPlatform, JVMPlatform)
     build                    := buildJs(Compile / fullLinkJS).value,
     Dev / build              := buildJs(Compile / fastLinkJS).value,
     Test / parallelExecution := false,
+    npmInstall               := syncNodeModules.value,
+    Test / test              := (Test / test).dependsOn(npmInstall).value,
+    Test / testOnly          := (Test / testOnly).dependsOn(npmInstall).evaluated,
+    Test / testQuick         := (Test / testQuick).dependsOn(npmInstall).evaluated,
     libraryDependencies ++= Seq("net.exoego" %%% "scala-js-nodejs-v14" % "0.12.0"),
     scalaJSUseMainModuleInitializer := false,
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
@@ -126,6 +131,36 @@ def buildJs(jsTask: TaskKey[Attributed[Report]]): Def.Initialize[Task[File]] = D
   )
 
   targetFile
+}
+
+def syncNodeModules: Def.Initialize[Task[Unit]] = Def.task {
+  val log        = streams.value.log
+  val npmDir     = baseDirectory.value / "npm"
+  val targetDir  = crossTarget.value
+  val lockFile   = npmDir / "package-lock.json"
+  val nodeDir    = npmDir / "node_modules"
+  val exec       = run(log)(_, _)
+  val needInstall =
+    !nodeDir.exists() || (lockFile.exists() && lockFile.lastModified() > nodeDir.lastModified())
+
+  if (needInstall) {
+    exec("npm ci", npmDir)
+  }
+
+  val packageJson = npmDir / "package.json"
+  if (packageJson.exists()) {
+    IO.copyFile(packageJson, targetDir / "package.json")
+  }
+  if (lockFile.exists()) {
+    IO.copyFile(lockFile, targetDir / "package-lock.json")
+  }
+
+  IO.delete(targetDir / "node_modules")
+  if (nodeDir.exists()) {
+    IO.copyDirectory(nodeDir, targetDir / "node_modules", CopyOptions().withOverwrite(true))
+  } else {
+    log.warn("npm node_modules directory not found after installation")
+  }
 }
 
 // Command to do a local release under a specific version


### PR DESCRIPTION
## Summary
- ensure the Scala.js project installs npm dependencies via a new `npmInstall` task that runs before js test commands
- add a reusable `syncNodeModules` helper to mirror the build step when syncing node modules into the target directory

## Testing
- sbt apexlsJS/test

------
https://chatgpt.com/codex/tasks/task_e_68e10da9023c8323a6937545f73189bb