### PR TITLE
feat: accept Summer '26 multi-line string literals (#447)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Acceptance of Summer '26 multi-line string literals (`'''...'''`) in expressions and `switch` when clauses (#447)
+- Qualified enum constants are now permitted in `switch` when clauses (e.g. `when MyEnum.A`) (#441)
+- Distinct exit codes from `CheckForIssues` to separate warnings-only and unused-only outcomes (#440)
+- Improved lexer error messages for invalid escape sequences, including the offending sequence
+
 ### Fixed
 
 - Static methods on inner classes are now properly validated and flagged (@metalshark)
 - Public/global methods implementing interfaces from external namespaces are no longer incorrectly flagged as unused (#401)
+- Methods invoked only from triggers are no longer flagged as unused
+- Test class discovery now follows interface use relationships, so test classes referenced via interfaces are correctly included
+- Outline parser column offsets aligned with outline-parser 2.0 0-based half-open columns, removing off-by-one diagnostics
+- Outline parser validation failures now retry via an ANTLR fallback to preserve diagnostics
+
+### Changed
+
+- Removed the ANTLR-first parsing mode; OutlineParser is now the sole parser path. The `--antlr` / ANTLR parser option is deprecated and a no-op (#433)
+- Upgraded to apex-parser 5.1.0 and the antlr4 4.13 runtime
+- Slimmed the JS module surface to the published apex-ls facades
+
+### Removed
+
+- v1 ForceIgnore implementation (V2 has been the default since 6.0.0)
 
 ## [6.0.2] - 2025-11-25
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Literals.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Literals.scala
@@ -165,6 +165,11 @@ object Literal {
           .toScala(from.StringLiteral())
           .map(x => StringLiteral(CodeParser.getText(x)))
       )
+      .orElse(
+        CodeParser
+          .toScala(from.MultilineStringLiteral())
+          .map(x => StringLiteral(CodeParser.getText(x)))
+      )
       .orElse(CodeParser.toScala(from.BooleanLiteral()).map(_ => BooleanLiteral))
       .getOrElse(NullLiteral)
   }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/stmts/Switch.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/stmts/Switch.scala
@@ -83,6 +83,11 @@ object WhenLiteral {
       )
       .orElse(
         CodeParser
+          .toScala(literal.MultilineStringLiteral())
+          .map(l => WhenStringLiteral(CodeParser.getText(l)))
+      )
+      .orElse(
+        CodeParser
           .toScala(literal.qualifiedName())
           .flatMap(qn => {
             val ids = CodeParser.toScala(qn.id()).map(Id.construct)

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/LiteralTypeTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/LiteralTypeTest.scala
@@ -70,6 +70,20 @@ class LiteralTypeTest extends AnyFunSuite with Matchers with TestHelper {
     literal("0.123456789012345678901234567890123456789012345678d", TypeNames.Double)
   }
 
+  test("Multi-line string literal") {
+    literal("'''\n'''", TypeNames.String)
+    literal("'''\nabc'''", TypeNames.String)
+    literal("'''\nabc\ndef'''", TypeNames.String)
+    literal("'''\n'a'\n'''", TypeNames.String)
+  }
+
+  test("Multi-line bound string literal") {
+    val aSet = Set(Name("a"))
+    typeLiteral("'''\n:a\n'''") should matchPattern {
+      case BoundStringLiteral(bound) if bound == aSet =>
+    }
+  }
+
   test("Max Decimal") {
     typeDeclaration(
       "public class Dummy { Object a = 0.123456789012345678901234567890123456789012345678; }"

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/SwitchTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/SwitchTest.scala
@@ -219,6 +219,21 @@ class SwitchTest extends AnyFunSuite with TestHelper {
     assert(dummyIssues == "Error: line 1 at 31-34: Duplicate when case for 'A'\n")
   }
 
+  test("Multi-line string single control") {
+    typeDeclaration("public class Dummy {{switch on 'A' {when '''\nA''' {} }}}")
+    assert(!hasIssues)
+  }
+
+  test("Multi-line string control on multi-line expression") {
+    typeDeclaration("public class Dummy {{switch on '''\nA''' {when '''\nA''' {} }}}")
+    assert(!hasIssues)
+  }
+
+  test("Multi-line string mixed control") {
+    typeDeclaration("public class Dummy {{switch on 'A' {when 'A', '''\nB''' {} }}}")
+    assert(!hasIssues)
+  }
+
   test("String switch with Null") {
     typeDeclaration("public class Dummy {{switch on 'A' {when null {} when else {}}}}")
     assert(!hasIssues)


### PR DESCRIPTION
## Summary

- Wire the new `MultilineStringLiteral` token (Salesforce Summer '26, triple-quoted strings) through `Literal.construct` so it parses and types as `String`, alongside the existing `StringLiteral` branch
- Wire the same token through `WhenLiteral.construct` so multi-line strings are accepted in `switch` when clauses, mirroring the single-quoted string behaviour
- Bound variable extraction (`:foo` interpolation) flows through the shared `StringLiteral.apply` and works for multi-line strings too

Closes #447

## Test plan

- [x] `sbt apexlsJVM/testOnly com.nawforce.apexlink.cst.LiteralTypeTest com.nawforce.apexlink.cst.SwitchTest` — 87 tests pass, including new cases:
  - `Multi-line string literal` — types as `String`
  - `Multi-line bound string literal` — `:a` inside `'''...'''` produces `BoundStringLiteral`
  - `Multi-line string single control` — `switch on 'A' { when '''\nA''' {} }`
  - `Multi-line string control on multi-line expression` — both sides multi-line
  - `Multi-line string mixed control` — multi-line and single-quoted in same when clause
- [x] `sbt apexlsJVM/test` — full JVM suite green (2389 tests)
- [x] `sbt scalafmtCheckAll` — clean