### PR TITLE
fix: align IntegrationTest diagnostics with runtime behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `@IntegrationTest` classes no longer reject ordinary helper members, and calls to `@IntegrationTest` methods from non-integration contexts are reported as warnings instead of deploy-blocking errors (#470)
 - Unused warnings for public static methods now call out their static nature and explain how to document intentional external entry points (#406)
 - Unused warnings for virtual/override method hierarchies now include context when all related overrides are unused (#403)
 - Global interface methods now inherit their containing interface visibility, preventing valid implementations from being incorrectly flagged as unused (#405)

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
@@ -635,9 +635,12 @@ final case class MethodCallWithId(target: Id, arguments: ArraySeq[Expression]) e
           method.modifiers.contains(INTEGRATION_TEST_ANNOTATION) &&
           !context.bodyModifiers(_ == INTEGRATION_TEST_ANNOTATION)
         ) {
-          context.logError(
-            location,
-            "@IntegrationTest methods can only be called from @IntegrationTest methods"
+          context.log(
+            Issue(
+              WARNING_CATEGORY,
+              location,
+              "@IntegrationTest methods can only be called from @IntegrationTest methods"
+            )
           )
         }
         context.addDependency(method)

--- a/jvm/src/main/scala/com/nawforce/pkgforce/modifiers/MethodModifiers.scala
+++ b/jvm/src/main/scala/com/nawforce/pkgforce/modifiers/MethodModifiers.scala
@@ -213,16 +213,6 @@ object MethodModifiers {
           "Method with @TearDown annotation must be in an @IntegrationTest class"
         )
         extendedModifiers
-      } else if (
-        ownerInfo.modifiers.contains(INTEGRATION_TEST_ANNOTATION) &&
-        !extendedModifiers.contains(INTEGRATION_TEST_ANNOTATION) &&
-        !extendedModifiers.contains(TEAR_DOWN_ANNOTATION)
-      ) {
-        logger.logError(
-          context,
-          "@IntegrationTest classes can only contain @IntegrationTest and @TearDown methods"
-        )
-        extendedModifiers
       } else {
         extendedModifiers
       }

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
@@ -81,7 +81,7 @@ class MethodTest extends AnyFunSuite with TestHelper {
     assert(
       getMessages(
         root.join("Dummy.cls")
-      ) == "Error: line 1 at 61-82: @IntegrationTest methods can only be called from @IntegrationTest methods\n"
+      ) == "Warning: line 1 at 61-82: @IntegrationTest methods can only be called from @IntegrationTest methods\n"
     )
   }
 
@@ -95,7 +95,7 @@ class MethodTest extends AnyFunSuite with TestHelper {
     assert(
       getMessages(
         root.join("Dummy.cls")
-      ) == "Error: line 1 at 45-59: @IntegrationTest methods can only be called from @IntegrationTest methods\n"
+      ) == "Warning: line 1 at 45-59: @IntegrationTest methods can only be called from @IntegrationTest methods\n"
     )
   }
 
@@ -104,8 +104,15 @@ class MethodTest extends AnyFunSuite with TestHelper {
       "@IntegrationTest public class Dummy {@IntegrationTest static void f1(){} static void f2() {f1();} }"
     )
     assert(
-      dummyIssues == "Error: line 1 at 85-87: @IntegrationTest classes can only contain @IntegrationTest and @TearDown methods\nError: line 1 at 91-95: @IntegrationTest methods can only be called from @IntegrationTest methods\n"
+      dummyIssues == "Warning: line 1 at 91-95: @IntegrationTest methods can only be called from @IntegrationTest methods\n"
     )
+  }
+
+  test("IntegrationTest class can contain ordinary members") {
+    typeDeclaration(
+      "@IntegrationTest public class Dummy {static Integer counter = 0; String label; private Dummy(String label) {this.label = label;} static Integer helper() {counter += 1; return counter;} class InnerHelper {String value(String input) {return input;}} @IntegrationTest static void testA() {System.assert(true);} @TearDown static void cleanup() {}}"
+    )
+    assert(dummyIssues.isEmpty)
   }
 
   test("IntegrationTest can not access private TestVisible method") {

--- a/jvm/src/test/scala/com/nawforce/pkgforce/modifiers/MethodModifierTest.scala
+++ b/jvm/src/test/scala/com/nawforce/pkgforce/modifiers/MethodModifierTest.scala
@@ -533,21 +533,12 @@ class MethodModifierTest extends AnyFunSuite {
     )
   }
 
-  test("Unannotated method in integration test class should error") {
-    val issues = illegalClassMethodAccess(
-      ArraySeq(PUBLIC_MODIFIER, STATIC_MODIFIER),
-      ArraySeq(INTEGRATION_TEST_ANNOTATION)
-    )
+  test("Unannotated method in integration test class should be ok") {
     assert(
-      issues == Seq[Issue](
-        Issue(
-          Path("Dummy.cls"),
-          Diagnostic(
-            ERROR_CATEGORY,
-            Location(1, 51, 1, 55),
-            "@IntegrationTest classes can only contain @IntegrationTest and @TearDown methods"
-          )
-        )
+      legalClassMethodAccess(
+        ArraySeq(PUBLIC_MODIFIER, STATIC_MODIFIER),
+        ArraySeq(PUBLIC_MODIFIER, STATIC_MODIFIER),
+        ArraySeq(INTEGRATION_TEST_ANNOTATION)
       )
     )
   }


### PR DESCRIPTION
## Summary

- allow ordinary helper members inside `@IntegrationTest` classes
- report calls to `@IntegrationTest` methods from non-integration contexts as warnings instead of deploy-blocking errors
- add regressions covering ordinary `@IntegrationTest` members and warning severity for invalid call paths

## Why

Real-org testing for #470 showed Salesforce accepts these class/member shapes at deploy time. Calls from non-integration contexts can still fail at runtime or test execution, so apex-ls should surface that as a warning rather than an error.

## Validation

- `sbt scalafmtAll`
- `sbt 'apexlsJVM/testOnly com.nawforce.pkgforce.modifiers.MethodModifierTest com.nawforce.apexlink.cst.MethodTest'`
- `sbt test`

Closes #470