### PR TITLE
Validate string escapes, static inner methods, and comment/annotation interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Invalid string escape sequences in string literals are now properly validated and flagged
+- Static methods on inner classes are now properly validated and flagged
+
 ## [6.0.2] - 2025-11-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Invalid string escape sequences in string literals are now properly validated and flagged
 - Static methods on inner classes are now properly validated and flagged
+- Comment placement validation between annotations/modifiers and their targets improved
 
 ## [6.0.2] - 2025-11-25
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/MethodMap.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/MethodMap.scala
@@ -325,6 +325,12 @@ object MethodMap {
       .foreach(m => {
         setMethodError(m, s"protected method '${m.name}' cannot be static", errors)
       })
+    // Add errors for any static methods on inner classes
+    if (td.outerTypeName.isDefined && td.nature == CLASS_NATURE) {
+      staticLocals.foreach(m => {
+        setMethodError(m, s"Static methods are not allowed in inner classes", errors)
+      })
+    }
     staticLocals
       .filterNot(ignorableStatics.contains)
       .foreach(method => applyStaticMethod(workingMap, method))

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/ClassModifierTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/ClassModifierTest.scala
@@ -140,6 +140,94 @@ class ClassModifierTest extends AnyFunSuite with TestHelper {
     assert(dummyIssues.isEmpty)
   }
 
+  test("Annotation after single block comment on same line should error") {
+    typeDeclaration("/* comment */ @IsTest public class Dummy {}")
+    assert(dummyIssues.nonEmpty)
+  }
+
+  test("Annotation after multiple block comments on same line should error") {
+    typeDeclaration("/* comment1 */ /* comment2 */ @Deprecated public class Dummy {}")
+    assert(dummyIssues.nonEmpty)
+  }
+
+  test("Multiple annotations after block comment on same line should error") {
+    typeDeclaration("/* comment */ @IsTest @SuppressWarnings('PMD') public class Dummy {}")
+    assert(dummyIssues.nonEmpty)
+  }
+
+  test("Block comment between annotation and class should error") {
+    typeDeclaration("@IsTest /* comment */ public class Dummy {}")
+    assert(dummyIssues.nonEmpty)
+  }
+
+  test("Single line comment between annotation and class should error") {
+    typeDeclaration("@IsTest // comment\n public class Dummy {}")
+    assert(dummyIssues.nonEmpty)
+  }
+
+  test("Annotation after comment on inner class should error") {
+    typeDeclarationInner("public class Dummy {/* comment */ @Deprecated class Inner{}}")
+    assert(dummyIssues.nonEmpty)
+  }
+
+  test("Block comment between annotation and inner class should error") {
+    typeDeclarationInner("public class Dummy {@Deprecated /* comment */ class Inner{}}")
+    assert(dummyIssues.nonEmpty)
+  }
+
+  test("Single line comment between annotation and inner class should error") {
+    typeDeclarationInner("public class Dummy {@Deprecated // comment\n class Inner{}}")
+    assert(dummyIssues.nonEmpty)
+  }
+
+  test("Annotation after comment on method should error") {
+    try {
+      typeDeclaration("public class Dummy {/* comment */ @IsTest static void testMethod() {}}")
+      assert(dummyIssues.nonEmpty || hasIssues)
+    } catch {
+      case _: NoSuchElementException => assert(hasIssues)
+    }
+  }
+
+  test("Block comment between annotation and method should error") {
+    try {
+      typeDeclaration("public class Dummy {@IsTest /* comment */ static void testMethod() {}}")
+      assert(dummyIssues.nonEmpty || hasIssues)
+    } catch {
+      case _: NoSuchElementException => assert(hasIssues)
+    }
+  }
+
+  test("Single line comment between annotation and method should error") {
+    try {
+      typeDeclaration("public class Dummy {@IsTest // comment\n static void testMethod() {}}")
+      assert(dummyIssues.nonEmpty || hasIssues)
+    } catch {
+      case _: NoSuchElementException => assert(hasIssues)
+    }
+  }
+
+  test("Annotation after comment on inner class method should error") {
+    typeDeclaration(
+      "public class Dummy {class Inner {/* comment */ @Deprecated void method() {}}}"
+    )
+    assert(dummyIssues.nonEmpty)
+  }
+
+  test("Block comment between annotation and inner class method should error") {
+    typeDeclaration(
+      "public class Dummy {class Inner {@Deprecated /* comment */ void method() {}}}"
+    )
+    assert(dummyIssues.nonEmpty)
+  }
+
+  test("Single line comment between annotation and inner class method should error") {
+    typeDeclaration(
+      "public class Dummy {class Inner {@Deprecated // comment\n void method() {}}}"
+    )
+    assert(dummyIssues.nonEmpty)
+  }
+
   test("Global inner") {
     assert(
       typeDeclarationInner("global class Dummy {global class Inner{}}").modifiers == ArraySeq(

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/ClassModifierTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/ClassModifierTest.scala
@@ -208,23 +208,17 @@ class ClassModifierTest extends AnyFunSuite with TestHelper {
   }
 
   test("Annotation after comment on inner class method should error") {
-    typeDeclaration(
-      "public class Dummy {class Inner {/* comment */ @Deprecated void method() {}}}"
-    )
+    typeDeclaration("public class Dummy {class Inner {/* comment */ @Deprecated void method() {}}}")
     assert(dummyIssues.nonEmpty)
   }
 
   test("Block comment between annotation and inner class method should error") {
-    typeDeclaration(
-      "public class Dummy {class Inner {@Deprecated /* comment */ void method() {}}}"
-    )
+    typeDeclaration("public class Dummy {class Inner {@Deprecated /* comment */ void method() {}}}")
     assert(dummyIssues.nonEmpty)
   }
 
   test("Single line comment between annotation and inner class method should error") {
-    typeDeclaration(
-      "public class Dummy {class Inner {@Deprecated // comment\n void method() {}}}"
-    )
+    typeDeclaration("public class Dummy {class Inner {@Deprecated // comment\n void method() {}}}")
     assert(dummyIssues.nonEmpty)
   }
 

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
@@ -468,4 +468,9 @@ class MethodTest extends AnyFunSuite with TestHelper {
       createHappyOrg(root)
     }
   }
+
+  test("Static method on inner class") {
+    typeDeclaration("public class Dummy { class Inner { static void m() {} } }")
+    assert(dummyIssues.toLowerCase.contains("static") && dummyIssues.toLowerCase.contains("inner"))
+  }
 }

--- a/jvm/src/test/scala/com/nawforce/apexlink/pkg/HoverProviderTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/pkg/HoverProviderTest.scala
@@ -33,8 +33,8 @@ class HoverProviderTest extends AnyFunSuite with TestHelper {
   test("Hover for inner class") {
     val contentAndCursorPos =
       withCursor(
-        s"public virtual class Foo {public void after(){Du${CURSOR}mmy.dummyMethod();}  " +
-          s"private class Dummy {public static void dummyMethod(){} } }"
+        s"public virtual class Foo {public void after(){new Du${CURSOR}mmy();}  " +
+          s"private class Dummy {public Dummy(){} } }"
       )
     FileSystemHelper.run(Map("Foo.cls" -> contentAndCursorPos._1)) { root: PathLike =>
       val org = createHappyOrg(root)

--- a/shared/src/main/scala/com/nawforce/pkgforce/modifiers/FieldModifiers.scala
+++ b/shared/src/main/scala/com/nawforce/pkgforce/modifiers/FieldModifiers.scala
@@ -51,7 +51,8 @@ object FieldModifiers {
     idContext: IdContext
   ): ModifierResults = {
     val logger = new ModifierLogger()
-    val mods   = toModifiers(parser, modifierContexts)
+    ApexModifiers.validateCommentPlacement(parser, modifierContexts, idContext, logger)
+    val mods = toModifiers(parser, modifierContexts)
     fieldModifiers(logger, mods, outer, LogEntryContext(parser, idContext))
   }
 

--- a/shared/src/main/scala/com/nawforce/pkgforce/modifiers/MethodModifiers.scala
+++ b/shared/src/main/scala/com/nawforce/pkgforce/modifiers/MethodModifiers.scala
@@ -69,14 +69,15 @@ object MethodModifiers {
   def classMethodModifiers(
     parser: CodeParser,
     modifierContexts: ArraySeq[ModifierContext],
-    context: ParserRuleContext,
+    idContext: io.github.apexdevtools.apexparser.ApexParser.IdContext,
     ownerInfo: ClassOwnerInfo,
     isOuter: Boolean
   ): ModifierResults = {
 
     val logger = new ModifierLogger()
-    val mods   = toModifiers(parser, modifierContexts)
-    classMethodModifiers(logger, mods, LogEntryContext(parser, context), ownerInfo, isOuter)
+    ApexModifiers.validateCommentPlacement(parser, modifierContexts, idContext, logger)
+    val mods = toModifiers(parser, modifierContexts)
+    classMethodModifiers(logger, mods, LogEntryContext(parser, idContext), ownerInfo, isOuter)
   }
 
   def classMethodModifiers(
@@ -190,11 +191,12 @@ object MethodModifiers {
   def interfaceMethodModifiers(
     parser: CodeParser,
     modifierContexts: ArraySeq[ModifierContext],
-    context: ParserRuleContext
+    idContext: io.github.apexdevtools.apexparser.ApexParser.IdContext
   ): ModifierResults = {
     val logger = new ModifierLogger()
-    val mods   = toModifiers(parser, modifierContexts)
-    interfaceMethodModifiers(logger, mods, LogEntryContext(parser, context))
+    ApexModifiers.validateCommentPlacement(parser, modifierContexts, idContext, logger)
+    val mods = toModifiers(parser, modifierContexts)
+    interfaceMethodModifiers(logger, mods, LogEntryContext(parser, idContext))
   }
 
   def interfaceMethodModifiers(


### PR DESCRIPTION
Added validation for invalid escape sequences in string literals, or static methods declared within inner classes, and annotation/comment positioning that fails to compile.
Updated tests to cover these cases and improved error reporting for both issues.
There were no language errors when these mistakes were being inserted by Agentforce vibes.