### PR TITLE
fix: inherit interface method visibility

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeDeclarations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeDeclarations.scala
@@ -247,7 +247,8 @@ object InterfaceDeclaration {
               MethodModifiers.interfaceMethodModifiers(
                 parser,
                 CodeParser.toScala(method.modifier()),
-                method.id()
+                method.id(),
+                InterfaceOwnerInfo(modifiers.modifiers)
               ),
               method
             )

--- a/jvm/src/main/scala/com/nawforce/apexlink/opcst/TypeDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/opcst/TypeDeclaration.scala
@@ -40,7 +40,12 @@ import com.nawforce.apexlink.finding.{RelativeTypeContext, RelativeTypeName}
 import com.nawforce.apexlink.names.TypeNames
 import com.nawforce.apexlink.org.OrgInfo
 import com.nawforce.apexlink.types.apex.ThisType
-import com.nawforce.pkgforce.modifiers.{ClassOwnerInfo, FINAL_MODIFIER, ModifierResults}
+import com.nawforce.pkgforce.modifiers.{
+  ClassOwnerInfo,
+  FINAL_MODIFIER,
+  InterfaceOwnerInfo,
+  ModifierResults
+}
 import com.nawforce.pkgforce.names.{Names, TypeName}
 import com.nawforce.pkgforce.path.PathLike
 import com.nawforce.runtime.parsers.{CodeParser, Source, SourceData}
@@ -235,8 +240,14 @@ private[opcst] object OutlineParserInterfaceDeclaration {
     val id          = OutlineParserId.construct(itd.id, source.path)
 
     val methods = itd.methods.flatMap(m =>
-      OutlineParserClassBodyDeclaration
-        .constructInterfaceMethodDeclaration(path, m, source, typeContext, thisType)
+      OutlineParserClassBodyDeclaration.constructInterfaceMethodDeclaration(
+        path,
+        m,
+        source,
+        typeContext,
+        InterfaceOwnerInfo(modifierResults.modifiers),
+        thisType
+      )
     )
 
     val declaration = InterfaceDeclaration(
@@ -454,10 +465,12 @@ private[opcst] object OutlineParserClassBodyDeclaration {
     md: OPMethodDeclaration,
     source: Source,
     typeContext: RelativeTypeContext,
+    ownerInfo: InterfaceOwnerInfo,
     thisType: ThisType
   ): Option[ClassBodyDeclaration] = {
 
-    val modifierResults = interfaceMethodModifiers(path, md.id, md.annotations, md.modifiers)
+    val modifierResults =
+      interfaceMethodModifiers(path, md.id, md.annotations, md.modifiers, ownerInfo)
 
     val parameters = md.formalParameters
       .flatMap(OutlineParserFormalParameter.construct(path, _, source, typeContext))

--- a/jvm/src/main/scala/com/nawforce/pkgforce/modifiers/MethodModifiers.scala
+++ b/jvm/src/main/scala/com/nawforce/pkgforce/modifiers/MethodModifiers.scala
@@ -26,8 +26,8 @@ import io.github.apexdevtools.apexparser.ApexParser.ModifierContext
 import scala.collection.compat.immutable.ArraySeq
 
 sealed abstract class MethodOwnerInfo
-case object InterfaceOwnerInfo extends MethodOwnerInfo
-case object EnumOwnerInfo      extends MethodOwnerInfo
+case class InterfaceOwnerInfo(modifiers: ArraySeq[Modifier]) extends MethodOwnerInfo
+case object EnumOwnerInfo                                    extends MethodOwnerInfo
 case class ClassOwnerInfo(modifiers: ArraySeq[Modifier], isExtending: Boolean)
     extends MethodOwnerInfo
 
@@ -190,17 +190,19 @@ object MethodModifiers {
   def interfaceMethodModifiers(
     parser: CodeParser,
     modifierContexts: ArraySeq[ModifierContext],
-    context: ParserRuleContext
+    context: ParserRuleContext,
+    ownerInfo: InterfaceOwnerInfo
   ): ModifierResults = {
     val logger = new ModifierLogger()
     val mods   = toModifiers(parser, modifierContexts)
-    interfaceMethodModifiers(logger, mods, LogEntryContext(parser, context))
+    interfaceMethodModifiers(logger, mods, LogEntryContext(parser, context), ownerInfo)
   }
 
   def interfaceMethodModifiers(
     logger: ModifierLogger,
     modifiers: ArraySeq[(Modifier, LogEntryContext, String)],
-    context: LogEntryContext
+    context: LogEntryContext,
+    ownerInfo: InterfaceOwnerInfo
   ): ModifierResults = {
 
     val allowedModifiers = allowableModifiers(modifiers, Set.empty, "interface methods", logger)
@@ -212,6 +214,11 @@ object MethodModifiers {
       context
     )
 
-    ModifierResults(mods ++ ArraySeq(VIRTUAL_MODIFIER, PUBLIC_MODIFIER), logger.issues).intern
+    val interfaceVisibility = ownerInfo.modifiers
+      .intersect(visibilityModifiers)
+      .headOption
+      .getOrElse(PUBLIC_MODIFIER)
+
+    ModifierResults(mods ++ ArraySeq(VIRTUAL_MODIFIER, interfaceVisibility), logger.issues).intern
   }
 }

--- a/jvm/src/main/scala/com/nawforce/pkgforce/parsers/ApexClassVisitor.scala
+++ b/jvm/src/main/scala/com/nawforce/pkgforce/parsers/ApexClassVisitor.scala
@@ -95,10 +95,11 @@ class ApexClassVisitor(parser: CodeParser) extends TreeVisitor[ApexNode] {
   ): ArraySeq[ApexNode] = {
     val isOuter = parentStack.isEmpty
 
-    wrapParentStack(InterfaceOwnerInfo) {
-      val modifierContext = getModifierContext(parentContext(ctx))
-      val modifiers =
-        ApexModifiers.interfaceModifiers(parser, modifierContext.modifiers, isOuter, ctx.id())
+    val modifierContext = getModifierContext(parentContext(ctx))
+    val modifiers =
+      ApexModifiers.interfaceModifiers(parser, modifierContext.modifiers, isOuter, ctx.id())
+
+    wrapParentStack(InterfaceOwnerInfo(modifiers.modifiers)) {
       ArraySeq(
         new ApexLightNode(
           parser.getPathLocation(parentContext(ctx)),
@@ -199,7 +200,8 @@ class ApexClassVisitor(parser: CodeParser) extends TreeVisitor[ApexNode] {
       MethodModifiers.interfaceMethodModifiers(
         parser,
         ArraySeq.from(CodeParser.toScala(ctx.modifier())),
-        ctx.id()
+        ctx.id(),
+        parentStack.head.asInstanceOf[InterfaceOwnerInfo]
       )
 
     ArraySeq(

--- a/jvm/src/main/scala/com/nawforce/runtime/platform/OutlineParserModifierOps.scala
+++ b/jvm/src/main/scala/com/nawforce/runtime/platform/OutlineParserModifierOps.scala
@@ -146,11 +146,17 @@ object OutlineParserModifierOps {
     path: PathLike,
     id: OPId,
     annotations: Array[OPAnnotation],
-    src: Array[OPModifier]
+    src: Array[OPModifier],
+    ownerInfo: InterfaceOwnerInfo
   ): ModifierResults = {
     val logger = new ModifierLogger()
     val mods   = toModifiers(path, id.location, annotations, src)
-    MethodModifiers.interfaceMethodModifiers(logger, mods, OPLogEntryContext(path, id.location))
+    MethodModifiers.interfaceMethodModifiers(
+      logger,
+      mods,
+      OPLogEntryContext(path, id.location),
+      ownerInfo
+    )
   }
 
   def initializerBlockModifiers(isStatic: Boolean): ModifierResults =

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/InterfaceModifierTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/InterfaceModifierTest.scala
@@ -176,6 +176,20 @@ class InterfaceModifierTest extends AnyFunSuite with TestHelper {
     )
   }
 
+  test("Global interface methods inherit global visibility") {
+    val method = typeDeclaration("global interface Dummy {String foo();}").methods.head
+    assert(method.modifiers contains GLOBAL_MODIFIER)
+    assert(!(method.modifiers contains PUBLIC_MODIFIER))
+    assert(!hasIssues)
+  }
+
+  test("Public interface methods inherit public visibility") {
+    val method = typeDeclaration("public interface Dummy {String foo();}").methods.head
+    assert(method.modifiers contains PUBLIC_MODIFIER)
+    assert(!(method.modifiers contains GLOBAL_MODIFIER))
+    assert(!hasIssues)
+  }
+
   test("Illegal method modifier") {
     typeDeclaration("global interface Dummy {public void foo();}")
     assert(

--- a/jvm/src/test/scala/com/nawforce/apexlink/plugin/UnusedTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/plugin/UnusedTest.scala
@@ -440,6 +440,33 @@ class UnusedTest extends AnyFunSuite with TestHelper {
     }
   }
 
+  test("Global interface method is not flagged as unused") {
+    FileSystemHelper.run(
+      Map(
+        "Dummy.cls" -> "global interface Dummy {String selectOrganization();}",
+        "Foo.cls"   -> "public class Foo{ {Type t = Dummy.class;} }"
+      )
+    ) { root: PathLike =>
+      val org = createOrgWithUnused(root)
+      assert(orgIssuesFor(org, root.join("Dummy.cls")).isEmpty)
+    }
+  }
+
+  test("Public interface method can be flagged as unused") {
+    FileSystemHelper.run(
+      Map(
+        "Dummy.cls" -> "public interface Dummy {String selectOrganization();}",
+        "Foo.cls"   -> "public class Foo{ {Type t = Dummy.class;} }"
+      )
+    ) { root: PathLike =>
+      val org = createOrgWithUnused(root)
+      assert(
+        orgIssuesFor(org, root.join("Dummy.cls")) ==
+          "Unused: line 1 at 31-49: Unused public method 'System.String selectOrganization()'\n"
+      )
+    }
+  }
+
   test("Unused interface") {
     FileSystemHelper.run(Map("Dummy.cls" -> "public interface Dummy {void func();}")) {
       root: PathLike =>


### PR DESCRIPTION
## Summary

Fixes #405.

Interface methods now inherit the visibility of their containing interface instead of always being treated as public. This prevents methods declared on `global interface` types from being reported as unused public methods.

## Changes

- Change `InterfaceOwnerInfo` to carry interface modifiers.
- Pass interface owner modifiers through CST, OutlineParser, and ApexClassVisitor paths.
- Apply the containing interface visibility when constructing interface method modifiers, defaulting to public when no explicit interface visibility is present.
- Add coverage for global/public interface method modifier inheritance and unused analysis behavior.

## Test plan

- [ ] `sbt scalafmtAll` / targeted tests not run locally: the harness is currently blocked from opening sbt/ivy lock files under `~/.sbt` / `~/.ivy2` (`Operation not permitted`).