### PR TITLE
refactor: drop JS-portability shims from CST construction (#449 stage 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the ANTLR-first parsing mode; OutlineParser is now the sole parser path. The `--antlr` / ANTLR parser option is deprecated and a no-op (#433)
 - Upgraded to apex-parser 5.1.0 and the antlr4 4.13 runtime
 - Slimmed the JS module surface to the published apex-ls facades
+- Removed JS-portability shims `CodeParser.toScala(value)` and `CodeParser.getText(...)` from the CST construction layer; call sites now use `Option(...)` directly (#449)
 
 ### Removed
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
@@ -88,8 +88,7 @@ object ClassBodyDeclaration {
   ): Seq[ClassBodyDeclaration] = {
 
     val declarations: Seq[ClassBodyDeclaration] =
-      CodeParser
-        .toScala(memberDeclarationContext.methodDeclaration())
+      Option(memberDeclarationContext.methodDeclaration())
         .map(x =>
           Seq(
             ApexMethodDeclaration.construct(
@@ -103,8 +102,7 @@ object ClassBodyDeclaration {
           )
         )
         .orElse(
-          CodeParser
-            .toScala(memberDeclarationContext.fieldDeclaration())
+          Option(memberDeclarationContext.fieldDeclaration())
             .map(x =>
               ApexFieldDeclaration.construct(
                 thisType,
@@ -119,8 +117,7 @@ object ClassBodyDeclaration {
             )
         )
         .orElse(
-          CodeParser
-            .toScala(memberDeclarationContext.constructorDeclaration())
+          Option(memberDeclarationContext.constructorDeclaration())
             .map(x =>
               ApexConstructorDeclaration
                 .construct(
@@ -134,8 +131,7 @@ object ClassBodyDeclaration {
             )
         )
         .orElse(
-          CodeParser
-            .toScala(memberDeclarationContext.interfaceDeclaration())
+          Option(memberDeclarationContext.interfaceDeclaration())
             .map(x =>
               Seq(
                 InterfaceDeclaration.constructInner(
@@ -148,8 +144,7 @@ object ClassBodyDeclaration {
             )
         )
         .orElse(
-          CodeParser
-            .toScala(memberDeclarationContext.enumDeclaration())
+          Option(memberDeclarationContext.enumDeclaration())
             .map(x =>
               Seq(
                 EnumDeclaration.constructInner(
@@ -162,8 +157,7 @@ object ClassBodyDeclaration {
             )
         )
         .orElse(
-          CodeParser
-            .toScala(memberDeclarationContext.propertyDeclaration())
+          Option(memberDeclarationContext.propertyDeclaration())
             .map(x =>
               Seq(
                 ApexPropertyDeclaration
@@ -177,8 +171,7 @@ object ClassBodyDeclaration {
             )
         )
         .orElse(
-          CodeParser
-            .toScala(memberDeclarationContext.classDeclaration())
+          Option(memberDeclarationContext.classDeclaration())
             .map(x =>
               Seq(
                 ClassDeclaration.constructInner(
@@ -297,8 +290,7 @@ object ApexMethodDeclaration {
     modifiers: ModifierResults,
     from: MethodDeclarationContext
   ): ApexMethodDeclaration = {
-    val block = CodeParser
-      .toScala(from.block())
+    val block = Option(from.block())
       .map(b => Block.constructOuterFromANTLR(parser, b))
 
     new ApexMethodDeclaration(
@@ -318,8 +310,7 @@ object ApexMethodDeclaration {
     modifiers: ModifierResults,
     from: InterfaceMethodDeclarationContext
   ): ApexMethodDeclaration = {
-    val typeName = CodeParser
-      .toScala(from.typeRef())
+    val typeName = Option(from.typeRef())
       .map(tr => TypeReference.construct(tr))
       .getOrElse(TypeNames.Void)
     new ApexMethodDeclaration(
@@ -518,8 +509,7 @@ object FormalParameters {
   ): ArraySeq[FormalParameter] = {
     Option(from)
       .map(from => {
-        CodeParser
-          .toScala(from.formalParameterList())
+        Option(from.formalParameterList())
           .map(x => FormalParameterList.construct(parser, typeContext, x))
           .getOrElse(empty)
       })

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/CST.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/CST.scala
@@ -79,11 +79,11 @@ final case class Id(name: Name) extends CST {
 
 object Id {
   def construct(idContext: IdContext): Id = {
-    Id(Names(CodeParser.getText(idContext))).withContext(idContext)
+    Id(Names(Option(idContext).map(_.getText).getOrElse(""))).withContext(idContext)
   }
 
   def constructAny(idContext: AnyIdContext): Id = {
-    Id(Names(CodeParser.getText(idContext))).withContext(idContext)
+    Id(Names(Option(idContext).map(_.getText).getOrElse(""))).withContext(idContext)
   }
 }
 
@@ -99,7 +99,8 @@ object QualifiedName {
   def construct(qualifiedName: QualifiedNameContext): Option[QualifiedName] = {
     Option(qualifiedName).map(qualifiedName => {
       val ids = CodeParser.toScala(qualifiedName.id())
-      QualifiedName(ids.map(id => Names(CodeParser.getText(id)))).withContext(qualifiedName)
+      QualifiedName(ids.map(id => Names(Option(id).map(_.getText).getOrElse(""))))
+        .withContext(qualifiedName)
     })
   }
 }
@@ -113,12 +114,10 @@ final case class Annotation(
 object Annotation {
   def construct(annotation: AnnotationContext): Annotation = {
     val elementValue =
-      CodeParser
-        .toScala(annotation.elementValue())
+      Option(annotation.elementValue())
         .flatMap(ElementValue.construct)
     val elementValuePairs =
-      CodeParser
-        .toScala(annotation.elementValuePairs())
+      Option(annotation.elementValuePairs())
         .map(ElementValuePairs.construct)
         .getOrElse(Nil)
 
@@ -138,9 +137,9 @@ final case class ArrayInitializerElementValue(arrayInitializer: ElementValueArra
 
 object ElementValue {
   def construct(elementValue: ElementValueContext): Option[ElementValue] = {
-    val expression       = CodeParser.toScala(elementValue.expression())
-    val annotation       = CodeParser.toScala(elementValue.annotation())
-    val arrayInitializer = CodeParser.toScala(elementValue.elementValueArrayInitializer())
+    val expression       = Option(elementValue.expression())
+    val annotation       = Option(elementValue.annotation())
+    val arrayInitializer = Option(elementValue.elementValueArrayInitializer())
 
     if (expression.nonEmpty) {
       Some(ExpressionElementValue(Expression.construct(expression.get)).withContext(elementValue))
@@ -171,7 +170,10 @@ final case class ElementValuePair(id: String, elementValue: Option[ElementValue]
 
 object ElementValuePair {
   def construct(from: ElementValuePairContext): ElementValuePair = {
-    ElementValuePair(CodeParser.getText(from.id()), ElementValue.construct(from.elementValue()))
+    ElementValuePair(
+      Option(from.id()).map(_.getText).getOrElse(""),
+      ElementValue.construct(from.elementValue())
+    )
       .withContext(from)
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Creator.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Creator.scala
@@ -72,8 +72,7 @@ object IdCreatedNamePair {
   def construct(from: IdCreatedNamePairContext): IdCreatedNamePair = {
     IdCreatedNamePair(
       Id.constructAny(from.anyId()),
-      CodeParser
-        .toScala(from.typeList())
+      Option(from.typeList())
         .map(tl => TypeList.construct(tl))
         .getOrElse(TypeNames.emptyTypeNames)
     ).withContext(from)
@@ -93,13 +92,12 @@ final case class Creator(createdName: CreatedName, creatorRest: Option[CreatorRe
 object Creator {
   def construct(from: CreatorContext): Creator = {
     val rest: Option[CreatorRest] =
-      CodeParser
-        .toScala(from.noRest())
+      Option(from.noRest())
         .map(ClassCreatorRest.construct)
-        .orElse(CodeParser.toScala(from.classCreatorRest()).map(ClassCreatorRest.construct))
-        .orElse(CodeParser.toScala(from.arrayCreatorRest()).map(ArrayCreatorRest.construct))
-        .orElse(CodeParser.toScala(from.mapCreatorRest()).map(MapCreatorRest.construct))
-        .orElse(CodeParser.toScala(from.setCreatorRest()).map(SetOrListCreatorRest.construct))
+        .orElse(Option(from.classCreatorRest()).map(ClassCreatorRest.construct))
+        .orElse(Option(from.arrayCreatorRest()).map(ArrayCreatorRest.construct))
+        .orElse(Option(from.mapCreatorRest()).map(MapCreatorRest.construct))
+        .orElse(Option(from.setCreatorRest()).map(SetOrListCreatorRest.construct))
 
     Creator(CreatedName.construct(from.createdName()), rest).withContext(from)
   }
@@ -283,8 +281,8 @@ final case class ArrayCreatorRest(
 object ArrayCreatorRest {
   def construct(from: ArrayCreatorRestContext): ArrayCreatorRest = {
     ArrayCreatorRest(
-      CodeParser.toScala(from.expression()).map(Expression.construct),
-      CodeParser.toScala(from.arrayInitializer()).map(ArrayInitializer.construct)
+      Option(from.expression()).map(Expression.construct),
+      Option(from.arrayInitializer()).map(ArrayInitializer.construct)
     )
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
@@ -717,16 +717,13 @@ final case class MethodCallCtor(isSuper: Boolean, arguments: ArraySeq[Expression
 
 object MethodCall {
   def construct(from: MethodCallContext): MethodCall = {
-    CodeParser
-      .toScala(from.id())
+    Option(from.id())
       .map(id => {
         MethodCallWithId(Id.construct(id), expressions(from.expressionList())).withContext(from)
       })
       .getOrElse({
-        MethodCallCtor(
-          CodeParser.toScala(from.SUPER()).nonEmpty,
-          expressions(from.expressionList())
-        ).withContext(from)
+        MethodCallCtor(Option(from.SUPER()).nonEmpty, expressions(from.expressionList()))
+          .withContext(from)
       })
   }
 
@@ -736,8 +733,7 @@ object MethodCall {
   }
 
   private def expressions(from: ExpressionListContext): ArraySeq[Expression] = {
-    CodeParser
-      .toScala(from)
+    Option(from)
       .map(el => CodeParser.toScala(el.expression()).map(e => Expression.construct(e)))
       .getOrElse(Expression.emptyExpressions)
   }
@@ -960,21 +956,19 @@ object Expression {
     val cst: Expression = {
       from match {
         case expr: DotExpressionContext =>
-          CodeParser
-            .toScala(expr.anyId())
+          Option(expr.anyId())
             .map(id => {
               DotExpressionWithId(
                 Expression.construct(expr.expression()),
-                CodeParser.toScala(expr.DOT()).isEmpty,
+                Option(expr.DOT()).isEmpty,
                 Id.constructAny(id)
               )
             })
             .getOrElse({
               DotExpressionWithMethod(
                 Expression.construct(expr.expression()),
-                CodeParser.toScala(expr.DOT()).isEmpty,
-                CodeParser
-                  .toScala(expr.dotMethodCall())
+                Option(expr.DOT()).isEmpty,
+                Option(expr.dotMethodCall())
                   .map(method => {
                     MethodCall.construct(method)
                   })
@@ -1007,53 +1001,54 @@ object Expression {
           SubExpression(Expression.construct(expr.expression()))
 
         case expr: PostOpExpressionContext =>
-          val op = CodeParser
-            .toScala(expr.INC())
-            .orElse(CodeParser.toScala(expr.DEC()))
-          PostfixExpression(Expression.construct(expr.expression()), CodeParser.getText(op.get))
+          val op = Option(expr.INC())
+            .orElse(Option(expr.DEC()))
+          PostfixExpression(
+            Expression.construct(expr.expression()),
+            Option(op.get).map(_.getText).getOrElse("")
+          )
 
         case expr: PreOpExpressionContext =>
-          val op = CodeParser
-            .toScala(expr.ADD())
-            .orElse(CodeParser.toScala(expr.DEC()))
-            .orElse(CodeParser.toScala(expr.INC()))
-            .orElse(CodeParser.toScala(expr.SUB()))
-          PrefixExpression(Expression.construct(expr.expression()), CodeParser.getText(op.get))
+          val op = Option(expr.ADD())
+            .orElse(Option(expr.DEC()))
+            .orElse(Option(expr.INC()))
+            .orElse(Option(expr.SUB()))
+          PrefixExpression(
+            Expression.construct(expr.expression()),
+            Option(op.get).map(_.getText).getOrElse("")
+          )
 
         case expr: NegExpressionContext =>
-          val op = CodeParser
-            .toScala(expr.BANG())
-            .orElse(CodeParser.toScala(expr.TILDE()))
+          val op = Option(expr.BANG())
+            .orElse(Option(expr.TILDE()))
           NegationExpression(
             Expression.construct(expr.expression()),
-            CodeParser.getText(op.get) == "~"
+            Option(op.get).map(_.getText).getOrElse("") == "~"
           )
 
         case expr: Arth1ExpressionContext =>
-          val op = CodeParser
-            .toScala(expr.DIV())
-            .orElse(CodeParser.toScala(expr.MUL()))
+          val op = Option(expr.DIV())
+            .orElse(Option(expr.MUL()))
           val expressions = CodeParser.toScala(expr.expression())
           if (expressions.length == 2) {
             BinaryExpression(
               Expression.construct(expressions.head),
               Expression.construct(expressions(1)),
-              CodeParser.getText(op.get)
+              Option(op.get).map(_.getText).getOrElse("")
             )
           } else {
             EmptyExpr()
           }
 
         case expr: Arth2ExpressionContext =>
-          val op = CodeParser
-            .toScala(expr.ADD())
-            .orElse(CodeParser.toScala(expr.SUB()))
+          val op = Option(expr.ADD())
+            .orElse(Option(expr.SUB()))
           val expressions = CodeParser.toScala(expr.expression())
           if (expressions.length == 2) {
             BinaryExpression(
               Expression.construct(expressions.head),
               Expression.construct(expressions(1)),
-              CodeParser.getText(op.get)
+              Option(op.get).map(_.getText).getOrElse("")
             )
           } else {
             EmptyExpr()
@@ -1075,10 +1070,10 @@ object Expression {
           }
 
         case expr: CmpExpressionContext =>
-          val assign = CodeParser.toScala(expr.ASSIGN()).nonEmpty
-          val op = CodeParser.getText(
-            CodeParser.toScala(expr.GT()).orElse(CodeParser.toScala(expr.LT())).get
-          )
+          val assign = Option(expr.ASSIGN()).nonEmpty
+          val op = Option(Option(expr.GT()).orElse(Option(expr.LT())).get)
+            .map(_.getText)
+            .getOrElse("")
           val opText = (assign, op) match {
             case (true, ">") => ">="
             case (true, "<") => "<="
@@ -1103,18 +1098,17 @@ object Expression {
           )
 
         case expr: EqualityExpressionContext =>
-          val op = CodeParser
-            .toScala(expr.EQUAL())
-            .orElse(CodeParser.toScala(expr.LESSANDGREATER()))
-            .orElse(CodeParser.toScala(expr.NOTEQUAL()))
-            .orElse(CodeParser.toScala(expr.TRIPLEEQUAL()))
-            .orElse(CodeParser.toScala(expr.TRIPLENOTEQUAL()))
+          val op = Option(expr.EQUAL())
+            .orElse(Option(expr.LESSANDGREATER()))
+            .orElse(Option(expr.NOTEQUAL()))
+            .orElse(Option(expr.TRIPLEEQUAL()))
+            .orElse(Option(expr.TRIPLENOTEQUAL()))
           val expressions = CodeParser.toScala(expr.expression())
           if (expressions.length == 2) {
             BinaryExpression(
               Expression.construct(expressions.head),
               Expression.construct(expressions(1)),
-              CodeParser.getText(op.get)
+              Option(op.get).map(_.getText).getOrElse("")
             )
           } else {
             EmptyExpr()
@@ -1205,23 +1199,22 @@ object Expression {
           }
 
         case expr: AssignExpressionContext =>
-          val op = CodeParser
-            .toScala(expr.ADD_ASSIGN())
-            .orElse(CodeParser.toScala(expr.AND_ASSIGN()))
-            .orElse(CodeParser.toScala(expr.ASSIGN()))
-            .orElse(CodeParser.toScala(expr.DIV_ASSIGN()))
-            .orElse(CodeParser.toScala(expr.LSHIFT_ASSIGN()))
-            .orElse(CodeParser.toScala(expr.MUL_ASSIGN()))
-            .orElse(CodeParser.toScala(expr.OR_ASSIGN()))
-            .orElse(CodeParser.toScala(expr.RSHIFT_ASSIGN()))
-            .orElse(CodeParser.toScala(expr.SUB_ASSIGN()))
-            .orElse(CodeParser.toScala(expr.URSHIFT_ASSIGN()))
-            .orElse(CodeParser.toScala(expr.XOR_ASSIGN()))
+          val op = Option(expr.ADD_ASSIGN())
+            .orElse(Option(expr.AND_ASSIGN()))
+            .orElse(Option(expr.ASSIGN()))
+            .orElse(Option(expr.DIV_ASSIGN()))
+            .orElse(Option(expr.LSHIFT_ASSIGN()))
+            .orElse(Option(expr.MUL_ASSIGN()))
+            .orElse(Option(expr.OR_ASSIGN()))
+            .orElse(Option(expr.RSHIFT_ASSIGN()))
+            .orElse(Option(expr.SUB_ASSIGN()))
+            .orElse(Option(expr.URSHIFT_ASSIGN()))
+            .orElse(Option(expr.XOR_ASSIGN()))
           val expressions = CodeParser.toScala(expr.expression())
           BinaryExpression(
             Expression.construct(expressions.head),
             Expression.construct(expressions(1)),
-            CodeParser.getText(op.get)
+            Option(op.get).map(_.getText).getOrElse("")
           )
         case expr: PrimaryExpressionContext =>
           PrimaryExpression(Primary.construct(expr.primary()))
@@ -1239,7 +1232,7 @@ object Expression {
 
 object Arguments {
   def construct(from: ArgumentsContext): ArraySeq[Expression] = {
-    val el = CodeParser.toScala(from.expressionList())
+    val el = Option(from.expressionList())
     if (el.nonEmpty) {
       Expression.construct(CodeParser.toScala(el.get.expression()))
     } else {

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Literals.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Literals.scala
@@ -117,7 +117,7 @@ case object NullLiteral extends Literal {
 
 object IntegerOrLongLiteral {
   def apply(context: LiteralContext): Literal = {
-    val value = CodeParser.getText(context)
+    val value = Option(context).map(_.getText).getOrElse("")
     if (value.last.toLower == 'l') {
       if (value.length > 20) // 19 + 1 for 'l'
         OversizeLongLiteral(CST.sourceContext.value.get.getLocation(context))
@@ -134,7 +134,7 @@ object IntegerOrLongLiteral {
 
 object DoubleOrDecimalLiteral {
   def apply(context: LiteralContext): Literal = {
-    val value = CodeParser.getText(context)
+    val value = Option(context).map(_.getText).getOrElse("")
     if (value.last.toLower == 'd') {
       DoubleLiteral
     } else if (value.length > 50) {
@@ -147,30 +147,25 @@ object DoubleOrDecimalLiteral {
 
 object Literal {
   def construct(from: LiteralContext): Literal = {
-    CodeParser
-      .toScala(from.IntegerLiteral())
+    Option(from.IntegerLiteral())
       .map(_ => IntegerOrLongLiteral(from))
       .orElse(
-        CodeParser
-          .toScala(from.LongLiteral())
+        Option(from.LongLiteral())
           .map(_ => IntegerOrLongLiteral(from))
       )
       .orElse(
-        CodeParser
-          .toScala(from.NumberLiteral())
+        Option(from.NumberLiteral())
           .map(_ => DoubleOrDecimalLiteral(from))
       )
       .orElse(
-        CodeParser
-          .toScala(from.StringLiteral())
-          .map(x => StringLiteral(CodeParser.getText(x)))
+        Option(from.StringLiteral())
+          .map(x => StringLiteral(Option(x).map(_.getText).getOrElse("")))
       )
       .orElse(
-        CodeParser
-          .toScala(from.MultilineStringLiteral())
-          .map(x => StringLiteral(CodeParser.getText(x)))
+        Option(from.MultilineStringLiteral())
+          .map(x => StringLiteral(Option(x).map(_.getText).getOrElse("")))
       )
-      .orElse(CodeParser.toScala(from.BooleanLiteral()).map(_ => BooleanLiteral))
+      .orElse(Option(from.BooleanLiteral()).map(_ => BooleanLiteral))
       .getOrElse(NullLiteral)
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
@@ -261,26 +261,24 @@ object SOQL {
       .toScala(query.selectList().selectEntry())
 
     val aggregateFunctions = entries
-      .flatMap(se => CodeParser.toScala(se.soqlFunction()))
+      .flatMap(se => Option(se.soqlFunction()))
       .filter(fn =>
-        CodeParser.toScala(fn.AVG()).nonEmpty ||
-          CodeParser.toScala(fn.COUNT()).nonEmpty ||
-          CodeParser.toScala(fn.COUNT_DISTINCT()).nonEmpty ||
-          CodeParser.toScala(fn.MIN()).nonEmpty ||
-          CodeParser.toScala(fn.MAX()).nonEmpty ||
-          CodeParser.toScala(fn.SUM()).nonEmpty
+        Option(fn.AVG()).nonEmpty ||
+          Option(fn.COUNT()).nonEmpty ||
+          Option(fn.COUNT_DISTINCT()).nonEmpty ||
+          Option(fn.MIN()).nonEmpty ||
+          Option(fn.MAX()).nonEmpty ||
+          Option(fn.SUM()).nonEmpty
       )
-    val countFunctions = aggregateFunctions.filter(fn => CodeParser.toScala(fn.COUNT()).nonEmpty)
+    val countFunctions = aggregateFunctions.filter(fn => Option(fn.COUNT()).nonEmpty)
     val emptyCountFunctions =
-      countFunctions.filter(fn => CodeParser.toScala(fn.fieldName()).isEmpty)
+      countFunctions.filter(fn => Option(fn.fieldName()).isEmpty)
 
     val resultType =
       if (entries.size == 1 && emptyCountFunctions.size == 1) {
         // Count queries are only valid for 'Select Count() From...', otherwise assume is aggregate
         COUNT_RESULT_QUERY
-      } else if (
-        CodeParser.toScala(query.groupByClause()).nonEmpty || aggregateFunctions.nonEmpty
-      ) {
+      } else if (Option(query.groupByClause()).nonEmpty || aggregateFunctions.nonEmpty) {
         AGGREGATE_RESULT_QUERY
       } else {
         LIST_RESULT_QUERY
@@ -293,7 +291,11 @@ object SOQL {
       CodeParser
         .toScala(query.fromNameList().fieldName())
         .map(nameList =>
-          DotName(CodeParser.toScala(nameList.soqlId()).map(name => Name(CodeParser.getText(name))))
+          DotName(
+            CodeParser
+              .toScala(nameList.soqlId())
+              .map(name => Name(Option(name).map(_.getText).getOrElse("")))
+          )
         )
     new SOQL(resultType, fromNames.toArray, boundedExpressions)
   }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Properties.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Properties.scala
@@ -175,15 +175,14 @@ object PropertyBlock {
       propertyBlockContext
     )
     val cst = {
-      val getter = CodeParser.toScala(propertyBlockContext.getter())
-      val setter = CodeParser.toScala(propertyBlockContext.setter())
+      val getter = Option(propertyBlockContext.getter())
+      val setter = Option(propertyBlockContext.setter())
 
       if (getter.nonEmpty) {
         Some(
           GetterPropertyBlock(
             modifiers,
-            CodeParser
-              .toScala(getter.get.block())
+            Option(getter.get.block())
               .map(bc => Block.constructOuterFromANTLR(parser, bc))
           )
         )
@@ -192,8 +191,7 @@ object PropertyBlock {
           SetterPropertyBlock(
             modifiers,
             typeName,
-            CodeParser
-              .toScala(setter.get.block())
+            Option(setter.get.block())
               .map(bc => Block.constructOuterFromANTLR(parser, bc))
           )
         )

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
@@ -260,9 +260,8 @@ final case class ForStatement(control: Option[ForControl], statement: Option[Sta
 object ForStatement {
   def construct(parser: CodeParser, statement: ForStatementContext): ForStatement = {
     ForStatement(
-      CodeParser.toScala(statement.forControl()).map(fc => ForControl.construct(parser, fc)),
-      CodeParser
-        .toScala(statement.statement())
+      Option(statement.forControl()).map(fc => ForControl.construct(parser, fc)),
+      Option(statement.statement())
         .flatMap(stmt => Statement.construct(parser, stmt))
     ).withContext(statement)
   }
@@ -279,8 +278,7 @@ sealed abstract class ForControl extends CST {
 object ForControl {
   def construct(parser: CodeParser, from: ForControlContext): ForControl = {
     val cst =
-      CodeParser
-        .toScala(from.enhancedForControl())
+      Option(from.enhancedForControl())
         .map(efc => EnhancedForControl.construct(efc))
         .getOrElse(BasicForControl.construct(parser, from))
     cst.withContext(from)
@@ -408,16 +406,13 @@ final case class BasicForControl(
 object BasicForControl {
   def construct(parser: CodeParser, from: ForControlContext): BasicForControl = {
     val forInit =
-      CodeParser
-        .toScala(from.forInit())
+      Option(from.forInit())
         .map(fi => ForInit.construct(parser, fi))
     val expression =
-      CodeParser
-        .toScala(from.expression())
+      Option(from.expression())
         .map(e => Expression.construct(e))
     val forUpdate =
-      CodeParser
-        .toScala(from.forUpdate())
+      Option(from.forUpdate())
         .map(u => ForUpdate.construct(u))
     BasicForControl(forInit, expression, forUpdate).withContext(from)
   }
@@ -448,12 +443,11 @@ final case class ExpressionListForInit(expressions: ArraySeq[Expression]) extend
 
 object ForInit {
   def construct(parser: CodeParser, from: ForInitContext): ForInit = {
-    CodeParser
-      .toScala(from.localVariableDeclaration())
+    Option(from.localVariableDeclaration())
       .map(lvd => LocalVariableForInit(LocalVariableDeclaration.construct(parser, lvd)))
       .getOrElse({
         val expressions =
-          CodeParser.toScala(CodeParser.toScala(from.expressionList()).get.expression())
+          CodeParser.toScala(Option(from.expressionList()).get.expression())
         ExpressionListForInit(Expression.construct(expressions))
       })
       .withContext(from)
@@ -487,7 +481,7 @@ object WhileStatement {
   def construct(parser: CodeParser, statement: WhileStatementContext): WhileStatement = {
     WhileStatement(
       Expression.construct(statement.parExpression().expression()),
-      CodeParser.toScala(statement.statement()).flatMap(stmt => Statement.construct(parser, stmt))
+      Option(statement.statement()).flatMap(stmt => Statement.construct(parser, stmt))
     ).withContext(statement)
   }
 }
@@ -531,8 +525,7 @@ object TryStatement {
   def construct(parser: CodeParser, from: TryStatementContext): TryStatement = {
     val catches = CodeParser.toScala(from.catchClause())
     val finallyBlock =
-      CodeParser
-        .toScala(from.finallyBlock())
+      Option(from.finallyBlock())
         .map(fb => Block.constructInner(parser, fb.block()))
     TryStatement(
       Block.constructInner(parser, from.block()),
@@ -601,9 +594,8 @@ object CatchClause {
         CatchClause(
           ApexModifiers.catchModifiers(parser, CodeParser.toScala(from.modifier()), from),
           qualifiedName,
-          CodeParser.getText(from.id()),
-          CodeParser
-            .toScala(from.block())
+          Option(from.id()).map(_.getText).getOrElse(""),
+          Option(from.block())
             .map(block => Block.constructInner(parser, block))
         ).withContext(from)
       })
@@ -641,8 +633,7 @@ final case class ReturnStatement(expression: Option[Expression]) extends Stateme
 object ReturnStatement {
   def construct(statement: ReturnStatementContext): ReturnStatement = {
     ReturnStatement(
-      CodeParser
-        .toScala(statement.expression())
+      Option(statement.expression())
         .map(e => Expression.construct(e))
     ).withContext(statement)
   }
@@ -757,8 +748,7 @@ final case class UpsertStatement(expression: Expression, field: Option[Qualified
 object UpsertStatement {
   def construct(statement: UpsertStatementContext): UpsertStatement = {
     val expression = Expression.construct(statement.expression())
-    val qualifiedName = CodeParser
-      .toScala(statement.qualifiedName())
+    val qualifiedName = Option(statement.qualifiedName())
       .flatMap(qualifiedName => QualifiedName.construct(qualifiedName))
     UpsertStatement(expression, qualifiedName).withContext(statement)
   }
@@ -817,13 +807,11 @@ final case class RunAsStatement(expressions: ArraySeq[Expression], block: Option
 object RunAsStatement {
   def construct(parser: CodeParser, statement: RunAsStatementContext): RunAsStatement = {
     val expressions: ArraySeq[Expression] =
-      CodeParser
-        .toScala(statement.expressionList())
+      Option(statement.expressionList())
         .map(el => Expression.construct(CodeParser.toScala(el.expression())))
         .getOrElse(Expression.emptyExpressions)
     val block =
-      CodeParser
-        .toScala(statement.block())
+      Option(statement.block())
         .map(b => Block.constructInner(parser, b))
     RunAsStatement(expressions, block).withContext(statement)
   }
@@ -886,7 +874,7 @@ object Statement {
     * @param statement ANTLR statement context
     */
   def construct(parser: CodeParser, statement: StatementContext): Option[Statement] = {
-    val typedStatement = CodeParser.toScala(statement.getChild(0))
+    val typedStatement = Option(statement.getChild(0))
     if (typedStatement.isEmpty) {
       // Log here just in case
       LoggerOps.info(s"Apex Statement found without content in ${parser.source.path}")

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeDeclarations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeDeclarations.scala
@@ -98,7 +98,8 @@ object ClassDeclaration {
     modifiers: ModifierResults,
     classDeclaration: ClassDeclarationContext
   ): ClassDeclaration = {
-    val thisType = outerType.asInner(CodeParser.getText(classDeclaration.id()))
+    val thisType =
+      outerType.asInner(Option(classDeclaration.id()).map(_.getText).getOrElse(""))
     construct(parser, thisType, Some(outerType.typeName), modifiers, classDeclaration)
   }
 
@@ -111,18 +112,15 @@ object ClassDeclaration {
   ): ClassDeclaration = {
 
     val extendType =
-      CodeParser
-        .toScala(classDeclaration.typeRef())
+      Option(classDeclaration.typeRef())
         .map(tr => TypeReference.construct(tr))
         .getOrElse(TypeNames.InternalObject)
     val implementsType =
-      CodeParser
-        .toScala(classDeclaration.typeList())
+      Option(classDeclaration.typeList())
         .map(tl => TypeList.construct(tl))
         .getOrElse(TypeNames.emptyTypeNames)
 
-    val classBodyDeclarations = CodeParser
-      .toScala(classDeclaration.classBody())
+    val classBodyDeclarations = Option(classDeclaration.classBody())
       .map(cb => CodeParser.toScala(cb.classBodyDeclaration()))
       .getOrElse(ArraySeq())
     val typeContext = new RelativeTypeContext
@@ -130,22 +128,20 @@ object ClassDeclaration {
     val bodyDeclarations =
       classBodyDeclarations
         .flatMap(cbd =>
-          CodeParser
-            .toScala(cbd.block())
+          Option(cbd.block())
             .map(x =>
               ArraySeq(
                 ApexInitializerBlock.construct(
                   parser,
                   thisType,
                   ApexModifiers
-                    .initializerBlockModifiers(CodeParser.toScala(cbd.STATIC()).isDefined),
+                    .initializerBlockModifiers(Option(cbd.STATIC()).isDefined),
                   x
                 )
               )
             )
             .orElse(
-              CodeParser
-                .toScala(cbd.memberDeclaration())
+              Option(cbd.memberDeclaration())
                 .map(x =>
                   ClassBodyDeclaration.construct(
                     parser,
@@ -219,7 +215,8 @@ object InterfaceDeclaration {
     modifiers: ModifierResults,
     interfaceDeclaration: InterfaceDeclarationContext
   ): InterfaceDeclaration = {
-    val thisType = outerType.asInner(CodeParser.getText(interfaceDeclaration.id()))
+    val thisType =
+      outerType.asInner(Option(interfaceDeclaration.id()).map(_.getText).getOrElse(""))
     construct(parser, thisType, Some(outerType.typeName), modifiers, interfaceDeclaration)
   }
 
@@ -232,16 +229,14 @@ object InterfaceDeclaration {
   ): InterfaceDeclaration = {
 
     val implementsType =
-      CodeParser
-        .toScala(interfaceDeclaration.typeList())
+      Option(interfaceDeclaration.typeList())
         .map(x => TypeList.construct(x))
         .getOrElse(ArraySeq(TypeNames.InternalInterface))
 
     val typeContext = new RelativeTypeContext()
 
     val methods =
-      CodeParser
-        .toScala(interfaceDeclaration.interfaceBody())
+      Option(interfaceDeclaration.interfaceBody())
         .map(interfaceBody => CodeParser.toScala(interfaceBody.interfaceMethodDeclaration()))
         .map(methods => {
           methods.map(method => {
@@ -396,7 +391,8 @@ object EnumDeclaration {
     modifiers: ModifierResults,
     enumDeclaration: EnumDeclarationContext
   ): EnumDeclaration = {
-    val thisType = outerType.asInner(CodeParser.getText(enumDeclaration.id()))
+    val thisType =
+      outerType.asInner(Option(enumDeclaration.id()).map(_.getText).getOrElse(""))
     construct(parser, thisType, Some(outerType.typeName), modifiers, enumDeclaration)
   }
 
@@ -409,8 +405,7 @@ object EnumDeclaration {
   ): EnumDeclaration = {
 
     val id = Id.construct(enumDeclaration.id())
-    val constants = CodeParser
-      .toScala(enumDeclaration.enumConstants())
+    val constants = Option(enumDeclaration.enumConstants())
       .map(ec => CodeParser.toScala(ec.id()))
       .getOrElse(ArraySeq())
     val fields = constants.map(constant => {

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeReference.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeReference.scala
@@ -63,16 +63,17 @@ private[cst] object ANTLRCST {
 
   private class ANTLRTypeName(typeName: TypeNameContext) extends CSTTypeName {
     override def typeArguments(): CSTTypeArguments =
-      new ANTLRTypeArguments(CodeParser.toScala(typeName.typeArguments()))
-    override def isList: Boolean           = CodeParser.toScala(typeName.LIST()).nonEmpty
-    override def isSet: Boolean            = CodeParser.toScala(typeName.SET()).nonEmpty
-    override def isMap: Boolean            = CodeParser.toScala(typeName.MAP()).nonEmpty
-    override def getIdText: Option[String] = Option(typeName.id()).map(id => CodeParser.getText(id))
+      new ANTLRTypeArguments(Option(typeName.typeArguments()))
+    override def isList: Boolean = Option(typeName.LIST()).nonEmpty
+    override def isSet: Boolean  = Option(typeName.SET()).nonEmpty
+    override def isMap: Boolean  = Option(typeName.MAP()).nonEmpty
+    override def getIdText: Option[String] =
+      Option(typeName.id()).map(id => Option(id).map(_.getText).getOrElse(""))
   }
 
   private[cst] class ANTLRTypeReference(typeRef: TypeRefContext) extends CSTTypeReference {
     override def arraySubscriptsCount(): Int =
-      CodeParser.getText(typeRef.arraySubscripts()).count(_ == '[')
+      Option(typeRef.arraySubscripts()).map(_.getText).getOrElse("").count(_ == '[')
     override def typeNames(): ArraySeq[CSTTypeName] =
       CodeParser.toScala(typeRef.typeName()).map(new ANTLRTypeName(_))
   }
@@ -85,7 +86,7 @@ object TypeReference {
   }
 
   def construct(typeRef: TypeRefContext): TypeName = {
-    construct(CodeParser.toScala(typeRef).map(new ANTLRCST.ANTLRTypeReference(_)))
+    construct(Option(typeRef).map(new ANTLRCST.ANTLRTypeReference(_)))
   }
 
   def construct(typeRefOpt: Option[CSTTypeReference]): TypeName = {

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Variables.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Variables.scala
@@ -76,7 +76,7 @@ object VariableDeclarator {
     isReadOnly: Boolean,
     variableDeclarator: VariableDeclaratorContext
   ): VariableDeclarator = {
-    val init = CodeParser.toScala(variableDeclarator.expression()).map(Expression.construct)
+    val init = Option(variableDeclarator.expression()).map(Expression.construct)
     VariableDeclarator(typeName, isReadOnly, Id.construct(variableDeclarator.id()), init)
       .withContext(variableDeclarator)
   }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/stmts/Switch.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/stmts/Switch.scala
@@ -56,39 +56,33 @@ final case class WhenLongLiteral(negate: Boolean, value: String) extends WhenLit
 object WhenLiteral {
   def construct(context: WhenLiteralContext): Option[WhenLiteral] = {
     val literal = flattenLiteral(context)
-    CodeParser
-      .toScala(literal.NULL())
+    Option(literal.NULL())
       .map(_ => new WhenNullLiteral())
       .orElse(
-        CodeParser
-          .toScala(literal.IntegerLiteral())
+        Option(literal.IntegerLiteral())
           .map(l => {
             val negate = CodeParser.toScala(literal.SUB()).size % 2 != 0
-            WhenIntegerLiteral(negate, CodeParser.getText(l))
+            WhenIntegerLiteral(negate, Option(l).map(_.getText).getOrElse(""))
           })
       )
       .orElse(
-        CodeParser
-          .toScala(literal.LongLiteral())
+        Option(literal.LongLiteral())
           .map(l => {
             val negate = CodeParser.toScala(literal.SUB()).size % 2 != 0
-            val text   = CodeParser.getText(l)
+            val text   = Option(l).map(_.getText).getOrElse("")
             WhenLongLiteral(negate, text.substring(0, text.length - 1))
           })
       )
       .orElse(
-        CodeParser
-          .toScala(literal.StringLiteral())
-          .map(l => WhenStringLiteral(CodeParser.getText(l)))
+        Option(literal.StringLiteral())
+          .map(l => WhenStringLiteral(Option(l).map(_.getText).getOrElse("")))
       )
       .orElse(
-        CodeParser
-          .toScala(literal.MultilineStringLiteral())
-          .map(l => WhenStringLiteral(CodeParser.getText(l)))
+        Option(literal.MultilineStringLiteral())
+          .map(l => WhenStringLiteral(Option(l).map(_.getText).getOrElse("")))
       )
       .orElse(
-        CodeParser
-          .toScala(literal.qualifiedName())
+        Option(literal.qualifiedName())
           .flatMap(qn => {
             val ids = CodeParser.toScala(qn.id()).map(Id.construct)
             ids.lastOption.map(last => WhenIdLiteral(ids.dropRight(1), last))
@@ -99,7 +93,7 @@ object WhenLiteral {
 
   private def flattenLiteral(value: WhenLiteralContext): WhenLiteralContext = {
     // Remove nesting when a literal is wrapped in brackets
-    CodeParser.toScala(value.whenLiteral()).map(flattenLiteral).getOrElse(value)
+    Option(value.whenLiteral()).map(flattenLiteral).getOrElse(value)
   }
 }
 
@@ -217,8 +211,7 @@ final case class WhenSObjectValue(typeName: TypeName, id: Id) extends WhenValue 
 
 object WhenValue {
   def construct(value: WhenValueContext): WhenValue = {
-    CodeParser
-      .toScala(value.ELSE())
+    Option(value.ELSE())
       .map(_ => new WhenElseValue())
       .getOrElse(if (!value.whenLiteral().isEmpty) {
         WhenLiteralsValue(
@@ -244,7 +237,7 @@ final case class WhenControl(whenValue: WhenValue, block: Block) extends CST {
 object WhenControl {
   def construct(parser: CodeParser, whenControl: WhenControlContext): WhenControl = {
     WhenControl(
-      CodeParser.toScala(whenControl.whenValue()).map(v => WhenValue.construct(v)).get,
+      Option(whenControl.whenValue()).map(v => WhenValue.construct(v)).get,
       Block.constructInner(parser, whenControl.block())
     ).withContext(whenControl)
   }

--- a/jvm/src/main/scala/com/nawforce/apexlink/diagnostics/IssueOps.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/diagnostics/IssueOps.scala
@@ -94,7 +94,7 @@ object IssueOps {
       Diagnostic(
         ERROR_CATEGORY,
         location.location,
-        s"Unexpected annotation '${CodeParser.getText(context)}' on class declaration"
+        s"Unexpected annotation '${Option(context).map(_.getText).getOrElse("")}' on class declaration"
       )
     )
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/apex/FullDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/apex/FullDeclaration.scala
@@ -428,8 +428,7 @@ object FullDeclaration {
     val modifiers = ArraySeq.unsafeWrapArray(CodeParser.toScala(typeDeclaration.modifier()).toArray)
     val thisType  = TypeName(name).withNamespace(module.namespace)
 
-    val cst: Option[FullDeclaration] = CodeParser
-      .toScala(typeDeclaration.classDeclaration())
+    val cst: Option[FullDeclaration] = Option(typeDeclaration.classDeclaration())
       .map(cd => {
         val classModifiers = ApexModifiers.classModifiers(parser, modifiers, outer = true, cd.id())
         ClassDeclaration.construct(
@@ -441,8 +440,7 @@ object FullDeclaration {
         )
       })
       .orElse(
-        CodeParser
-          .toScala(typeDeclaration.interfaceDeclaration())
+        Option(typeDeclaration.interfaceDeclaration())
           .map(id =>
             InterfaceDeclaration.construct(
               parser,
@@ -454,8 +452,7 @@ object FullDeclaration {
           )
       )
       .orElse(
-        CodeParser
-          .toScala(typeDeclaration.enumDeclaration())
+        Option(typeDeclaration.enumDeclaration())
           .map(ed =>
             EnumDeclaration.construct(
               parser,

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/apex/TriggerDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/apex/TriggerDeclaration.scala
@@ -235,8 +235,7 @@ object TriggerDeclaration {
         return None
       }
 
-      CodeParser
-        .toScala(trigger.triggerBlock())
+      Option(trigger.triggerBlock())
         .map(triggerBlock => {
           val statementsAndDeclarations = splitStatementsAndDeclarations(
             parser,
@@ -263,8 +262,8 @@ object TriggerDeclaration {
     /* TODO: Ignoring most declarations types here, e.g. methods, to fix the declaration hierarchy needs to change. */
     val statements = mutable.ArrayBuffer[Statement]()
     members.foreach(member => {
-      val statementContext   = CodeParser.toScala(member.statement())
-      val declarationContext = CodeParser.toScala(member.triggerMemberDeclaration())
+      val statementContext   = Option(member.statement())
+      val declarationContext = Option(member.triggerMemberDeclaration())
       if (statementContext.nonEmpty) {
         Statement
           .construct(parser, statementContext.get)
@@ -273,8 +272,7 @@ object TriggerDeclaration {
         // Field & Property syntax is allowed in triggers but they are scoped as statements so we need to treat
         // them as local variable declarations
         val modifiers = CodeParser.toScala(member.modifier())
-        CodeParser
-          .toScala(declarationContext.get.fieldDeclaration())
+        Option(declarationContext.get.fieldDeclaration())
           .foreach(field =>
             statements.append(
               LocalVariableDeclarationStatement
@@ -295,21 +293,21 @@ object TriggerDeclaration {
   }
 
   private def constructCase(triggerCase: TriggerCaseContext): TriggerCase = {
-    if (CodeParser.toScala(triggerCase.BEFORE()).nonEmpty) {
-      if (CodeParser.toScala(triggerCase.INSERT()).nonEmpty)
+    if (Option(triggerCase.BEFORE()).nonEmpty) {
+      if (Option(triggerCase.INSERT()).nonEmpty)
         BEFORE_INSERT
-      else if (CodeParser.toScala(triggerCase.UPDATE()).nonEmpty)
+      else if (Option(triggerCase.UPDATE()).nonEmpty)
         BEFORE_UPDATE
-      else if (CodeParser.toScala(triggerCase.DELETE()).nonEmpty)
+      else if (Option(triggerCase.DELETE()).nonEmpty)
         BEFORE_DELETE
       else
         BEFORE_UNDELETE
     } else {
-      if (CodeParser.toScala(triggerCase.INSERT()).nonEmpty)
+      if (Option(triggerCase.INSERT()).nonEmpty)
         AFTER_INSERT
-      else if (CodeParser.toScala(triggerCase.UPDATE()).nonEmpty)
+      else if (Option(triggerCase.UPDATE()).nonEmpty)
         AFTER_UPDATE
-      else if (CodeParser.toScala(triggerCase.DELETE()).nonEmpty)
+      else if (Option(triggerCase.DELETE()).nonEmpty)
         AFTER_DELETE
       else
         AFTER_UNDELETE

--- a/jvm/src/main/scala/com/nawforce/pkgforce/modifiers/Modifier.scala
+++ b/jvm/src/main/scala/com/nawforce/pkgforce/modifiers/Modifier.scala
@@ -262,16 +262,20 @@ object ApexModifiers {
   ): ArraySeq[(Modifier, LogEntryContext, String)] = {
 
     modifierContexts.flatMap(modifierContext => {
-      val annotation = CodeParser.toScala(modifierContext.annotation())
+      val annotation = Option(modifierContext.annotation())
       val modifiers =
         annotation
           .map(a =>
             ModifierOps(
-              "@" + CodeParser.getText(a.qualifiedName()).toLowerCase,
-              CodeParser.toScala(a.elementValue()).map(ev => CodeParser.getText(ev)).getOrElse("")
+              "@" + Option(a.qualifiedName()).map(_.getText).getOrElse("").toLowerCase,
+              Option(a.elementValue())
+                .map(ev => Option(ev).map(_.getText).getOrElse(""))
+                .getOrElse("")
             )
           )
-          .getOrElse(ModifierOps(CodeParser.getText(modifierContext).toLowerCase, ""))
+          .getOrElse(
+            ModifierOps(Option(modifierContext).map(_.getText).getOrElse("").toLowerCase, "")
+          )
 
       modifiers.map(m =>
         (

--- a/jvm/src/main/scala/com/nawforce/pkgforce/parsers/ApexClassVisitor.scala
+++ b/jvm/src/main/scala/com/nawforce/pkgforce/parsers/ApexClassVisitor.scala
@@ -42,10 +42,12 @@ class ApexClassVisitor(parser: CodeParser) extends TreeVisitor[ApexNode] {
     val modifierContext = getModifierContext(parentContext(ctx))
     val classModifiers =
       ApexModifiers.classModifiers(parser, modifierContext.modifiers, isOuter, ctx.id())
-    val extendsType = CodeParser
-      .toScala(ctx.typeRef())
+    val extendsType = Option(ctx.typeRef())
       .map(typeRef =>
-        ExtendsType(Name(CodeParser.getText(typeRef)), parser.getPathLocation(typeRef).location)
+        ExtendsType(
+          Name(Option(typeRef).map(_.getText).getOrElse("")),
+          parser.getPathLocation(typeRef).location
+        )
       )
 
     wrapParentStack(ClassOwnerInfo(classModifiers.modifiers, extendsType.nonEmpty)) {
@@ -53,12 +55,12 @@ class ApexClassVisitor(parser: CodeParser) extends TreeVisitor[ApexNode] {
         new ApexLightNode(
           parser.getPathLocation(parentContext(ctx)),
           CLASS_NATURE,
-          Name(CodeParser.getText(ctx.id())),
+          Name(Option(ctx.id()).map(_.getText).getOrElse("")),
           parser.getPathLocation(ctx.id()).location,
           extendsType,
           visitChildren(ctx),
           classModifiers.modifiers,
-          s"${classModifiers.modifiers.mkString(" ")} class ${CodeParser.getText(ctx.id())}",
+          s"${classModifiers.modifiers.mkString(" ")} class ${Option(ctx.id()).map(_.getText).getOrElse("")}",
           classModifiers.modifiers.mkString(" "),
           classModifiers.issues
         )
@@ -75,12 +77,12 @@ class ApexClassVisitor(parser: CodeParser) extends TreeVisitor[ApexNode] {
       new ApexLightNode(
         parser.getPathLocation(ctx),
         TRIGGER_NATURE,
-        Name(CodeParser.getText(ids.head)),
+        Name(Option(ids.head).map(_.getText).getOrElse("")),
         parser.getPathLocation(ids.head).location,
         None,
         visitChildren(ctx),
         ArraySeq(),
-        s"trigger ${CodeParser.getText(ids.head)} on ${CodeParser.getText(ids.tail.head)}",
+        s"trigger ${Option(ids.head).map(_.getText).getOrElse("")} on ${Option(ids.tail.head).map(_.getText).getOrElse("")}",
         "",
         ArraySeq()
       )
@@ -101,12 +103,12 @@ class ApexClassVisitor(parser: CodeParser) extends TreeVisitor[ApexNode] {
         new ApexLightNode(
           parser.getPathLocation(parentContext(ctx)),
           INTERFACE_NATURE,
-          Name(CodeParser.getText(ctx.id())),
+          Name(Option(ctx.id()).map(_.getText).getOrElse("")),
           parser.getPathLocation(ctx.id()).location,
           None,
           visitChildren(ctx),
           modifiers.modifiers,
-          s"${modifiers.modifiers.mkString(" ")} interface ${CodeParser.getText(ctx.id())}",
+          s"${modifiers.modifiers.mkString(" ")} interface ${Option(ctx.id()).map(_.getText).getOrElse("")}",
           modifiers.modifiers.mkString(" "),
           modifiers.issues
         )
@@ -128,12 +130,12 @@ class ApexClassVisitor(parser: CodeParser) extends TreeVisitor[ApexNode] {
         new ApexLightNode(
           parser.getPathLocation(parentContext(ctx)),
           ENUM_NATURE,
-          Name(CodeParser.getText(ctx.id())),
+          Name(Option(ctx.id()).map(_.getText).getOrElse("")),
           parser.getPathLocation(ctx.id()).location,
           None,
           visitChildren(ctx),
           modifiers.modifiers,
-          s"${modifiers.modifiers.mkString(" ")} enum ${CodeParser.getText(ctx.id())}",
+          s"${modifiers.modifiers.mkString(" ")} enum ${Option(ctx.id()).map(_.getText).getOrElse("")}",
           modifiers.modifiers.mkString(" "),
           modifiers.issues
         )
@@ -151,7 +153,7 @@ class ApexClassVisitor(parser: CodeParser) extends TreeVisitor[ApexNode] {
     ArraySeq(
       ApexConstructorNode(
         parser.getPathLocation(parentContext(parentContext(ctx))),
-        Name(CodeParser.getText(ctx.qualifiedName())),
+        Name(Option(ctx.qualifiedName()).map(_.getText).getOrElse("")),
         parser.getPathLocation(ctx.qualifiedName()).location,
         ArraySeq(),
         modifiers.modifiers,
@@ -176,12 +178,14 @@ class ApexClassVisitor(parser: CodeParser) extends TreeVisitor[ApexNode] {
     ArraySeq(
       ApexMethodNode(
         parser.getPathLocation(parentContext(parentContext(ctx))),
-        Name(CodeParser.getText(ctx.id())),
+        Name(Option(ctx.id()).map(_.getText).getOrElse("")),
         parser.getPathLocation(ctx.id()).location,
         ArraySeq(),
         modifiers.modifiers,
         modifiers.issues,
-        CodeParser.toScala(ctx.typeRef()).map(CodeParser.getText).getOrElse("void"),
+        Option(ctx.typeRef())
+          .map(x => Option(x).map(_.getText).getOrElse(""))
+          .getOrElse("void"),
         formatFormalParameters(ctx.formalParameters())
       )
     )
@@ -201,12 +205,14 @@ class ApexClassVisitor(parser: CodeParser) extends TreeVisitor[ApexNode] {
     ArraySeq(
       ApexMethodNode(
         parser.getPathLocation(ctx),
-        Name(CodeParser.getText(ctx.id())),
+        Name(Option(ctx.id()).map(_.getText).getOrElse("")),
         parser.getPathLocation(ctx.id()).location,
         ArraySeq(),
         modifiers.modifiers,
         modifiers.issues,
-        CodeParser.toScala(ctx.typeRef()).map(CodeParser.getText).getOrElse("void"),
+        Option(ctx.typeRef())
+          .map(x => Option(x).map(_.getText).getOrElse(""))
+          .getOrElse("void"),
         formatFormalParameters(ctx.formalParameters())
       )
     )
@@ -215,9 +221,7 @@ class ApexClassVisitor(parser: CodeParser) extends TreeVisitor[ApexNode] {
   private def formatFormalParameters(
     ctx: FormalParametersContext
   ): ArraySeq[ApexFormalParameter] = {
-    val params = CodeParser
-      .toScala(ctx.formalParameterList())
-      .toSeq
+    val params = Option(ctx.formalParameterList()).toSeq
       .flatMap(f => CodeParser.toScala(f.formalParameter()))
     ArraySeq.unsafeWrapArray(
       params
@@ -229,8 +233,8 @@ class ApexClassVisitor(parser: CodeParser) extends TreeVisitor[ApexNode] {
           )
           ApexFormalParameter(
             modifiers.modifiers,
-            CodeParser.getText(fp.typeRef()),
-            CodeParser.getText(fp.id()),
+            Option(fp.typeRef()).map(_.getText).getOrElse(""),
+            Option(fp.id()).map(_.getText).getOrElse(""),
             modifiers.issues
           )
         })
@@ -243,7 +247,7 @@ class ApexClassVisitor(parser: CodeParser) extends TreeVisitor[ApexNode] {
     visitChildren: VisitChildren
   ): ArraySeq[ApexNode] = {
     val modifierContext     = classBodyModifierContext(parentContext(parentContext(ctx)))
-    val fieldType           = CodeParser.getText(ctx.typeRef())
+    val fieldType           = Option(ctx.typeRef()).map(_.getText).getOrElse("")
     val variableDeclarators = CodeParser.toScala(ctx.variableDeclarators().variableDeclarator())
     val modifiers = FieldModifiers.fieldModifiers(
       parser,
@@ -257,13 +261,12 @@ class ApexClassVisitor(parser: CodeParser) extends TreeVisitor[ApexNode] {
         new ApexLightNode(
           parser.getPathLocation(modifierContext.enclosing),
           FIELD_NATURE,
-          Name(CodeParser.getText(vd.id())),
+          Name(Option(vd.id()).map(_.getText).getOrElse("")),
           parser.getPathLocation(vd.id()).location,
           None,
           ArraySeq(),
           modifiers.modifiers,
-          s"${appendSpace(modifiers.modifiers.mkString(" "))}$fieldType ${CodeParser
-              .getText(vd.id())}",
+          s"${appendSpace(modifiers.modifiers.mkString(" "))}$fieldType ${Option(vd.id()).map(_.getText).getOrElse("")}",
           s"$fieldType ${modifiers.modifiers.mkString(" ")}",
           modifiers.issues
         )
@@ -273,13 +276,12 @@ class ApexClassVisitor(parser: CodeParser) extends TreeVisitor[ApexNode] {
         new ApexLightNode(
           parser.getPathLocation(vd),
           FIELD_NATURE,
-          Name(CodeParser.getText(vd.id())),
+          Name(Option(vd.id()).map(_.getText).getOrElse("")),
           parser.getPathLocation(vd.id()).location,
           None,
           ArraySeq(),
           modifiers.modifiers,
-          s"${appendSpace(modifiers.modifiers.mkString(" "))}$fieldType ${CodeParser
-              .getText(vd.id())}",
+          s"${appendSpace(modifiers.modifiers.mkString(" "))}$fieldType ${Option(vd.id()).map(_.getText).getOrElse("")}",
           s"$fieldType ${modifiers.modifiers.mkString(" ")}",
           modifiers.issues
         )
@@ -299,18 +301,17 @@ class ApexClassVisitor(parser: CodeParser) extends TreeVisitor[ApexNode] {
         parentStack.size == 1,
         ctx.id()
       )
-    val fieldType = CodeParser.getText(ctx.typeRef())
+    val fieldType = Option(ctx.typeRef()).map(_.getText).getOrElse("")
     ArraySeq(
       new ApexLightNode(
         parser.getPathLocation(modifierContext.enclosing),
         PROPERTY_NATURE,
-        Name(CodeParser.getText(ctx.id())),
+        Name(Option(ctx.id()).map(_.getText).getOrElse("")),
         parser.getPathLocation(ctx.id()).location,
         None,
         ArraySeq(),
         modifiers.modifiers,
-        s"${appendSpace(modifiers.modifiers.mkString(" "))}$fieldType ${CodeParser
-            .getText(ctx.id())}",
+        s"${appendSpace(modifiers.modifiers.mkString(" "))}$fieldType ${Option(ctx.id()).map(_.getText).getOrElse("")}",
         s"$fieldType ${modifiers.modifiers.mkString(" ")}",
         modifiers.issues
       )
@@ -325,11 +326,11 @@ class ApexClassVisitor(parser: CodeParser) extends TreeVisitor[ApexNode] {
       CodeParser
         .toScala(ctx.id())
         .map(id => {
-          val constantName = CodeParser.getText(id)
+          val constantName = Option(id).map(_.getText).getOrElse("")
           new ApexLightNode(
             parser.getPathLocation(id),
             ENUM_CONSTANT_NATURE,
-            Name(CodeParser.getText(id)),
+            Name(Option(id).map(_.getText).getOrElse("")),
             parser.getPathLocation(id).location,
             None,
             ArraySeq.empty,

--- a/jvm/src/main/scala/com/nawforce/runtime/parsers/CodeParser.scala
+++ b/jvm/src/main/scala/com/nawforce/runtime/parsers/CodeParser.scala
@@ -140,17 +140,6 @@ object CodeParser {
     parser.clearCache()
   }
 
-  // Helper for JS Portability
-  def getText(context: ParserRuleContext): String = {
-    Option(context).map(_.getText).getOrElse("")
-  }
-
-  // Helper for JS Portability
-  def getText(context: TerminalNode): String = {
-    Option(context).map(_.getText).getOrElse("")
-  }
-
-  // Helper for JS Portability
   def toScala[T: ClassTag](collection: java.util.List[T]): ArraySeq[T] = {
     collection match {
       case null                    => CodeParser.emptyArraySeq
@@ -158,11 +147,6 @@ object CodeParser {
       case al: util.ArrayList[T]   => ArraySeq.unsafeWrapArray(al.toArray().asInstanceOf[Array[T]])
       case l                       => ArraySeq.unsafeWrapArray(l.asScala.toArray)
     }
-  }
-
-  // Helper for JS Portability
-  def toScala[T](value: T): Option[T] = {
-    Option(value)
   }
 
   private val emptyArraySeq = ArraySeq()

--- a/jvm/src/main/scala/com/nawforce/runtime/parsers/Source.scala
+++ b/jvm/src/main/scala/com/nawforce/runtime/parsers/Source.scala
@@ -65,7 +65,7 @@ case class Source(
   /** Find a location for a rule, adapts based on source offsets to give absolute position in file
     */
   def getLocation(context: ParserRuleContext): PathLocation = {
-    val stop = CodeParser.toScala(context.stop).getOrElse(context.start)
+    val stop = Option(context.stop).getOrElse(context.start)
     PathLocation(
       path,
       adjustLocation(


### PR DESCRIPTION
## Summary

Stage 1 of #449 — mechanical removal of the JS-portability scaffolding that shipped through `CodeParser`. With the JS module slimmed in #446 the wrappers are no longer pulling weight; they just added ceremony to every CST construct method.

- Replaced `CodeParser.toScala(value)` (single-value overload) with `Option(value)` everywhere it was called.
- Replaced `CodeParser.getText(x)` with `Option(x).map(_.getText).getOrElse("")` everywhere it was called.
- Deleted the now-unused single-value `toScala` and both `getText` methods from `CodeParser`.
- Kept the `java.util.List` overload of `toScala` since it does real Java collection conversion work.

No semantic change. Stage 2 (extractor-based pattern matching) is left for opportunistic follow-up as the ticket suggests.

Closes #449 stage 1.

## Test plan

- [x] `sbt clean apexlsJVM/compile` — clean (only pre-existing deprecation warnings)
- [x] `sbt apexlsJVM/test` — all 2393 tests pass
- [x] `sbt scalafmtCheckAll` — clean
- [x] `grep -rn "CodeParser\.toScala\|CodeParser\.getText" jvm/src/main/scala` — only matches are the surviving list-overload `toScala` calls; no `getText` remain