### PR TITLE
fix: suppress cascading syntax errors in method bodies (#422)

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
@@ -37,6 +37,9 @@ abstract class Statement extends CST with ControlFlow {
   def verify(context: ScopeVerifyContext): Unit
 }
 
+/** Errors collected when parsing a block on-demand failed. */
+final case class ParseErrors(issues: ArraySeq[Issue])
+
 /** Block of statements, nesting uses a Block as a Statement.
   *
   * There are two types of Block, an Outer which can use lazy loading and an Inner which does not. The OuterBlock
@@ -45,7 +48,21 @@ abstract class Statement extends CST with ControlFlow {
   * need to use.
   */
 abstract class Block extends Statement {
+
+  /** Statements in the block. Returns an empty Seq if parsing failed; callers that need to
+    * distinguish parse-failure from a genuinely-empty block should use [[statementsOrErrors]].
+    */
   def statements(context: Option[ScopeVerifyContext] = None): Seq[Statement]
+
+  /** Statements in the block, or the parse errors that prevented them being built.
+    *
+    * `Right(stmts)` — parsing succeeded; callers can verify or otherwise consume the statements.
+    * `Left(errors)` — parsing failed; the syntax errors have already been logged to `context`,
+    * but the AST is unreliable so callers should not run downstream analysis.
+    */
+  def statementsOrErrors(
+    context: Option[ScopeVerifyContext] = None
+  ): Either[ParseErrors, Seq[Statement]]
 }
 
 object Block {
@@ -114,11 +131,17 @@ private final case class OuterBlock(
 ) extends Block {
   private var statementsRef: WeakReference[Seq[Statement]] = _
   private var reParsed                                     = false
+  // Sticky once a parse fails; reset on each re-parse so re-validation reflects current source.
+  private var parseErrors: ArraySeq[Issue] = ArraySeq.empty
 
   override def verify(context: ScopeVerifyContext): Unit = {
     val blockContext = new InnerScopeVerifyContext(context)
     statements(Some(blockContext)).foreach(_.verify(blockContext))
-    verifyControlPath(blockContext, BlockControlPattern())
+    // Skip control-flow analysis on a parse failure: it walks a partial AST and
+    // reliably emits spurious "Expected return statement"/"Method does not return"
+    // errors on top of the real syntax error.
+    if (parseErrors.isEmpty)
+      verifyControlPath(blockContext, BlockControlPattern())
     context.typePlugin.foreach(_.onScopeValidated(context.isStatic, blockContext))
   }
 
@@ -138,6 +161,9 @@ private final case class OuterBlock(
         // otherwise we need to re-parse on subsequent validations to re-report the errors
         if (result.issues.isEmpty) {
           blockContextRef = new WeakReference(statementContext)
+          parseErrors = ArraySeq.empty
+        } else {
+          parseErrors = result.issues
         }
         reParsed = true
       }
@@ -152,6 +178,13 @@ private final case class OuterBlock(
       }
     }
     statements
+  }
+
+  override def statementsOrErrors(
+    context: Option[ScopeVerifyContext] = None
+  ): Either[ParseErrors, Seq[Statement]] = {
+    val stmts = statements(context)
+    if (parseErrors.nonEmpty) Left(ParseErrors(parseErrors)) else Right(stmts)
   }
 
   // Construct statements from ANTLR AST
@@ -177,6 +210,10 @@ private final case class StatementBlock(statements: Seq[Statement]) extends Bloc
   }
 
   override def statements(context: Option[ScopeVerifyContext] = None): Seq[Statement] = statements
+
+  override def statementsOrErrors(
+    context: Option[ScopeVerifyContext] = None
+  ): Either[ParseErrors, Seq[Statement]] = Right(statements)
 }
 
 final case class LocalVariableDeclarationStatement(

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
@@ -49,16 +49,16 @@ final case class ParseErrors(issues: ArraySeq[Issue])
   */
 abstract class Block extends Statement {
 
-  /** Statements in the block. Returns an empty Seq if parsing failed; callers that need to
-    * distinguish parse-failure from a genuinely-empty block should use [[statementsOrErrors]].
+  /** Statements in the block. Returns best-effort statements if parsing failed; callers that need
+    * to distinguish parse-failure from a genuinely-empty block should use [[statementsOrErrors]].
     */
   def statements(context: Option[ScopeVerifyContext] = None): Seq[Statement]
 
-  /** Statements in the block, or the parse errors that prevented them being built.
+  /** Statements in the block, or the parse errors encountered while building them.
     *
     * `Right(stmts)` — parsing succeeded; callers can verify or otherwise consume the statements.
-    * `Left(errors)` — parsing failed; the syntax errors have already been logged to `context`,
-    * but the AST is unreliable so callers should not run downstream analysis.
+    * `Left(errors)` — parsing failed; the syntax errors have been logged when a context was
+    * supplied, but the AST is unreliable so callers should not run downstream analysis.
     */
   def statementsOrErrors(
     context: Option[ScopeVerifyContext] = None

--- a/jvm/src/main/scala/com/nawforce/runtime/parsers/CollectingErrorListener.scala
+++ b/jvm/src/main/scala/com/nawforce/runtime/parsers/CollectingErrorListener.scala
@@ -50,9 +50,31 @@ class CollectingErrorListener(path: PathLike) extends BaseErrorListener {
         malformedMultilineStringMessage(recognizer, offendingSymbol).getOrElse(msg)
     }
 
-    _issues.addOne(
-      new Issue(path, Diagnostic(SYNTAX_CATEGORY, Location(line, charPositionInLine), improvedMsg))
-    )
+    // Drop syntax errors that are recovery noise from an earlier error on the same line.
+    // ANTLR's lexer recovery frequently emits cascading diagnostics at adjacent columns
+    // (e.g. an invalid escape \s reports first at the backslash, then again at the closing
+    // quote of the same string once recovery re-enters string lexing).
+    if (!isRecoveryNoise(line, improvedMsg)) {
+      _issues.addOne(
+        new Issue(
+          path,
+          Diagnostic(SYNTAX_CATEGORY, Location(line, charPositionInLine), improvedMsg)
+        )
+      )
+    }
+  }
+
+  private def isRecoveryNoise(line: Int, message: String): Boolean = {
+    if (_issues.isEmpty) false
+    else {
+      val previous = _issues.last.diagnostic
+      // Only collapse the typical "invalid escape" recovery cascade where one bad escape
+      // in a string produces multiple diagnostics at neighbouring columns. Other same-line
+      // duplicates (e.g. two genuine "missing ';'" errors on a one-line class) are kept.
+      previous.location.startLine == line &&
+      previous.message.startsWith("Invalid escape sequence") &&
+      message.startsWith("Invalid escape sequence")
+    }
   }
 
   // Detect the `'''abc'''` / `''''''` shape — three textually adjacent StringLiteral

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/BlockTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/BlockTest.scala
@@ -102,4 +102,91 @@ class BlockTest extends AnyFunSuite with Matchers with TestHelper {
     }
   }
 
+  test("Method body parse failure does not cascade to 'Expected return statement'") {
+    typeDeclaration("""public class Dummy {
+        |  public String getFields() {
+        |    String a = '\s';
+        |    return a;
+        |  }
+        |}""".stripMargin)
+    val issues = dummyIssues
+    // Phase 1: spurious control-flow error from partial AST is suppressed.
+    assert(!issues.contains("Expected return statement"))
+    assert(!issues.contains("Code path does not return"))
+    assert(!issues.contains("Method does not return"))
+    // The lexer diagnostic is still reported.
+    assert(issues.contains("Invalid escape sequence '\\s' in string"))
+  }
+
+  test("Successful method body parse still verifies control flow") {
+    // Regression guard for Phase 1: a method that legitimately falls off the end
+    // (without a syntax error) must still be flagged.
+    typeDeclaration("""public class Dummy {
+        |  public String getFields() {
+        |  }
+        |}""".stripMargin)
+    assert(dummyIssues.contains("Method does not return a value"))
+  }
+
+  test("OuterBlock.statementsOrErrors returns Left on parse failure") {
+    FileSystemHelper.run(
+      Map(
+        "Dummy.cls" ->
+          """public class Dummy {
+            |  public void m() {
+            |    String a = '\s';
+            |  }
+            |}""".stripMargin
+      )
+    ) { root: PathLike =>
+      createOrg(root)
+      val td = unmanagedClass("Dummy").get
+      val block =
+        td.methods.find(_.name.value == "m").get.asInstanceOf[ApexMethodDeclaration].block.get
+      block.statementsOrErrors() match {
+        case Left(ParseErrors(issues)) =>
+          assert(issues.nonEmpty)
+          assert(issues.exists(_.diagnostic.message.contains("Invalid escape sequence '\\s'")))
+        case Right(_) =>
+          fail("expected Left(ParseErrors) for a method body with a syntax error")
+      }
+    }
+  }
+
+  test("OuterBlock.statementsOrErrors returns Right when parse succeeds") {
+    FileSystemHelper.run(
+      Map(
+        "Dummy.cls" ->
+          """public class Dummy {
+            |  public void m() {
+            |    Integer x = 1;
+            |  }
+            |}""".stripMargin
+      )
+    ) { root: PathLike =>
+      createHappyOrg(root)
+      val td = unmanagedClass("Dummy").get
+      val block =
+        td.methods.find(_.name.value == "m").get.asInstanceOf[ApexMethodDeclaration].block.get
+      block.statementsOrErrors() match {
+        case Right(stmts) => assert(stmts.size == 1)
+        case Left(_)      => fail("expected Right for a well-formed method body")
+      }
+    }
+  }
+
+  test("Cascading lexer recovery errors on same line are collapsed") {
+    typeDeclaration("""public class Dummy {
+        |  public void m() {
+        |    String a = '\s';
+        |  }
+        |}""".stripMargin)
+    val escapeErrors = dummyIssues
+      .split("\n")
+      .count(_.contains("Invalid escape sequence"))
+    // Without the cluster suppression, the lexer reports the same escape error twice
+    // on this line as recovery re-enters the string.
+    assert(escapeErrors == 1, s"expected a single escape error, got:\n${dummyIssues}")
+  }
+
 }

--- a/jvm/src/test/scala/com/nawforce/apexlink/types/ValidationMapFallbackTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/types/ValidationMapFallbackTest.scala
@@ -5,7 +5,9 @@ import com.nawforce.apexlink.cst.{
   Block,
   BodyDeclarationVerifyContext,
   ClassBodyDeclaration,
-  ScopeVerifyContext
+  ParseErrors,
+  ScopeVerifyContext,
+  Statement
 }
 import com.nawforce.apexlink.cst.{ClassDeclaration => CSTClassDeclaration}
 import com.nawforce.apexlink.types.apex.TriggerDeclaration
@@ -53,6 +55,10 @@ class ValidationMapFallbackTest extends AnyFunSuite with TestHelper {
     private var _verifyCount: Int = 0
 
     override def statements(context: Option[ScopeVerifyContext]): Seq[Nothing] = Seq.empty
+
+    override def statementsOrErrors(
+      context: Option[ScopeVerifyContext]
+    ): Either[ParseErrors, Seq[Statement]] = Right(Seq.empty)
 
     override def verify(context: ScopeVerifyContext): Unit = {
       _verifyCount += 1


### PR DESCRIPTION
## Summary

Fixes #422.

When a method body fails to parse (e.g. an invalid escape `'\s'` in a string), ANTLR's recovery produced a noisy cluster of diagnostics on top of the original error:

- the lexer reported the bad escape **twice** — once at the backslash, again at the closing quote when recovery re-entered the string
- control-flow analysis ran on the partial AST and emitted a **spurious** `Expected return statement` / `Method does not return a value`

Both are now suppressed. Example: a class with a single `'\s'` invalid escape used to report 4 diagnostics; it now reports a single `Invalid escape sequence '\s' in string`.

## Changes

- **`OuterBlock`** tracks whether its on-demand block parse produced issues. `verify()` still runs per-statement verification on the salvaged AST so downstream features (rename, navigation, references) keep working — only `verifyControlPath` is skipped on parse failure.
- **`statementsOrErrors()`** is a new sibling to `statements()` returning `Either[ParseErrors, Seq[Statement]]` for callers that want to distinguish a parse failure from a genuinely empty block. `statements()` retains its existing best-effort `Seq` behaviour, so existing call-sites are unaffected.
- **`CollectingErrorListener`** collapses adjacent `Invalid escape sequence` diagnostics on the same line — the typical lexer-recovery cascade — while leaving unrelated same-line errors (e.g. two genuine missing `;` errors) untouched.

## Test plan

- [x] New `BlockTest` cases cover:
  - the cascade no longer emits `Expected return statement` / `Code path does not return` / `Method does not return`
  - a successful parse still verifies control flow (regression guard)
  - `statementsOrErrors` returns `Left(ParseErrors)` on failure, `Right(stmts)` on success
  - the duplicate `Invalid escape sequence` diagnostic is collapsed
- [x] Full JVM test suite passes (2398 tests)
- [x] JS cross-build compiles cleanly
- [x] `sbt scalafmtCheckAll` clean