### PR TITLE
feat: diagnose malformed multi-line string literals (#443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Acceptance of Summer '26 multi-line string literals (`'''...'''`) in expressions and `switch` when clauses (#447)
+- Targeted diagnostic for malformed multi-line string literals such as `'''abc'''` and `''''''`, replacing the generic "mismatched input" syntax error (#443)
 - Qualified enum constants are now permitted in `switch` when clauses (e.g. `when MyEnum.A`) (#441)
 - Distinct exit codes from `CheckForIssues` to separate warnings-only and unused-only outcomes (#440)
 - Improved lexer error messages for invalid escape sequences, including the offending sequence

--- a/jvm/src/main/scala/com/nawforce/runtime/parsers/CollectingErrorListener.scala
+++ b/jvm/src/main/scala/com/nawforce/runtime/parsers/CollectingErrorListener.scala
@@ -15,7 +15,8 @@ package com.nawforce.runtime.parsers
 
 import com.nawforce.pkgforce.diagnostics.{Diagnostic, Issue, SYNTAX_CATEGORY}
 import com.nawforce.pkgforce.path.{Location, PathLike}
-import org.antlr.v4.runtime.{BaseErrorListener, RecognitionException, Recognizer}
+import io.github.apexdevtools.apexparser.ApexLexer
+import org.antlr.v4.runtime.{BaseErrorListener, Parser, RecognitionException, Recognizer, Token}
 
 import scala.collection.compat.immutable.ArraySeq
 import scala.collection.mutable
@@ -45,12 +46,47 @@ class CollectingErrorListener(path: PathLike) extends BaseErrorListener {
             s"Invalid escape sequence '$escape' in string"
           case _ => msg
         }
-      case _ => msg
+      case _ =>
+        malformedMultilineStringMessage(recognizer, offendingSymbol).getOrElse(msg)
     }
 
     _issues.addOne(
       new Issue(path, Diagnostic(SYNTAX_CATEGORY, Location(line, charPositionInLine), improvedMsg))
     )
+  }
+
+  // Detect the `'''abc'''` / `''''''` shape — three textually adjacent StringLiteral
+  // tokens where the outer two are empty `''`. The lexer can't fold these into a
+  // MultilineStringLiteral because the body must start on a new line, so they
+  // surface as a generic "mismatched input" parser error on the middle token.
+  // A WS token between the literals breaks adjacency and skips the rewrite.
+  private def malformedMultilineStringMessage(
+    recognizer: Recognizer[_, _],
+    offendingSymbol: Any
+  ): Option[String] = {
+    (recognizer, offendingSymbol) match {
+      case (parser: Parser, token: Token) if token.getType == ApexLexer.StringLiteral =>
+        val tokens = parser.getTokenStream
+        val idx    = token.getTokenIndex
+        if (idx > 0 && idx < tokens.size - 1) {
+          val prev = tokens.get(idx - 1)
+          val next = tokens.get(idx + 1)
+          if (
+            prev.getType == ApexLexer.StringLiteral &&
+            next.getType == ApexLexer.StringLiteral &&
+            prev.getText == "''" &&
+            next.getText == "''" &&
+            prev.getStopIndex + 1 == token.getStartIndex &&
+            token.getStopIndex + 1 == next.getStartIndex
+          )
+            Some(
+              "Malformed multi-line string literal, the body of '''...''' must start on a new line"
+            )
+          else
+            None
+        } else None
+      case _ => None
+    }
   }
 
   def issues: ArraySeq[Issue] = {

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/LiteralTypeTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/LiteralTypeTest.scala
@@ -236,4 +236,53 @@ class LiteralTypeTest extends AnyFunSuite with Matchers with TestHelper {
     assert(syntaxErrors.nonEmpty, "Should have syntax errors for unclosed string")
   }
 
+  test("Malformed multi-line string with body") {
+    val parser =
+      CodeParser(Path("Dummy.cls"), SourceData("public class Dummy { String a = '''abc'''; }"))
+    val result       = parser.parseClass()
+    val syntaxErrors = result.issues.filter(_.diagnostic.category.name == "Syntax")
+    assert(syntaxErrors.nonEmpty)
+    assert(
+      syntaxErrors.exists(
+        _.diagnostic.message.contains(
+          "Malformed multi-line string literal, the body of '''...''' must start on a new line"
+        )
+      )
+    )
+  }
+
+  test("Malformed multi-line string six quotes") {
+    val parser =
+      CodeParser(Path("Dummy.cls"), SourceData("public class Dummy { String a = ''''''; }"))
+    val result       = parser.parseClass()
+    val syntaxErrors = result.issues.filter(_.diagnostic.category.name == "Syntax")
+    assert(syntaxErrors.nonEmpty)
+    assert(
+      syntaxErrors.exists(
+        _.diagnostic.message.contains(
+          "Malformed multi-line string literal, the body of '''...''' must start on a new line"
+        )
+      )
+    )
+  }
+
+  test("Adjacent string literals with whitespace are not flagged as multi-line") {
+    // '' 'abc' '' is three legitimate string literals — still a syntax error
+    // (Apex has no string concatenation) but it should NOT trigger the
+    // multi-line diagnostic because there is whitespace between the tokens.
+    val parser =
+      CodeParser(Path("Dummy.cls"), SourceData("public class Dummy { String a = '' 'abc' ''; }"))
+    val result       = parser.parseClass()
+    val syntaxErrors = result.issues.filter(_.diagnostic.category.name == "Syntax")
+    assert(syntaxErrors.nonEmpty)
+    assert(
+      !syntaxErrors.exists(_.diagnostic.message.contains("Malformed multi-line string literal"))
+    )
+  }
+
+  test("Well-formed multi-line string is not flagged") {
+    typeDeclaration("public class Dummy { String a = '''\nabc\n'''; }")
+    assert(dummyIssues.isEmpty)
+  }
+
 }


### PR DESCRIPTION
## Summary

- Hook `CollectingErrorListener.syntaxError` to recognise the `'''abc'''` / `''''''` shape: an offending `StringLiteral` token whose immediate textual neighbours are both empty `''` literals
- Substitute a targeted diagnostic — *"Malformed multi-line string literal, the body of '''...''' must start on a new line"* — in place of the generic "mismatched input" error
- Adjacency check (`stopIndex + 1 == startIndex`) means whitespace between the literals leaves the original syntax error in place, so the legitimate `'' 'abc' ''` three-string-concat error is untouched
- Detection only fires inside the existing error path, so there's no cost on well-formed code

Closes #443

## Test plan

- [x] `sbt apexlsJVM/testOnly com.nawforce.apexlink.cst.LiteralTypeTest` — 20 tests pass, including new cases:
  - `Malformed multi-line string with body` — `'''abc'''` produces the new diagnostic
  - `Malformed multi-line string six quotes` — `''''''` produces the new diagnostic
  - `Adjacent string literals with whitespace are not flagged as multi-line` — `'' 'abc' ''` still reports the generic syntax error, not the multi-line one
  - `Well-formed multi-line string is not flagged` — `'''\nabc\n'''` parses cleanly
- [x] `sbt apexlsJVM/test` — full JVM suite green (2393 tests)
- [x] `sbt scalafmtCheckAll` — clean