### PR TITLE
feat: recognize Summer '26 test annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Recognition of Summer '26 test annotations `@IntegrationTest` and `@TearDown`, including test-class and unused-analysis handling (#468)
 - Acceptance of Summer '26 multi-line string literals (`'''...'''`) in expressions and `switch` when clauses (#447)
 - Targeted diagnostic for malformed multi-line string literals such as `'''abc'''` and `''''''`, replacing the generic "mismatched input" syntax error (#443)
 - Qualified enum constants are now permitted in `switch` when clauses (e.g. `when MyEnum.A`) (#441)

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
@@ -26,6 +26,11 @@ import com.nawforce.apexlink.types.other.{AnyDeclaration, RecordSetDeclaration}
 import com.nawforce.apexlink.types.platform.{PlatformTypeDeclaration, PlatformTypes}
 import com.nawforce.apexlink.types.synthetic.CustomConstructorDeclaration
 import com.nawforce.pkgforce.diagnostics.{ERROR_CATEGORY, Issue, WARNING_CATEGORY}
+import com.nawforce.pkgforce.modifiers.{
+  INTEGRATION_TEST_ANNOTATION,
+  PRIVATE_MODIFIER,
+  TEST_VISIBLE_ANNOTATION
+}
 import com.nawforce.pkgforce.names.{EncodedName, Name, Names, TypeName}
 import com.nawforce.pkgforce.path.{Locatable, Location, PathLocation}
 import com.nawforce.runtime.parsers.CodeParser
@@ -442,6 +447,16 @@ final case class DotExpressionWithId(expression: Expression, safeNavigation: Boo
     val field: Option[FieldDeclaration] =
       DotExpression.findField(name, inputType, context.module, input.isStatic)
     if (field.nonEmpty) {
+      if (
+        field.get.modifiers.contains(TEST_VISIBLE_ANNOTATION) &&
+        field.get.visibility.contains(PRIVATE_MODIFIER) &&
+        context.thisType.modifiers.contains(INTEGRATION_TEST_ANNOTATION)
+      ) {
+        context.logError(
+          location,
+          "@IntegrationTest classes can not access private @TestVisible fields"
+        )
+      }
       context.addDependency(field.get)
       if (input.isStatic.contains(true) && !field.get.thisTypeIdOpt.contains(context.typeId))
         Referenceable.addReferencingLocation(inputType, field.get, location, context.thisType)
@@ -606,6 +621,25 @@ final case class MethodCallWithId(target: Id, arguments: ArraySeq[Expression]) e
     callee.findMethod(target.name, argTypes, staticContext, context) match {
       case Right(method) =>
         cachedMethod = Some(method)
+        if (
+          method.modifiers.contains(TEST_VISIBLE_ANNOTATION) &&
+          method.visibility.contains(PRIVATE_MODIFIER) &&
+          context.thisType.modifiers.contains(INTEGRATION_TEST_ANNOTATION)
+        ) {
+          context.logError(
+            location,
+            "@IntegrationTest classes can not access private @TestVisible methods"
+          )
+        }
+        if (
+          method.modifiers.contains(INTEGRATION_TEST_ANNOTATION) &&
+          !context.bodyModifiers(_ == INTEGRATION_TEST_ANNOTATION)
+        ) {
+          context.logError(
+            location,
+            "@IntegrationTest methods can only be called from @IntegrationTest methods"
+          )
+        }
         context.addDependency(method)
         if (staticContext.contains(true) && !method.thisTypeIdOpt.contains(context.typeId))
           Referenceable.addReferencingLocation(callee, method, location, context.thisType)

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
@@ -19,6 +19,11 @@ import com.nawforce.apexlink.org.Referenceable
 import com.nawforce.apexlink.types.apex.{ApexClassDeclaration, ApexFieldLike}
 import com.nawforce.apexlink.types.core.{FieldDeclaration, TypeDeclaration}
 import com.nawforce.apexlink.types.platform.PlatformTypes
+import com.nawforce.pkgforce.modifiers.{
+  INTEGRATION_TEST_ANNOTATION,
+  PRIVATE_MODIFIER,
+  TEST_VISIBLE_ANNOTATION
+}
 import com.nawforce.pkgforce.names._
 import com.nawforce.pkgforce.path.Location
 import com.nawforce.runtime.parsers.CodeParser
@@ -149,6 +154,16 @@ final case class IdPrimary(id: Id) extends Primary {
     cachedClassFieldDeclaration = field
 
     if (field.nonEmpty && isAccessible(td, field.get, staticContext)) {
+      if (
+        field.get.modifiers.contains(TEST_VISIBLE_ANNOTATION) &&
+        field.get.visibility.contains(PRIVATE_MODIFIER) &&
+        context.thisType.modifiers.contains(INTEGRATION_TEST_ANNOTATION)
+      ) {
+        context.logError(
+          location,
+          "@IntegrationTest classes can not access private @TestVisible fields"
+        )
+      }
       Referenceable.addReferencingLocation(field.get, location, context.thisType)
       context.addDependency(field.get)
       Some(

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/VerifyContext.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/VerifyContext.scala
@@ -75,6 +75,9 @@ trait VerifyContext {
   /** Test predicate returns true for a modifier on the containing scope */
   def modifiers(pred: Modifier => Boolean): Boolean = parent().exists(_.modifiers(pred))
 
+  /** Test predicate returns true for a modifier on the containing body declaration. */
+  def bodyModifiers(pred: Modifier => Boolean): Boolean = parent().exists(_.bodyModifiers(pred))
+
   /** Test if issues are currently being suppressed */
   def suppressIssues: Boolean = disableIssueDepth != 0 || parent().exists(_.suppressIssues)
 
@@ -275,6 +278,9 @@ final class BodyDeclarationVerifyContext(
 
   override def modifiers(pred: Modifier => Boolean): Boolean =
     classBodyDeclaration.modifiers.exists(pred) || super.modifiers(pred)
+
+  override def bodyModifiers(pred: Modifier => Boolean): Boolean =
+    classBodyDeclaration.modifiers.exists(pred)
 
   override def suppressIssues: Boolean =
     classBodyDeclaration.modifiers.contains(SUPPRESS_WARNINGS_ANNOTATION_PMD) ||

--- a/jvm/src/main/scala/com/nawforce/apexlink/deps/ReferencingCollector.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/deps/ReferencingCollector.scala
@@ -4,7 +4,7 @@
 package com.nawforce.apexlink.deps
 
 import com.nawforce.apexlink.types.apex.ApexDeclaration
-import com.nawforce.pkgforce.modifiers.ISTEST_ANNOTATION
+import com.nawforce.pkgforce.modifiers.ApexModifiers
 import com.nawforce.pkgforce.parsers.INTERFACE_NATURE
 
 import scala.collection.mutable
@@ -39,7 +39,7 @@ object ReferencingCollector {
       return false
 
     // Always save test classes, we don't bail out here as we want to capture test->test dependencies
-    if (path.head.modifiers.contains(ISTEST_ANNOTATION))
+    if (ApexModifiers.hasTestClassModifier(path.head.modifiers))
       accum.put(typeName, TestInfo(path.head, path))
 
     if (!primary) {

--- a/jvm/src/main/scala/com/nawforce/apexlink/opcst/OutlineParserFullDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/opcst/OutlineParserFullDeclaration.scala
@@ -10,7 +10,7 @@ import com.nawforce.apexlink.org.OPM
 import com.nawforce.apexlink.types.apex.{FullDeclaration, ThisType}
 import com.nawforce.pkgforce.diagnostics.LoggerOps
 import com.nawforce.pkgforce.documents.ClassDocument
-import com.nawforce.pkgforce.modifiers.ISTEST_ANNOTATION
+import com.nawforce.pkgforce.modifiers.ApexModifiers
 import com.nawforce.pkgforce.names.TypeName
 import com.nawforce.runtime.parsers.{Source, SourceData}
 import com.nawforce.runtime.platform.OutlineParserModifierOps.{
@@ -77,7 +77,11 @@ object OutlineParserFullDeclaration {
       )
 
     val thisType =
-      ThisType(module, thisTypeNameWithNS, modifierResults.modifiers.contains(ISTEST_ANNOTATION))
+      ThisType(
+        module,
+        thisTypeNameWithNS,
+        ApexModifiers.hasTestClassModifier(modifierResults.modifiers)
+      )
 
     val rv = OutlineParserClassDeclaration.construct(
       cls.path,
@@ -111,7 +115,11 @@ object OutlineParserFullDeclaration {
       )
 
     val thisType =
-      ThisType(module, thisTypeNameWithNS, modifierResults.modifiers.contains(ISTEST_ANNOTATION))
+      ThisType(
+        module,
+        thisTypeNameWithNS,
+        ApexModifiers.hasTestClassModifier(modifierResults.modifiers)
+      )
 
     val rv = OutlineParserInterfaceDeclaration.construct(
       cls.path,
@@ -145,7 +153,11 @@ object OutlineParserFullDeclaration {
       )
 
     val thisType =
-      ThisType(module, thisTypeNameWithNS, modifierResults.modifiers.contains(ISTEST_ANNOTATION))
+      ThisType(
+        module,
+        thisTypeNameWithNS,
+        ApexModifiers.hasTestClassModifier(modifierResults.modifiers)
+      )
 
     val rv =
       OutlineParserEnumDeclaration.construct(etd, source, thisType, outerTypeName, modifierResults)

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/OPM.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/OPM.scala
@@ -36,7 +36,7 @@ import com.nawforce.apexlink.types.schema.{SObjectDeclaration, SchemaSObjectType
 import com.nawforce.pkgforce.diagnostics.{IssueLogger, _}
 import io.github.apexdevtools.apexls.api.IssuesCollection
 import com.nawforce.pkgforce.documents._
-import com.nawforce.pkgforce.modifiers.ISTEST_ANNOTATION
+import com.nawforce.pkgforce.modifiers.ApexModifiers
 import com.nawforce.pkgforce.names.TypeNameFuncs.TypeNameFuncs
 import com.nawforce.pkgforce.names.{EncodedName, Name, TypeIdentifier, TypeName}
 import com.nawforce.pkgforce.path.{Location, PathLike, PathLocation}
@@ -516,7 +516,7 @@ object OPM {
           getTypeAndSummaryOfPath(path)
             .filter { case (typeId, summary) =>
               typeId.toString
-              !excludeTestClasses || !summary.modifiers.contains(ISTEST_ANNOTATION)
+              !excludeTestClasses || !ApexModifiers.hasTestClassModifier(summary.modifiers)
             }
             .map { case (typeId, _) =>
               (typeId, collector.transitives(typeId))

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/OrgTestClasses.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/OrgTestClasses.scala
@@ -20,7 +20,12 @@ import com.nawforce.apexlink.finding.TypeResolver
 import com.nawforce.apexlink.rpc.{ClassTestItem, MethodTestItem, TargetLocation}
 import com.nawforce.apexlink.types.apex.{ApexDeclaration, ApexMethodLike}
 import com.nawforce.apexlink.types.core.{TypeDeclaration, TypeId}
-import com.nawforce.pkgforce.modifiers.{ISTEST_ANNOTATION, Modifier, TEST_METHOD_MODIFIER}
+import com.nawforce.pkgforce.modifiers.{
+  INTEGRATION_TEST_ANNOTATION,
+  ISTEST_ANNOTATION,
+  Modifier,
+  TEST_METHOD_MODIFIER
+}
 import com.nawforce.pkgforce.names.TypeName
 import com.nawforce.pkgforce.path.PathLike
 import com.nawforce.runtime.platform.Path
@@ -97,7 +102,8 @@ trait OrgTestClasses {
   }
 
   private def hasTestModifier(modifiers: ArraySeq[Modifier]): Boolean = {
-    modifiers.contains(TEST_METHOD_MODIFIER) || modifiers.contains(ISTEST_ANNOTATION)
+    modifiers.contains(TEST_METHOD_MODIFIER) || modifiers.contains(ISTEST_ANNOTATION) || modifiers
+      .contains(INTEGRATION_TEST_ANNOTATION)
   }
 
   private def findTestClassReferences(

--- a/jvm/src/main/scala/com/nawforce/apexlink/plugins/UnusedPlugin.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/plugins/UnusedPlugin.scala
@@ -400,7 +400,9 @@ object UnusedPlugin {
   private val excludedTestMethodModifiers: Set[Modifier] =
     Set(
       ISTEST_ANNOTATION,
+      INTEGRATION_TEST_ANNOTATION,
       TEST_SETUP_ANNOTATION,
+      TEAR_DOWN_ANNOTATION,
       TEST_METHOD_MODIFIER,
       SUPPRESS_WARNINGS_ANNOTATION_PMD,
       SUPPRESS_WARNINGS_ANNOTATION_UNUSED

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/apex/FullDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/apex/FullDeclaration.scala
@@ -433,7 +433,7 @@ object FullDeclaration {
         val classModifiers = ApexModifiers.classModifiers(parser, modifiers, outer = true, cd.id())
         ClassDeclaration.construct(
           parser,
-          ThisType(module, thisType, classModifiers.modifiers.contains(ISTEST_ANNOTATION)),
+          ThisType(module, thisType, ApexModifiers.hasTestClassModifier(classModifiers.modifiers)),
           None,
           classModifiers,
           cd

--- a/jvm/src/main/scala/com/nawforce/pkgforce/modifiers/MethodModifiers.scala
+++ b/jvm/src/main/scala/com/nawforce/pkgforce/modifiers/MethodModifiers.scala
@@ -16,6 +16,7 @@ package com.nawforce.pkgforce.modifiers
 import com.nawforce.pkgforce.modifiers.ApexModifiers.{
   allowableModifiers,
   asModifiers,
+  hasTestClassModifier,
   toModifiers,
   visibilityModifiers
 }
@@ -47,12 +48,14 @@ object MethodModifiers {
     FUTURE_ANNOTATION,
     INVOCABLE_METHOD_ANNOTATION,
     ISTEST_ANNOTATION,
+    INTEGRATION_TEST_ANNOTATION,
     TEST_VISIBLE_ANNOTATION,
     NAMESPACE_ACCESSIBLE_ANNOTATION,
     READ_ONLY_ANNOTATION,
     SUPPRESS_WARNINGS_ANNOTATION_PMD,
     SUPPRESS_WARNINGS_ANNOTATION_UNUSED,
     TEST_SETUP_ANNOTATION,
+    TEAR_DOWN_ANNOTATION,
     HTTP_DELETE_ANNOTATION,
     HTTP_GET_ANNOTATION,
     HTTP_PATCH_ANNOTATION,
@@ -165,19 +168,59 @@ object MethodModifiers {
         extendedModifiers
       } else if (
         (extendedModifiers
-          .contains(ISTEST_ANNOTATION) || extendedModifiers.contains(TEST_METHOD_MODIFIER)) &&
+          .contains(ISTEST_ANNOTATION) || extendedModifiers.contains(
+          INTEGRATION_TEST_ANNOTATION
+        ) || extendedModifiers
+          .contains(TEST_METHOD_MODIFIER) || extendedModifiers.contains(TEAR_DOWN_ANNOTATION)) &&
         !extendedModifiers.contains(STATIC_MODIFIER)
       ) {
-        logger.logError(context, "testMethod and @IsTest methods must be static")
+        logger.logError(
+          context,
+          "testMethod, @IsTest, @IntegrationTest and @TearDown methods must be static"
+        )
         STATIC_MODIFIER +: extendedModifiers
       } else if (
         (extendedModifiers
           .contains(ISTEST_ANNOTATION) || extendedModifiers.contains(TEST_SETUP_ANNOTATION)) &&
-        !ownerInfo.modifiers.contains(ISTEST_ANNOTATION)
+        !hasTestClassModifier(ownerInfo.modifiers)
       ) {
         logger.logError(
           context,
-          "Method with @IsTest or @TestSetup annotation must be in a class with @IsTest annotation"
+          "Method with @IsTest or @TestSetup annotation must be in a test class"
+        )
+        extendedModifiers
+      } else if (
+        extendedModifiers.contains(INTEGRATION_TEST_ANNOTATION) &&
+        !ownerInfo.modifiers.contains(INTEGRATION_TEST_ANNOTATION)
+      ) {
+        logger.logError(
+          context,
+          "Method with @IntegrationTest annotation must be in an @IntegrationTest class"
+        )
+        extendedModifiers
+      } else if (
+        extendedModifiers.contains(ISTEST_ANNOTATION) &&
+        ownerInfo.modifiers.contains(INTEGRATION_TEST_ANNOTATION)
+      ) {
+        logger.logError(context, "@IntegrationTest classes can not contain @IsTest methods")
+        extendedModifiers
+      } else if (
+        extendedModifiers.contains(TEAR_DOWN_ANNOTATION) &&
+        !ownerInfo.modifiers.contains(INTEGRATION_TEST_ANNOTATION)
+      ) {
+        logger.logError(
+          context,
+          "Method with @TearDown annotation must be in an @IntegrationTest class"
+        )
+        extendedModifiers
+      } else if (
+        ownerInfo.modifiers.contains(INTEGRATION_TEST_ANNOTATION) &&
+        !extendedModifiers.contains(INTEGRATION_TEST_ANNOTATION) &&
+        !extendedModifiers.contains(TEAR_DOWN_ANNOTATION)
+      ) {
+        logger.logError(
+          context,
+          "@IntegrationTest classes can only contain @IntegrationTest and @TearDown methods"
         )
         extendedModifiers
       } else {

--- a/jvm/src/main/scala/com/nawforce/pkgforce/modifiers/Modifier.scala
+++ b/jvm/src/main/scala/com/nawforce/pkgforce/modifiers/Modifier.scala
@@ -74,6 +74,8 @@ case object INVOCABLE_VARIABLE_ANNOTATION extends Modifier("@InvocableVariable")
 
 case object ISTEST_ANNOTATION extends Modifier("@IsTest")
 
+case object INTEGRATION_TEST_ANNOTATION extends Modifier("@IntegrationTest")
+
 case object READ_ONLY_ANNOTATION extends Modifier("@ReadOnly")
 
 case object REMOTE_ACTION_ANNOTATION extends Modifier("@RemoteAction")
@@ -83,6 +85,8 @@ case object SUPPRESS_WARNINGS_ANNOTATION_PMD extends Modifier("@SuppressWarnings
 case object SUPPRESS_WARNINGS_ANNOTATION_UNUSED extends Modifier("@SuppressWarnings('Unused')")
 
 case object TEST_SETUP_ANNOTATION extends Modifier("@TestSetup")
+
+case object TEAR_DOWN_ANNOTATION extends Modifier("@TearDown")
 
 case object TEST_VISIBLE_ANNOTATION extends Modifier("@TestVisible")
 
@@ -132,11 +136,13 @@ object ModifierOps {
       INVOCABLE_METHOD_ANNOTATION,
       INVOCABLE_VARIABLE_ANNOTATION,
       ISTEST_ANNOTATION,
+      INTEGRATION_TEST_ANNOTATION,
       READ_ONLY_ANNOTATION,
       REMOTE_ACTION_ANNOTATION,
       SUPPRESS_WARNINGS_ANNOTATION_PMD,
       SUPPRESS_WARNINGS_ANNOTATION_UNUSED,
       TEST_SETUP_ANNOTATION,
+      TEAR_DOWN_ANNOTATION,
       TEST_VISIBLE_ANNOTATION,
       NAMESPACE_ACCESSIBLE_ANNOTATION,
       REST_RESOURCE_ANNOTATION,
@@ -198,8 +204,16 @@ object ApexModifiers {
   private val TypeModifiersAndAnnotations: Set[Modifier] =
     TypeAnnotations ++ TypeModifiers
 
+  def hasTestClassModifier(modifiers: ArraySeq[Modifier]): Boolean =
+    modifiers.contains(ISTEST_ANNOTATION) || modifiers.contains(INTEGRATION_TEST_ANNOTATION)
+
   private val ClassAnnotations: Set[Modifier] =
-    TypeAnnotations ++ Set(ISTEST_ANNOTATION, REST_RESOURCE_ANNOTATION, JSON_ACCESS_ANNOTATION)
+    TypeAnnotations ++ Set(
+      ISTEST_ANNOTATION,
+      INTEGRATION_TEST_ANNOTATION,
+      REST_RESOURCE_ANNOTATION,
+      JSON_ACCESS_ANNOTATION
+    )
 
   private val ClassModifiers: Set[Modifier] =
     TypeModifiers ++ Set(ABSTRACT_MODIFIER, VIRTUAL_MODIFIER) ++ sharingModifiers.toSet
@@ -383,11 +397,14 @@ object ApexModifiers {
 
     val results =
       if (logger.isEmpty) {
-        if (outer && !mods.contains(ISTEST_ANNOTATION) && mods.contains(PRIVATE_MODIFIER)) {
+        if (mods.contains(ISTEST_ANNOTATION) && mods.contains(INTEGRATION_TEST_ANNOTATION)) {
+          logger.logError(idContext, s"Classes can not be both @IsTest and @IntegrationTest")
+          mods.filterNot(_ == INTEGRATION_TEST_ANNOTATION)
+        } else if (outer && !hasTestClassModifier(mods) && mods.contains(PRIVATE_MODIFIER)) {
           logger.logError(idContext, s"Private modifier is not allowed on outer classes")
           mods.filterNot(_ == PRIVATE_MODIFIER)
         } else if (
-          outer && !mods.contains(ISTEST_ANNOTATION) && !(mods.contains(GLOBAL_MODIFIER) || mods
+          outer && !hasTestClassModifier(mods) && !(mods.contains(GLOBAL_MODIFIER) || mods
             .contains(PUBLIC_MODIFIER))
         ) {
           logger.logError(idContext, s"Outer classes must be declared either 'global' or 'public'")
@@ -395,15 +412,15 @@ object ApexModifiers {
         } else if (mods.contains(ABSTRACT_MODIFIER) && mods.contains(VIRTUAL_MODIFIER)) {
           logger.logError(idContext, s"Abstract classes are virtual classes")
           mods.filterNot(_ == VIRTUAL_MODIFIER)
-        } else if (!outer && mods.contains(ISTEST_ANNOTATION)) {
-          logger.logError(idContext, s"isTest can only be used on outer classes")
-          mods.filterNot(_ == ISTEST_ANNOTATION)
+        } else if (!outer && hasTestClassModifier(mods)) {
+          logger.logError(idContext, s"Test annotations can only be used on outer classes")
+          mods.filterNot(mod => mod == ISTEST_ANNOTATION || mod == INTEGRATION_TEST_ANNOTATION)
         } else if (
-          mods.contains(ISTEST_ANNOTATION) && (mods
+          hasTestClassModifier(mods) && (mods
             .contains(ABSTRACT_MODIFIER) || mods.contains(VIRTUAL_MODIFIER))
         ) {
-          logger.logError(idContext, s"isTest classes can not be abstract or virtual")
-          mods.filterNot(_ == ISTEST_ANNOTATION)
+          logger.logError(idContext, s"Test classes can not be abstract or virtual")
+          mods.filterNot(mod => mod == ISTEST_ANNOTATION || mod == INTEGRATION_TEST_ANNOTATION)
         } else {
           mods
         }

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/ClassModifierTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/ClassModifierTest.scala
@@ -105,6 +105,12 @@ class ClassModifierTest extends AnyFunSuite with TestHelper {
     assert(dummyIssues.isEmpty)
   }
 
+  test("IntegrationTest annotation class") {
+    val modifiers = typeDeclaration("@IntegrationTest public class Dummy {}").modifiers
+    assert(modifiers.toSet == Set(PUBLIC_MODIFIER, INTEGRATION_TEST_ANNOTATION))
+    assert(dummyIssues.isEmpty)
+  }
+
   test("TestVisible annotation class") {
     val modifiers = typeDeclaration("@TestVisible public class Dummy {}").modifiers
     assert(modifiers.toSet == Set(PUBLIC_MODIFIER, TEST_VISIBLE_ANNOTATION))

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
@@ -64,6 +64,78 @@ class MethodTest extends AnyFunSuite with TestHelper {
     assert(dummyIssues.isEmpty)
   }
 
+  test("IntegrationTest method called from IntegrationTest method") {
+    typeDeclaration(
+      "@IntegrationTest public class Dummy {@IntegrationTest static void f1(){} @IntegrationTest static void f2() {f1();} }"
+    )
+    assert(dummyIssues.isEmpty)
+  }
+
+  test("IntegrationTest method called from IsTest method") {
+    typeDeclarations(
+      Map(
+        "IntegrationDummy.cls" -> "@IntegrationTest public class IntegrationDummy {@IntegrationTest public static void f1(){}}",
+        "Dummy.cls" -> "@IsTest public class Dummy {@IsTest public static void f2() {IntegrationDummy.f1();}}"
+      )
+    )
+    assert(
+      getMessages(
+        root.join("Dummy.cls")
+      ) == "Error: line 1 at 61-82: @IntegrationTest methods can only be called from @IntegrationTest methods\n"
+    )
+  }
+
+  test("IntegrationTest method called from non-test context") {
+    typeDeclarations(
+      Map(
+        "TestDummy.cls" -> "@IntegrationTest public class TestDummy {@IntegrationTest public static void f1(){}}",
+        "Dummy.cls" -> "public class Dummy {public static void f2() {TestDummy.f1();}}"
+      )
+    )
+    assert(
+      getMessages(
+        root.join("Dummy.cls")
+      ) == "Error: line 1 at 45-59: @IntegrationTest methods can only be called from @IntegrationTest methods\n"
+    )
+  }
+
+  test("IntegrationTest method called from IntegrationTest class helper") {
+    typeDeclaration(
+      "@IntegrationTest public class Dummy {@IntegrationTest static void f1(){} static void f2() {f1();} }"
+    )
+    assert(
+      dummyIssues == "Error: line 1 at 85-87: @IntegrationTest classes can only contain @IntegrationTest and @TearDown methods\nError: line 1 at 91-95: @IntegrationTest methods can only be called from @IntegrationTest methods\n"
+    )
+  }
+
+  test("IntegrationTest can not access private TestVisible method") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {@TestVisible private static void helper(){}}",
+        "Dummy.cls" -> "@IntegrationTest public class Dummy {@IntegrationTest public static void f2() {Target.helper();}}"
+      )
+    )
+    assert(
+      getMessages(
+        root.join("Dummy.cls")
+      ) == "Error: line 1 at 79-94: @IntegrationTest classes can not access private @TestVisible methods\n"
+    )
+  }
+
+  test("IntegrationTest can not access private TestVisible field") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {@TestVisible private static String helper;}",
+        "Dummy.cls" -> "@IntegrationTest public class Dummy {@IntegrationTest public static void f2() {String value = Target.helper;}}"
+      )
+    )
+    assert(
+      getMessages(
+        root.join("Dummy.cls")
+      ) == "Error: line 1 at 94-107: @IntegrationTest classes can not access private @TestVisible fields\n"
+    )
+  }
+
   test("Method call with non-ambiguous target") {
     FileSystemHelper.run(
       Map(

--- a/jvm/src/test/scala/com/nawforce/apexlink/plugin/UnusedTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/plugin/UnusedTest.scala
@@ -464,6 +464,23 @@ class UnusedTest extends AnyFunSuite with TestHelper {
     }
   }
 
+  test("Unused empty integration test class") {
+    FileSystemHelper.run(Map("Dummy.cls" -> "@IntegrationTest public class Dummy {}")) {
+      root: PathLike =>
+        val org = createOrgWithUnused(root)
+        assert(orgIssuesFor(org, root.join("Dummy.cls")).isEmpty)
+    }
+  }
+
+  test("Unused TearDown method") {
+    FileSystemHelper.run(
+      Map("Dummy.cls" -> "@IntegrationTest public class Dummy {@TearDown static void cleanup() {}}")
+    ) { root: PathLike =>
+      val org = createOrgWithUnused(root)
+      assert(orgIssuesFor(org, root.join("Dummy.cls")).isEmpty)
+    }
+  }
+
   test("Unused class") {
     FileSystemHelper.run(Map("Dummy.cls" -> "public class Dummy {Object a; void func() {}}")) {
       root: PathLike =>

--- a/jvm/src/test/scala/com/nawforce/pkgforce/modifiers/ClassModifierTest.scala
+++ b/jvm/src/test/scala/com/nawforce/pkgforce/modifiers/ClassModifierTest.scala
@@ -111,6 +111,22 @@ class ClassModifierTest extends AnyFunSuite {
     assert(legalClassAccess(ArraySeq(ISTEST_ANNOTATION)))
   }
 
+  test("isTest and IntegrationTest annotations") {
+    val issues = illegalClassAccess(ArraySeq(ISTEST_ANNOTATION, INTEGRATION_TEST_ANNOTATION))
+    assert(
+      issues == Seq[Issue](
+        Issue(
+          Path("Dummy.cls"),
+          diagnostics.Diagnostic(
+            ERROR_CATEGORY,
+            Location(1, 31, 1, 36),
+            "Classes can not be both @IsTest and @IntegrationTest"
+          )
+        )
+      )
+    )
+  }
+
   test("isTest and abstract modifier") {
     val issues = illegalClassAccess(ArraySeq(ISTEST_ANNOTATION, ABSTRACT_MODIFIER))
     assert(
@@ -120,7 +136,7 @@ class ClassModifierTest extends AnyFunSuite {
           diagnostics.Diagnostic(
             ERROR_CATEGORY,
             Location(1, 23, 1, 28),
-            "isTest classes can not be abstract or virtual"
+            "Test classes can not be abstract or virtual"
           )
         )
       )
@@ -136,7 +152,7 @@ class ClassModifierTest extends AnyFunSuite {
           diagnostics.Diagnostic(
             ERROR_CATEGORY,
             Location(1, 22, 1, 27),
-            "isTest classes can not be abstract or virtual"
+            "Test classes can not be abstract or virtual"
           )
         )
       )
@@ -221,7 +237,7 @@ class ClassModifierTest extends AnyFunSuite {
           diagnostics.Diagnostic(
             ERROR_CATEGORY,
             Location(1, 34, 1, 37),
-            "isTest can only be used on outer classes"
+            "Test annotations can only be used on outer classes"
           )
         )
       )

--- a/jvm/src/test/scala/com/nawforce/pkgforce/modifiers/MethodModifierTest.scala
+++ b/jvm/src/test/scala/com/nawforce/pkgforce/modifiers/MethodModifierTest.scala
@@ -340,7 +340,7 @@ class MethodModifierTest extends AnyFunSuite {
           Diagnostic(
             ERROR_CATEGORY,
             Location(1, 49, 1, 53),
-            "Method with @IsTest or @TestSetup annotation must be in a class with @IsTest annotation"
+            "Method with @IsTest or @TestSetup annotation must be in a test class"
           )
         )
       )
@@ -357,7 +357,62 @@ class MethodModifierTest extends AnyFunSuite {
           Diagnostic(
             ERROR_CATEGORY,
             Location(1, 52, 1, 56),
-            "Method with @IsTest or @TestSetup annotation must be in a class with @IsTest annotation"
+            "Method with @IsTest or @TestSetup annotation must be in a test class"
+          )
+        )
+      )
+    )
+  }
+
+  test("TearDown in non-integration test class should error") {
+    val issues =
+      illegalClassMethodAccess(ArraySeq(TEAR_DOWN_ANNOTATION, PUBLIC_MODIFIER, STATIC_MODIFIER))
+    assert(
+      issues == Seq[Issue](
+        Issue(
+          Path("Dummy.cls"),
+          Diagnostic(
+            ERROR_CATEGORY,
+            Location(1, 51, 1, 55),
+            "Method with @TearDown annotation must be in an @IntegrationTest class"
+          )
+        )
+      )
+    )
+  }
+
+  test("TearDown in isTest class should error") {
+    val issues = illegalClassMethodAccess(
+      ArraySeq(TEAR_DOWN_ANNOTATION, PUBLIC_MODIFIER, STATIC_MODIFIER),
+      ArraySeq(ISTEST_ANNOTATION)
+    )
+    assert(
+      issues == Seq[Issue](
+        Issue(
+          Path("Dummy.cls"),
+          Diagnostic(
+            ERROR_CATEGORY,
+            Location(1, 52, 1, 56),
+            "Method with @TearDown annotation must be in an @IntegrationTest class"
+          )
+        )
+      )
+    )
+  }
+
+  test("TearDown without static should error") {
+    val issues = illegalClassMethodAccess(
+      ArraySeq(TEAR_DOWN_ANNOTATION, PUBLIC_MODIFIER),
+      ArraySeq(INTEGRATION_TEST_ANNOTATION)
+    )
+    assert(
+      issues == Seq[Issue](
+        Issue(
+          Path("Dummy.cls"),
+          Diagnostic(
+            ERROR_CATEGORY,
+            Location(1, 54, 1, 58),
+            "testMethod, @IsTest, @IntegrationTest and @TearDown methods must be static"
           )
         )
       )
@@ -376,7 +431,7 @@ class MethodModifierTest extends AnyFunSuite {
           Diagnostic(
             ERROR_CATEGORY,
             Location(1, 43, 1, 47),
-            "testMethod and @IsTest methods must be static"
+            "testMethod, @IsTest, @IntegrationTest and @TearDown methods must be static"
           )
         )
       )
@@ -393,7 +448,7 @@ class MethodModifierTest extends AnyFunSuite {
           Diagnostic(
             ERROR_CATEGORY,
             Location(1, 39, 1, 43),
-            "testMethod and @IsTest methods must be static"
+            "testMethod, @IsTest, @IntegrationTest and @TearDown methods must be static"
           )
         )
       )
@@ -416,6 +471,83 @@ class MethodModifierTest extends AnyFunSuite {
         ArraySeq(TEST_SETUP_ANNOTATION, PUBLIC_MODIFIER, STATIC_MODIFIER),
         ArraySeq(TEST_SETUP_ANNOTATION, PUBLIC_MODIFIER, STATIC_MODIFIER),
         ArraySeq(ISTEST_ANNOTATION)
+      )
+    )
+  }
+
+  test("TearDown in integration test class should be ok") {
+    assert(
+      legalClassMethodAccess(
+        ArraySeq(TEAR_DOWN_ANNOTATION, PUBLIC_MODIFIER, STATIC_MODIFIER),
+        ArraySeq(TEAR_DOWN_ANNOTATION, PUBLIC_MODIFIER, STATIC_MODIFIER),
+        ArraySeq(INTEGRATION_TEST_ANNOTATION)
+      )
+    )
+  }
+
+  test("IntegrationTest method in integration test class should be ok") {
+    assert(
+      legalClassMethodAccess(
+        ArraySeq(INTEGRATION_TEST_ANNOTATION, PUBLIC_MODIFIER, STATIC_MODIFIER),
+        ArraySeq(INTEGRATION_TEST_ANNOTATION, PUBLIC_MODIFIER, STATIC_MODIFIER),
+        ArraySeq(INTEGRATION_TEST_ANNOTATION)
+      )
+    )
+  }
+
+  test("IntegrationTest method in non-integration test class should error") {
+    val issues = illegalClassMethodAccess(
+      ArraySeq(INTEGRATION_TEST_ANNOTATION, PUBLIC_MODIFIER, STATIC_MODIFIER),
+      ArraySeq(ISTEST_ANNOTATION)
+    )
+    assert(
+      issues == Seq[Issue](
+        Issue(
+          Path("Dummy.cls"),
+          Diagnostic(
+            ERROR_CATEGORY,
+            Location(1, 59, 1, 63),
+            "Method with @IntegrationTest annotation must be in an @IntegrationTest class"
+          )
+        )
+      )
+    )
+  }
+
+  test("IsTest method in integration test class should error") {
+    val issues = illegalClassMethodAccess(
+      ArraySeq(ISTEST_ANNOTATION, PUBLIC_MODIFIER, STATIC_MODIFIER),
+      ArraySeq(INTEGRATION_TEST_ANNOTATION)
+    )
+    assert(
+      issues == Seq[Issue](
+        Issue(
+          Path("Dummy.cls"),
+          Diagnostic(
+            ERROR_CATEGORY,
+            Location(1, 59, 1, 63),
+            "@IntegrationTest classes can not contain @IsTest methods"
+          )
+        )
+      )
+    )
+  }
+
+  test("Unannotated method in integration test class should error") {
+    val issues = illegalClassMethodAccess(
+      ArraySeq(PUBLIC_MODIFIER, STATIC_MODIFIER),
+      ArraySeq(INTEGRATION_TEST_ANNOTATION)
+    )
+    assert(
+      issues == Seq[Issue](
+        Issue(
+          Path("Dummy.cls"),
+          Diagnostic(
+            ERROR_CATEGORY,
+            Location(1, 51, 1, 55),
+            "@IntegrationTest classes can only contain @IntegrationTest and @TearDown methods"
+          )
+        )
       )
     )
   }


### PR DESCRIPTION
## Summary
- recognize `@IntegrationTest` and `@TearDown` annotations
- validate integration-test class/method rules, including `@IsTest` conflicts, allowed method annotations, static teardown methods, and integration-test call restrictions
- prevent `@IntegrationTest` classes from using private `@TestVisible` fields and methods
- treat `@IntegrationTest` classes/methods and `@TearDown` methods correctly for test discovery and unused analysis
- update sample snapshots for revised test-annotation diagnostics

## Tests
- `sbt scalafmtAll`
- `sbt 'apexlsJVM/testOnly com.nawforce.pkgforce.modifiers.ClassModifierTest com.nawforce.apexlink.cst.ClassModifierTest com.nawforce.pkgforce.modifiers.MethodModifierTest' 'apexlsJVM/testOnly com.nawforce.apexlink.cst.MethodTest com.nawforce.apexlink.cst.ConstructorTest -- -z IntegrationTest -z TestVisible' 'apexlsJVM/testOnly com.nawforce.apexlink.plugin.UnusedTest -- -z integration -z TearDown'`
- `sbt apexlsJVM/build`
- `cd js/npm && SAMPLES=$(cd ../../../apex-samples && pwd) npm run test-snapshot -- --runInBand`
- `cd js/npm && SAMPLES=$(cd ../../../apex-samples && pwd) npm run test-samples -- --runInBand`

Closes #468
