### PR TITLE
feat: support qualified enum constants in switch when clauses

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/stmts/Switch.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/stmts/Switch.scala
@@ -35,7 +35,7 @@ sealed abstract class WhenLiteral extends CST {
 final class WhenNullLiteral extends WhenLiteral {
   override def isComparableTo(typeName: TypeName): Boolean = true
 }
-final case class WhenIdLiteral(id: Id) extends WhenLiteral {
+final case class WhenIdLiteral(qualifier: Seq[Id], id: Id) extends WhenLiteral {
   override def isComparableTo(typeName: TypeName): Boolean = false // Not used
   override def toString: String                            = id.name.value.toLowerCase
 }
@@ -84,8 +84,10 @@ object WhenLiteral {
       .orElse(
         CodeParser
           .toScala(literal.qualifiedName())
-          .flatMap(qn => CodeParser.toScala(qn.id()).lastOption)
-          .map(l => WhenIdLiteral(Id.construct(l)))
+          .flatMap(qn => {
+            val ids = CodeParser.toScala(qn.id()).map(Id.construct)
+            ids.lastOption.map(last => WhenIdLiteral(ids.dropRight(1), last))
+          })
       )
       .map(_.withContext(literal))
   }
@@ -145,19 +147,34 @@ final case class WhenLiteralsValue(literals: Seq[WhenLiteral]) extends WhenValue
 
     nonNull.foreach {
       case iv: WhenIdLiteral =>
+        if (iv.qualifier.nonEmpty) {
+          val qualifierTypeName = TypeName(iv.qualifier.map(_.name).reverse)
+          context.getTypeFor(qualifierTypeName, context.thisType) match {
+            case Right(qualifierType) =>
+              if (qualifierType.typeName != typeDeclaration.typeName) {
+                context.logError(
+                  iv.qualifier.head.location,
+                  s"Qualifier '$qualifierTypeName' does not match switch expression type '${typeDeclaration.typeName}'"
+                )
+                return Seq()
+              }
+              context.addDependency(qualifierType)
+            case Left(_) =>
+              context.logError(
+                iv.qualifier.head.location,
+                s"No type declaration found for '$qualifierTypeName'"
+              )
+              return Seq()
+          }
+        }
         val field = typeDeclaration.findField(iv.id.name, Some(true))
-        field.foreach(field => {
-          Referenceable.addReferencingLocation(
-            typeDeclaration,
-            field,
-            iv.location,
-            context.thisType
-          )
-          context.addDependency(field)
-        })
-        if (field.isEmpty) {
-          context.logError(iv.id.location, "Value must be a enum constant")
-          return Seq()
+        field match {
+          case Some(f) =>
+            Referenceable.addReferencingLocation(typeDeclaration, f, iv.location, context.thisType)
+            context.addDependency(f)
+          case None =>
+            context.logError(iv.id.location, "Value must be a enum constant")
+            return Seq()
         }
       case _ =>
     }

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/SwitchTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/SwitchTest.scala
@@ -138,6 +138,52 @@ class SwitchTest extends AnyFunSuite with TestHelper {
     )
   }
 
+  test("Enum qualified control (same enum)") {
+    typeDeclaration("public class Dummy {enum E {A,B} {E e;switch on e {when E.A {}}}}")
+    assert(!hasIssues)
+  }
+
+  test("Enum qualified control (outer qualified)") {
+    typeDeclaration("public class Dummy {enum E {A,B} {E e;switch on e {when Dummy.E.A {}}}}")
+    assert(!hasIssues)
+  }
+
+  test("Enum qualified control (bad value)") {
+    typeDeclaration("public class Dummy {enum E {A,B} {E e;switch on e {when E.BAD {}}}}")
+    assert(
+      dummyIssues ==
+        "Error: line 1 at 58-61: Value must be a enum constant\n"
+    )
+  }
+
+  test("Enum qualified control (wrong enum)") {
+    typeDeclaration(
+      "public class Dummy {enum E {A,B} enum F {A,B} {E e;switch on e {when F.A {}}}}"
+    )
+    assert(
+      dummyIssues ==
+        "Error: line 1 at 69-70: Qualifier 'F' does not match switch expression type 'Dummy.E'\n"
+    )
+  }
+
+  test("Enum qualified control (unknown qualifier)") {
+    typeDeclaration("public class Dummy {enum E {A,B} {E e;switch on e {when Missing.A {}}}}")
+    assert(
+      dummyIssues ==
+        "Error: line 1 at 56-63: No type declaration found for 'Missing'\n"
+    )
+  }
+
+  test("Enum qualified multi control") {
+    typeDeclaration("public class Dummy {enum E {A,B} {E e;switch on e {when E.A, E.B {}}}}")
+    assert(!hasIssues)
+  }
+
+  test("Enum qualified mixed unqualified") {
+    typeDeclaration("public class Dummy {enum E {A,B} {E e;switch on e {when A, E.B {}}}}")
+    assert(!hasIssues)
+  }
+
   test("String single control") {
     typeDeclaration("public class Dummy {{switch on 'A' {when 'A' {} }}}")
     assert(!hasIssues)


### PR DESCRIPTION
Fixes #441 (semantic portion — version bump already landed via #446).

## Background

apex-parser 5.1.0 introduced [apex-parser#88](https://github.com/apex-dev-tools/apex-parser/pull/88) which changed `whenLiteral` to match `qualifiedName` in place of `id`, so:

\`\`\`apex
switch on e {
  when MyEnum.VALUE { ... }
  when MyClass.MyEnum.VALUE { ... }
}
\`\`\`

now parses. The version bump landed via #446. This PR completes the semantic side.

## Problem

Previously [Switch.scala](jvm/src/main/scala/com/nawforce/apexlink/cst/stmts/Switch.scala) called \`lastOption\` on the parsed id list and dropped everything else. Consequences:

- \`when WrongEnum.VALUE\` was accepted as long as the switch enum also had a \`VALUE\`.
- An unknown qualifier produced no diagnostic.
- No dependency was tracked on the enum type — only on the constant field.

## Approach

\`WhenIdLiteral\` now carries \`qualifier: Seq[Id]\` alongside the trailing \`id: Id\`. In \`WhenLiteralsValue.checkEnumValue\`, when \`qualifier.nonEmpty\`:

1. Build a \`TypeName\` from the qualifier (inner-first order).
2. Resolve it via \`context.getTypeFor\` and verify it matches the switch expression's enum type.
3. Track a dependency on the qualifier type when the match succeeds.

The qualifier check runs **before** the constant lookup. Without that ordering, a wrong qualifier whose enum happens to share a constant name with the switch enum would emit a spurious \`addReferencingLocation\` and \`addDependency\`, and a wrong qualifier with an unknown constant would surface the confusing \"Value must be a enum constant\" error instead of the actual type mismatch.

The common unqualified case (\`when VALUE\`) skips the qualifier block entirely, so it pays no extra cost vs the previous code.

## New tests

Added 7 cases to \`SwitchTest\`:

- \`Enum qualified control (same enum)\` — \`when E.A\`
- \`Enum qualified control (outer qualified)\` — \`when Dummy.E.A\`
- \`Enum qualified control (bad value)\` — \`when E.BAD\`
- \`Enum qualified control (wrong enum)\` — \`when F.A\` while switching on \`E\`
- \`Enum qualified control (unknown qualifier)\` — \`when Missing.A\`
- \`Enum qualified multi control\` — \`when E.A, E.B\`
- \`Enum qualified mixed unqualified\` — \`when A, E.B\`

## Validation

- \`sbt scalafmtCheckAll\` — clean
- \`sbt apexlsJVM/test\` — 2384/2384 pass