### PR TITLE
refactor: inline Tri* traits into Org/Package/Module and remove aliases

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/deps/DownWalker.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/deps/DownWalker.scala
@@ -16,7 +16,6 @@ package com.nawforce.apexlink.deps
 
 import com.nawforce.apexlink.api.Org
 import com.nawforce.apexlink.org.OPM
-import com.nawforce.apexlink.org.OPM.TPackage
 import com.nawforce.apexlink.types.apex.{ApexClassDeclaration, ApexDeclaration}
 import com.nawforce.apexlink.types.core.{DependencyHolder, TypeDeclaration}
 import com.nawforce.pkgforce.names.TypeIdentifier
@@ -40,7 +39,7 @@ case class NodeData(
 /** Downstream dependency walker. Collects information on the dependencies of a type. */
 class DownWalker(org: Org, apexOnly: Boolean, isSamePackage: Boolean = true) {
   private val hasGulpedPackages =
-    org.getPackages().collect({ case p: TPackage => p }).map(_.isGulped).exists(b => b)
+    org.getPackages().collect({ case p: OPM.PackageImpl => p }).map(_.isGulped).exists(b => b)
   private val transitiveCollector      = new TransitiveCollector(org, !hasGulpedPackages, apexOnly)
   private val maxDependencyCountParser = new MaxDependencyCountParser(org)
 


### PR DESCRIPTION
### Motivation
- Follow-up cleanup after the TriHierarchy/IPM removal to eliminate an indirection layer that is no longer providing polymorphic value. 
- Simplify the `OPM` object by consolidating package/module/org behaviour into the concrete classes and remove stale type aliases and scaladoc wording.

### Description
- Removed `TriOrg`, `TriPackage`, and `TriModule` traits and the `TOrg`/`TPackage`/`TModule` type aliases, and inlined their members directly into `OrgImpl`, `PackageImpl`, and `Module` in `OPM.scala`.
- Adjusted constructors and member definitions (replaced `override val` with plain `val` where appropriate and moved helper methods such as `orderedModules`, `isGhosted`, `firstModule`, `isGhostedType`, `isGhostedFieldName`, `namespace`, `namespacePrefix`, `basePackages`, `baseModules`, and `nextModule`).
- Updated `DownWalker.scala` to stop importing the removed alias and match directly on `OPM.PackageImpl` when checking for gulped packages.
- Cleaned up the `OPM` scaladoc to remove outdated generics/migration wording and ran `scalafmt` to reformat the changed sources.

### Testing
- Ran formatter: `sbt scalafmtAll` and it completed successfully.
- Ran the full test suite: `sbt test` and all tests passed (no failures).
- Verified compilation and a local `git` commit containing the refactor was created (conventional commit message used).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c7880cbf083238a8da955f8c628eb)