### PR TITLE
chore: prepare release 6.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.2] - 2025-11-25
+
 ### Fixed
 
 - Loop variables used only in iteration control (condition/increment) are no longer incorrectly flagged as unused (#397)

--- a/mcp-npm/package.json
+++ b/mcp-npm/package.json
@@ -11,7 +11,7 @@
     "README.md"
   ],
   "config": {
-    "jarVersion": "6.0.1",
+    "jarVersion": "6.0.2",
     "downloadUrl": "https://github.com/apex-dev-tools/apex-ls/releases/download/v{jarVersion}/apex-ls-mcp-v{jarVersion}-standalone.jar"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Prepares the repository for the 6.0.2 release.

### Changes
- Updated CHANGELOG.md with 6.0.2 release date (2025-11-25)
- Updated mcp-npm/package.json jarVersion to 6.0.2

### Release Notes (6.0.2)

#### Fixed
- Loop variables used only in iteration control (condition/increment) are no longer incorrectly flagged as unused (#397)
- Variables used in ghosted type list initializers are no longer incorrectly flagged as unused (#398)

## Next Steps
After merging this PR:
1. Create a GitHub Release with tag `v6.0.2` targeting `main`
2. The Publish workflow will automatically build and publish to Maven Central and NPM