### PR TITLE
fix: guide public static unused entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Unused warnings for public static methods now call out their static nature and explain how to document intentional external entry points (#406)
 - Unused warnings for virtual/override method hierarchies now include context when all related overrides are unused (#403)
 - Global interface methods now inherit their containing interface visibility, preventing valid implementations from being incorrectly flagged as unused (#405)
 - Verbose parser diagnostics at end-of-file now report `Unexpected end of input` while preserving concise expected-token messages (#457)

--- a/jvm/src/main/scala/com/nawforce/apexlink/plugins/UnusedPlugin.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/plugins/UnusedPlugin.scala
@@ -239,14 +239,16 @@ class UnusedPlugin(td: DependentType, isLibrary: Boolean) extends Plugin(td, isL
           case _ => None
         }
         .map(method => {
-          val hierarchyContext = method.unusedHierarchyContext(td.module, td.inTest)
-          val suffix           = if (method.hasHolders) s", $onlyTestCodeReferenceText" else ""
+          val hierarchyContext    = method.unusedHierarchyContext(td.module, td.inTest)
+          val entryPointCandidate = method.isPublicStaticEntryPointCandidate(td.inTest)
+          val methodModifierText  = method.unusedMethodModifierText(entryPointCandidate)
+          val suffix              = method.unusedMethodSuffix(entryPointCandidate)
           new Issue(
             method.location.path,
             Diagnostic(
               UNUSED_CATEGORY,
               method.idLocation,
-              s"Unused ${method.visibility.getOrElse(PRIVATE_MODIFIER).name} method '${method.signature}'$hierarchyContext$suffix"
+              s"Unused $methodModifierText method '${method.signature}'$hierarchyContext$suffix"
             )
           )
         })
@@ -297,6 +299,24 @@ class UnusedPlugin(td: DependentType, isLibrary: Boolean) extends Plugin(td, isL
         case _: MethodDeclaration => true
         case _                    => false
       })
+    }
+
+    def unusedMethodModifierText(includeStatic: Boolean): String = {
+      val visibility = method.visibility.getOrElse(PRIVATE_MODIFIER).name
+      if (includeStatic) s"$visibility static" else visibility
+    }
+
+    def isPublicStaticEntryPointCandidate(inTest: Boolean): Boolean = {
+      !inTest && method.isStatic && method.visibility.contains(PUBLIC_MODIFIER)
+    }
+
+    def unusedMethodSuffix(entryPointCandidate: Boolean): String = {
+      (method.hasHolders, entryPointCandidate) match {
+        case (true, true)  => s"; only referenced by test code, $publicStaticEntryPointActionText"
+        case (true, false) => s", $onlyTestCodeReferenceText"
+        case (false, true) => s"; $publicStaticEntryPointActionText"
+        case _             => ""
+      }
     }
 
     def unusedHierarchyContext(module: OPM.Module, inTest: Boolean): String = {
@@ -363,6 +383,8 @@ class UnusedPlugin(td: DependentType, isLibrary: Boolean) extends Plugin(td, isL
 object UnusedPlugin {
   val onlyTestCodeReferenceText =
     "only referenced by test code, remove or make private @TestVisible"
+  val publicStaticEntryPointActionText =
+    "remove, make private @TestVisible, or add @SuppressWarnings('Unused') with a comment if this is an external entry point"
 
   val suppressModifiers: Set[Modifier] =
     Set(SUPPRESS_WARNINGS_ANNOTATION_PMD, SUPPRESS_WARNINGS_ANNOTATION_UNUSED)

--- a/jvm/src/test/scala/com/nawforce/apexlink/plugin/UnusedTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/plugin/UnusedTest.scala
@@ -75,6 +75,21 @@ class UnusedTest extends AnyFunSuite with TestHelper {
     }
   }
 
+  test("Unused public static method includes entry point guidance") {
+    FileSystemHelper.run(
+      Map(
+        "Dummy.cls" -> "public class Dummy {public static void run() {}}",
+        "Foo.cls"   -> "public class Foo{ {Type t = Dummy.class;} }"
+      )
+    ) { root: PathLike =>
+      val org = createOrgWithUnused(root)
+      assert(
+        orgIssuesFor(org, root.join("Dummy.cls")) ==
+          "Unused: line 1 at 39-42: Unused public static method 'void run()'; remove, make private @TestVisible, or add @SuppressWarnings('Unused') with a comment if this is an external entry point\n"
+      )
+    }
+  }
+
   test("Unused global method") {
     FileSystemHelper.run(
       Map(
@@ -948,7 +963,7 @@ class UnusedTest extends AnyFunSuite with TestHelper {
       val org = createOrgWithUnused(root)
       assert(
         orgIssuesFor(org, root.join("Dummy.cls"))
-          == s"Unused: line 1 at 39-42: Unused public method 'void foo()', $onlyTestCodeReferenceText\n"
+          == "Unused: line 1 at 39-42: Unused public static method 'void foo()'; only referenced by test code, remove, make private @TestVisible, or add @SuppressWarnings('Unused') with a comment if this is an external entry point\n"
       )
     }
   }


### PR DESCRIPTION
## Summary
- include `static` in unused warnings for public static methods in non-test code
- add guidance to document intentional external entry points with `@SuppressWarnings('Unused')`
- update sample snapshots and changelog

## Tests
- `sbt scalafmtAll`
- `sbt 'apexlsJVM/testOnly com.nawforce.apexlink.plugin.UnusedTest -- -z "Unused public static method" -z "Unused method only referenced in test class"'`
- `sbt -error apexlsJVM/build`
- `cd js/npm && SAMPLES=$(cd ../../../apex-samples && pwd) npm run test-snapshot -- --runInBand`
- `cd js/npm && SAMPLES=$(cd ../../../apex-samples && pwd) npm run test-samples -- --runInBand`

Closes #406
