### PR TITLE
fix: flag static methods on inner classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Static methods on inner classes are now properly validated and flagged (@metalshark)
+
 ## [6.0.2] - 2025-11-25
 
 ### Fixed

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/MethodMap.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/MethodMap.scala
@@ -325,6 +325,12 @@ object MethodMap {
       .foreach(m => {
         setMethodError(m, s"protected method '${m.name}' cannot be static", errors)
       })
+    // Add errors for any static methods on inner classes
+    if (td.outerTypeName.isDefined && td.nature == CLASS_NATURE) {
+      staticLocals.foreach(m => {
+        setMethodError(m, s"Static methods are not allowed in inner classes", errors)
+      })
+    }
     staticLocals
       .filterNot(ignorableStatics.contains)
       .foreach(method => applyStaticMethod(workingMap, method))

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/HoverProvider.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/HoverProvider.scala
@@ -10,6 +10,7 @@ import com.nawforce.apexlink.types.apex.{
   ApexFullDeclaration,
   ApexMethodLike
 }
+import com.nawforce.apexlink.types.synthetic.CustomConstructorDeclaration
 import com.nawforce.pkgforce.path.{Locatable, Location, PathLike}
 
 trait HoverProvider extends SourceOps {
@@ -31,13 +32,19 @@ trait HoverProvider extends SourceOps {
     val validation = locateFromValidation(td, line, offset)
 
     validation._2.flatMap(loc => {
-      validation._1(loc).result.locatable match {
+      val result = validation._1(loc).result
+      result.locatable match {
         case Some(l: ApexMethodLike) =>
           Some(l, loc)
         case Some(l: ApexConstructorLike) =>
           Some(l, loc)
         case Some(l: ApexClassDeclaration) =>
           Some(l, loc)
+        case Some(_: CustomConstructorDeclaration) =>
+          result.declaration match {
+            case Some(c: ApexClassDeclaration) => Some(c, loc)
+            case _                             => None
+          }
         case _ =>
           None
       }

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
@@ -468,4 +468,9 @@ class MethodTest extends AnyFunSuite with TestHelper {
       createHappyOrg(root)
     }
   }
+
+  test("Static method on inner class") {
+    typeDeclaration("public class Dummy { class Inner { static void m() {} } }")
+    assert(dummyIssues.toLowerCase.contains("static") && dummyIssues.toLowerCase.contains("inner"))
+  }
 }

--- a/jvm/src/test/scala/com/nawforce/apexlink/pkg/HoverProviderTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/pkg/HoverProviderTest.scala
@@ -33,8 +33,8 @@ class HoverProviderTest extends AnyFunSuite with TestHelper {
   test("Hover for inner class") {
     val contentAndCursorPos =
       withCursor(
-        s"public virtual class Foo {public void after(){Du${CURSOR}mmy.dummyMethod();}  " +
-          s"private class Dummy {public static void dummyMethod(){} } }"
+        s"public virtual class Foo {public void after(){new Du${CURSOR}mmy();}  " +
+          s"private class Dummy {} }"
       )
     FileSystemHelper.run(Map("Foo.cls" -> contentAndCursorPos._1)) { root: PathLike =>
       val org = createHappyOrg(root)
@@ -44,7 +44,7 @@ class HoverProviderTest extends AnyFunSuite with TestHelper {
       assert(hoverItem.location.get.startLine == 1)
       assert(hoverItem.location.get.startPosition == 46)
       assert(hoverItem.location.get.endLine == 1)
-      assert(hoverItem.location.get.endPosition == 51)
+      assert(hoverItem.location.get.endPosition == 57)
     }
   }
 


### PR DESCRIPTION
## Summary

Static methods are not allowed in inner classes in Apex. This change adds validation to detect and report this error.

Based on work by @metalshark in PR #409 - split out for independent review/merge.

## Test plan

- [x] Added test case for static method on inner class
- [ ] Run `sbt test` to verify