### PR TITLE
refactor: extractor-based pattern matching in CST construction (#449 stage 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded to apex-parser 5.1.0 and the antlr4 4.13 runtime
 - Slimmed the JS module surface to the published apex-ls facades
 - Removed JS-portability shims `CodeParser.toScala(value)` and `CodeParser.getText(...)` from the CST construction layer; call sites now use `Option(...)` directly (#449)
+- Replaced cascading `Option(...).orElse(...)` chains in `Literal.construct` and `ClassBodyDeclaration.construct` with extractor-based pattern matching (#449)
 
 ### Removed
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
@@ -77,6 +77,44 @@ abstract class ClassBodyDeclaration(modifierResults: ModifierResults)
 }
 
 object ClassBodyDeclaration {
+  private object Member {
+    object Method {
+      def unapply(c: MemberDeclarationContext): Option[MethodDeclarationContext] = Option(
+        c.methodDeclaration()
+      )
+    }
+    object Field {
+      def unapply(c: MemberDeclarationContext): Option[FieldDeclarationContext] = Option(
+        c.fieldDeclaration()
+      )
+    }
+    object Constructor {
+      def unapply(c: MemberDeclarationContext): Option[ConstructorDeclarationContext] = Option(
+        c.constructorDeclaration()
+      )
+    }
+    object Interface {
+      def unapply(c: MemberDeclarationContext): Option[InterfaceDeclarationContext] = Option(
+        c.interfaceDeclaration()
+      )
+    }
+    object Enum {
+      def unapply(c: MemberDeclarationContext): Option[EnumDeclarationContext] = Option(
+        c.enumDeclaration()
+      )
+    }
+    object Property {
+      def unapply(c: MemberDeclarationContext): Option[PropertyDeclarationContext] = Option(
+        c.propertyDeclaration()
+      )
+    }
+    object Class {
+      def unapply(c: MemberDeclarationContext): Option[ClassDeclarationContext] = Option(
+        c.classDeclaration()
+      )
+    }
+  }
+
   def construct(
     parser: CodeParser,
     thisType: ThisType,
@@ -87,103 +125,77 @@ object ClassBodyDeclaration {
     memberDeclarationContext: MemberDeclarationContext
   ): Seq[ClassBodyDeclaration] = {
 
-    val declarations: Seq[ClassBodyDeclaration] =
-      Option(memberDeclarationContext.methodDeclaration())
-        .map(x =>
-          Seq(
-            ApexMethodDeclaration.construct(
-              parser,
-              thisType,
-              typeContext,
-              MethodModifiers
-                .classMethodModifiers(parser, modifiers, x.id(), classOwnerInfo, isOuter),
-              x
-            )
+    val declarations: Seq[ClassBodyDeclaration] = memberDeclarationContext match {
+      case Member.Method(x) =>
+        Seq(
+          ApexMethodDeclaration.construct(
+            parser,
+            thisType,
+            typeContext,
+            MethodModifiers
+              .classMethodModifiers(parser, modifiers, x.id(), classOwnerInfo, isOuter),
+            x
           )
         )
-        .orElse(
-          Option(memberDeclarationContext.fieldDeclaration())
-            .map(x =>
-              ApexFieldDeclaration.construct(
-                thisType,
-                FieldModifiers.fieldModifiers(
-                  parser,
-                  modifiers,
-                  isOuter,
-                  CodeParser.toScala(x.variableDeclarators().variableDeclarator()).head.id()
-                ),
-                x
-              )
-            )
+      case Member.Field(x) =>
+        ApexFieldDeclaration.construct(
+          thisType,
+          FieldModifiers.fieldModifiers(
+            parser,
+            modifiers,
+            isOuter,
+            CodeParser.toScala(x.variableDeclarators().variableDeclarator()).head.id()
+          ),
+          x
         )
-        .orElse(
-          Option(memberDeclarationContext.constructorDeclaration())
-            .map(x =>
-              ApexConstructorDeclaration
-                .construct(
-                  parser,
-                  thisType,
-                  typeContext,
-                  ApexModifiers.constructorModifiers(parser, modifiers, x),
-                  x
-                )
-                .toSeq
-            )
+      case Member.Constructor(x) =>
+        ApexConstructorDeclaration
+          .construct(
+            parser,
+            thisType,
+            typeContext,
+            ApexModifiers.constructorModifiers(parser, modifiers, x),
+            x
+          )
+          .toSeq
+      case Member.Interface(x) =>
+        Seq(
+          InterfaceDeclaration.constructInner(
+            parser,
+            thisType,
+            ApexModifiers.interfaceModifiers(parser, modifiers, outer = false, x.id()),
+            x
+          )
         )
-        .orElse(
-          Option(memberDeclarationContext.interfaceDeclaration())
-            .map(x =>
-              Seq(
-                InterfaceDeclaration.constructInner(
-                  parser,
-                  thisType,
-                  ApexModifiers.interfaceModifiers(parser, modifiers, outer = false, x.id()),
-                  x
-                )
-              )
-            )
+      case Member.Enum(x) =>
+        Seq(
+          EnumDeclaration.constructInner(
+            parser,
+            thisType,
+            ApexModifiers.enumModifiers(parser, modifiers, outer = false, x.id()),
+            x
+          )
         )
-        .orElse(
-          Option(memberDeclarationContext.enumDeclaration())
-            .map(x =>
-              Seq(
-                EnumDeclaration.constructInner(
-                  parser,
-                  thisType,
-                  ApexModifiers.enumModifiers(parser, modifiers, outer = false, x.id()),
-                  x
-                )
-              )
-            )
+      case Member.Property(x) =>
+        Seq(
+          ApexPropertyDeclaration.construct(
+            parser,
+            thisType,
+            FieldModifiers.fieldModifiers(parser, modifiers, isOuter, x.id()),
+            x
+          )
         )
-        .orElse(
-          Option(memberDeclarationContext.propertyDeclaration())
-            .map(x =>
-              Seq(
-                ApexPropertyDeclaration
-                  .construct(
-                    parser,
-                    thisType,
-                    FieldModifiers.fieldModifiers(parser, modifiers, isOuter, x.id()),
-                    x
-                  )
-              )
-            )
+      case Member.Class(x) =>
+        Seq(
+          ClassDeclaration.constructInner(
+            parser,
+            thisType,
+            ApexModifiers.classModifiers(parser, modifiers, outer = false, x.id()),
+            x
+          )
         )
-        .orElse(
-          Option(memberDeclarationContext.classDeclaration())
-            .map(x =>
-              Seq(
-                ClassDeclaration.constructInner(
-                  parser,
-                  thisType,
-                  ApexModifiers.classModifiers(parser, modifiers, outer = false, x.id()),
-                  x
-                )
-              )
-            )
-        )
-        .getOrElse(Seq())
+      case _ => Seq()
+    }
 
     declarations.map(_.withContext(memberDeclarationContext))
   }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Literals.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Literals.scala
@@ -19,7 +19,6 @@ import com.nawforce.apexlink.types.core.TypeDeclaration
 import com.nawforce.apexlink.types.platform.PlatformTypes
 import com.nawforce.pkgforce.names.Name
 import com.nawforce.pkgforce.path.PathLocation
-import com.nawforce.runtime.parsers.CodeParser
 import io.github.apexdevtools.apexparser.ApexParser.LiteralContext
 
 sealed abstract class Literal {
@@ -146,26 +145,26 @@ object DoubleOrDecimalLiteral {
 }
 
 object Literal {
-  def construct(from: LiteralContext): Literal = {
-    Option(from.IntegerLiteral())
-      .map(_ => IntegerOrLongLiteral(from))
-      .orElse(
-        Option(from.LongLiteral())
-          .map(_ => IntegerOrLongLiteral(from))
-      )
-      .orElse(
-        Option(from.NumberLiteral())
-          .map(_ => DoubleOrDecimalLiteral(from))
-      )
-      .orElse(
-        Option(from.StringLiteral())
-          .map(x => StringLiteral(Option(x).map(_.getText).getOrElse("")))
-      )
-      .orElse(
-        Option(from.MultilineStringLiteral())
-          .map(x => StringLiteral(Option(x).map(_.getText).getOrElse("")))
-      )
-      .orElse(Option(from.BooleanLiteral()).map(_ => BooleanLiteral))
-      .getOrElse(NullLiteral)
+  private object Lit {
+    object Int    { def unapply(c: LiteralContext): Boolean = c.IntegerLiteral() != null }
+    object Long   { def unapply(c: LiteralContext): Boolean = c.LongLiteral() != null    }
+    object Number { def unapply(c: LiteralContext): Boolean = c.NumberLiteral() != null  }
+    object Str {
+      def unapply(c: LiteralContext): Option[String] = Option(c.StringLiteral()).map(_.getText)
+    }
+    object MultiStr {
+      def unapply(c: LiteralContext): Option[String] =
+        Option(c.MultilineStringLiteral()).map(_.getText)
+    }
+    object Bool { def unapply(c: LiteralContext): Boolean = c.BooleanLiteral() != null }
+  }
+
+  def construct(from: LiteralContext): Literal = from match {
+    case Lit.Int() | Lit.Long() => IntegerOrLongLiteral(from)
+    case Lit.Number()           => DoubleOrDecimalLiteral(from)
+    case Lit.Str(s)             => StringLiteral(s)
+    case Lit.MultiStr(s)        => StringLiteral(s)
+    case Lit.Bool()             => BooleanLiteral
+    case _                      => NullLiteral
   }
 }


### PR DESCRIPTION
## Summary

Stage 2 of #449. Replaces cascading `Option(...).orElse(...)` chains in two CST construction sites with extractor-based pattern matching, giving a single flat `match` per grammar-alternative dispatch.

- `Literal.construct` — 6 alternatives (Int/Long/Number/Str/MultiStr/Bool)
- `ClassBodyDeclaration.construct` — 7 alternatives (Method/Field/Constructor/Interface/Enum/Property/Class)

Each grammar alternative gets a small `unapply` extractor that returns `Boolean` (presence check) or `Option[X]` (when the matched node is consumed downstream).

> Stacked on #452 (stage 1). Merge stage 1 first; this PR will retarget to `main` automatically.

## Test plan

- [x] `sbt scalafmtCheckAll` clean
- [x] `sbt apexlsJVM/test` — all 2393 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)