### PR TITLE
fix(ci): skip clean in ci-release to preserve apex-ls JAR for MCP build

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -68,6 +68,7 @@ jobs:
         if: ${{ github.event_name == 'release' && github.event.action == 'released' || inputs.pub_sbt }}
         run: sbt ci-release
         env:
+          CI_CLEAN: "" # Skip clean - MCP build needs apex-ls JAR in target/
           PGP_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
           PGP_SECRET: ${{ secrets.OSSRH_GPG_SECRET_KEY_BASE64 }}
           SONATYPE_PASSWORD: ${{ secrets.OSSRH_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes the publish workflow failure where the MCP build cannot find the apex-ls JAR.

## Problem

The `sbt-ci-release` plugin runs `clean` by default before publishing:
```scala
sys.env.getOrElse("CI_CLEAN", "; clean")
```

This causes the following sequence:
1. `sbt build` → apex-ls JAR exists in `jvm/target/`
2. `sbt ci-release` (main) → runs `clean`, **deletes** `jvm/target/`, then publishes
3. `sbt ci-release` (mcp) → **fails** because apex-ls JAR is gone

## Solution

Set `CI_CLEAN: ""` environment variable on the main publish step to skip the clean, preserving the apex-ls JAR for the MCP build.

## Testing

After merging:
1. Delete the failed v6.0.2 release and tag
2. Recreate the v6.0.2 release
3. Verify the Publish workflow completes successfully