### PR TITLE
fix: shorten verbose EOF parser diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,12 @@ This guide applies to all changes in the repository unless a more specific `AGEN
 
 ## Testing
 - Run `sbt test` for Scala/JVM/JS changes when feasible.
+- For sample-project regression tests, use the sibling `../apex-samples` checkout:
+  1. Build the JVM distribution/classpath first: `sbt apexlsJVM/build`
+  2. Run samples from the npm package directory:
+     `cd js/npm && SAMPLES=$(cd ../../../apex-samples && pwd) npm run test-samples -- --runInBand`
+  3. If snapshot changes are expected, update with:
+     `cd js/npm && SAMPLES=$(cd ../../../apex-samples && pwd) npm run test-snapshot -- --runInBand`
 - Document any skipped or partial test coverage in the PR if full test suite is impractical.
 
 ## Git & PR Etiquette

--- a/jvm/src/main/scala/com/nawforce/runtime/parsers/CollectingErrorListener.scala
+++ b/jvm/src/main/scala/com/nawforce/runtime/parsers/CollectingErrorListener.scala
@@ -27,6 +27,9 @@ class CollectingErrorListener(path: PathLike) extends BaseErrorListener {
   // Pattern to match lexer "token recognition error" messages containing escape sequences
   private val tokenErrorPattern = """token recognition error at: '(.*)'""".r
   private val escapePattern     = """.*(\\.).*""".r
+  private val verboseEofPattern = """mismatched input '<EOF>' expecting \{.*""".r
+
+  private final val MaxUsefulEofMessageLength = 160
 
   override def syntaxError(
     recognizer: Recognizer[_, _],
@@ -47,7 +50,9 @@ class CollectingErrorListener(path: PathLike) extends BaseErrorListener {
           case _ => msg
         }
       case _ =>
-        malformedMultilineStringMessage(recognizer, offendingSymbol).getOrElse(msg)
+        malformedMultilineStringMessage(recognizer, offendingSymbol)
+          .orElse(conciseEofMessage(msg))
+          .getOrElse(msg)
     }
 
     // Drop syntax errors that are recovery noise from an earlier error on the same line.
@@ -61,6 +66,14 @@ class CollectingErrorListener(path: PathLike) extends BaseErrorListener {
           Diagnostic(SYNTAX_CATEGORY, Location(line, charPositionInLine), improvedMsg)
         )
       )
+    }
+  }
+
+  private def conciseEofMessage(message: String): Option[String] = {
+    message match {
+      case verboseEofPattern() if message.length > MaxUsefulEofMessageLength =>
+        Some("Unexpected end of input")
+      case _ => None
     }
   }
 

--- a/jvm/src/test/scala/com/nawforce/apexlink/pkg/RefreshTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/pkg/RefreshTest.scala
@@ -257,8 +257,8 @@ class RefreshTest extends AnyFunSuite with TestHelper {
 
         assert(org.flush())
         assert(
-          getMessages(root.join("Dummy.cls"))
-            .startsWith("Syntax: line 1 at 20: mismatched input '<EOF>' expecting {")
+          getMessages(root.join("Dummy.cls")) ==
+            "Syntax: line 1 at 20: Unexpected end of input\n"
         )
       }
     }

--- a/jvm/src/test/scala/com/nawforce/pkgforce/parsers/CodeParserTest.scala
+++ b/jvm/src/test/scala/com/nawforce/pkgforce/parsers/CodeParserTest.scala
@@ -46,7 +46,18 @@ class CodeParserTest extends AnyFunSuite {
     val result = cp.parseClass()
     assert(result.issues.length == 1)
     assert(result.issues.head.diagnostic.location.displayPosition == "line 1 at 20")
-    assert(result.issues.head.diagnostic.message.startsWith("mismatched input '<EOF>' expecting {"))
+    assert(result.issues.head.diagnostic.message == "Unexpected end of input")
+  }
+
+  test("Short EOF expected-token messages are preserved") {
+    val path   = Path("Dummy.cls")
+    val cp     = CodeParser(path, SourceData("public class Dummy"))
+    val result = cp.parseClass()
+    assert(result.issues.length == 1)
+    assert(
+      result.issues.head.diagnostic.message ==
+        "mismatched input '<EOF>' expecting {'extends', 'implements', '{'}"
+    )
   }
 
   test("Class multiple errors") {
@@ -82,6 +93,6 @@ class CodeParserTest extends AnyFunSuite {
     assert(result.issues.length == 1)
     // The surrogate pair should only count as 1 unicode code point
     assert(result.issues.head.diagnostic.location.displayPosition == "line 1 at 34")
-    assert(result.issues.head.diagnostic.message.startsWith("mismatched input '<EOF>' expecting {"))
+    assert(result.issues.head.diagnostic.message == "Unexpected end of input")
   }
 }

--- a/jvm/src/test/scala/com/nawforce/pkgforce/parsers/SOQLParserTest.scala
+++ b/jvm/src/test/scala/com/nawforce/pkgforce/parsers/SOQLParserTest.scala
@@ -37,15 +37,13 @@ class SOQLParserTest extends AnyFunSuite with Matchers {
 
   test("Missing fields") {
     SOQLParser.parse("select") should matchPattern {
-      case Left(Seq(SOQLParser.ParserIssue(1, 6, err)))
-          if err.startsWith("mismatched input '<EOF>' expecting {") =>
+      case Left(Seq(SOQLParser.ParserIssue(1, 6, "Unexpected end of input"))) =>
     }
   }
 
   test("Missing from") {
     SOQLParser.parse("select A") should matchPattern {
-      case Left(Seq(SOQLParser.ParserIssue(1, 8, err)))
-          if err.startsWith("mismatched input '<EOF>' expecting {") =>
+      case Left(Seq(SOQLParser.ParserIssue(1, 8, "Unexpected end of input"))) =>
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #457.

Rewrites very verbose ANTLR EOF diagnostics such as:

```text
mismatched input '<EOF>' expecting {...hundreds of tokens...}
```

to:

```text
Unexpected end of input
```

Short EOF diagnostics are preserved because their limited expected-token sets are useful to users, e.g.:

```text
mismatched input '<EOF>' expecting {'extends', 'implements', '{'}
```

## Changes

- Add concise EOF-message rewriting in `CollectingErrorListener` only for brace-list EOF messages longer than the useful-message threshold.
- Update Apex/SOQL/refresh parser tests for shortened verbose EOF diagnostics.
- Add regression coverage that short EOF expected-token messages are left unchanged.

## Test plan

- [x] `sbt -error scalafmtAll "apexlsJVM/testOnly com.nawforce.pkgforce.parsers.CodeParserTest com.nawforce.pkgforce.parsers.SOQLParserTest com.nawforce.pkgforce.parsers.VFParserTest com.nawforce.apexlink.pkg.RefreshTest com.nawforce.apexlink.types.ComponentTest com.nawforce.apexlink.org.IssueManagerTest com.nawforce.apexlink.analysis.OrgAnalysisTest"`
- [x] Manual `CheckForIssues` repro for invalid escape + EOF cascade
- [x] `sbt -error apexlsJVM/build`
- [x] `cd js/npm && SAMPLES=$(cd ../../../apex-samples && pwd) npm run test-samples -- --runInBand`

Sample snapshot check passed without recorded output changes.