### PR TITLE
fix: restrict private TestVisible access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Private `@TestVisible` methods, fields, and constructors are now only visible from `@IsTest` callers, matching Salesforce visibility rules for non-test and `@IntegrationTest` code (#471)
 - `@IntegrationTest` classes no longer reject ordinary helper members, and calls to `@IntegrationTest` methods from non-integration contexts are reported as warnings instead of deploy-blocking errors (#470)
 - Unused warnings for public static methods now call out their static nature and explain how to document intentional external entry points (#406)
 - Unused warnings for virtual/override method hierarchies now include context when all related overrides are unused (#403)

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/ConstructorMap.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/ConstructorMap.scala
@@ -123,7 +123,7 @@ object ConstructorMap {
     thisType: TypeDeclaration,
     superType: Option[TypeDeclaration]
   ): Boolean = {
-    lazy val isTestVisible            = ctor.isTestVisible && thisType.isUnitTest
+    lazy val isTestVisible            = ctor.isTestVisible && thisType.isUnitTestContext
     lazy val isAccessedInThisContext  = areInSameApexFile(ctor, thisType)
     lazy val isAccessedInSuperContext = superType.nonEmpty && areInSameApexFile(ctor, superType.get)
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/ConstructorMap.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/ConstructorMap.scala
@@ -123,7 +123,7 @@ object ConstructorMap {
     thisType: TypeDeclaration,
     superType: Option[TypeDeclaration]
   ): Boolean = {
-    lazy val isTestVisible            = ctor.isTestVisible && thisType.inTest
+    lazy val isTestVisible            = ctor.isTestVisible && thisType.isUnitTest
     lazy val isAccessedInThisContext  = areInSameApexFile(ctor, thisType)
     lazy val isAccessedInSuperContext = superType.nonEmpty && areInSameApexFile(ctor, superType.get)
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
@@ -26,7 +26,7 @@ import com.nawforce.apexlink.types.other.{AnyDeclaration, RecordSetDeclaration}
 import com.nawforce.apexlink.types.platform.{PlatformTypeDeclaration, PlatformTypes}
 import com.nawforce.apexlink.types.synthetic.CustomConstructorDeclaration
 import com.nawforce.pkgforce.diagnostics.{ERROR_CATEGORY, Issue, WARNING_CATEGORY}
-import com.nawforce.pkgforce.modifiers.{INTEGRATION_TEST_ANNOTATION, PRIVATE_MODIFIER}
+import com.nawforce.pkgforce.modifiers.INTEGRATION_TEST_ANNOTATION
 import com.nawforce.pkgforce.names.{EncodedName, Name, Names, TypeName}
 import com.nawforce.pkgforce.path.{Locatable, Location, PathLocation}
 import com.nawforce.runtime.parsers.CodeParser
@@ -443,12 +443,7 @@ final case class DotExpressionWithId(expression: Expression, safeNavigation: Boo
     val field: Option[FieldDeclaration] =
       DotExpression.findField(name, inputType, context.module, input.isStatic)
     if (field.nonEmpty) {
-      if (
-        field.get.isTestVisible &&
-        field.get.visibility.contains(PRIVATE_MODIFIER) &&
-        !field.get.thisTypeIdOpt.contains(context.typeId) &&
-        !context.thisType.isUnitTest
-      ) {
+      if (TestVisibleAccess.isInvalidPrivateFieldAccess(field.get, context.thisType)) {
         context.logError(
           location,
           "Private @TestVisible fields can only be accessed from @IsTest classes"
@@ -618,12 +613,7 @@ final case class MethodCallWithId(target: Id, arguments: ArraySeq[Expression]) e
     callee.findMethod(target.name, argTypes, staticContext, context) match {
       case Right(method) =>
         cachedMethod = Some(method)
-        if (
-          method.isTestVisible &&
-          method.visibility.contains(PRIVATE_MODIFIER) &&
-          !method.thisTypeIdOpt.contains(context.typeId) &&
-          !context.thisType.isUnitTest
-        ) {
+        if (TestVisibleAccess.isInvalidPrivateMethodAccess(method, context.thisType)) {
           context.logError(
             location,
             "Private @TestVisible methods can only be accessed from @IsTest classes"

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
@@ -26,11 +26,7 @@ import com.nawforce.apexlink.types.other.{AnyDeclaration, RecordSetDeclaration}
 import com.nawforce.apexlink.types.platform.{PlatformTypeDeclaration, PlatformTypes}
 import com.nawforce.apexlink.types.synthetic.CustomConstructorDeclaration
 import com.nawforce.pkgforce.diagnostics.{ERROR_CATEGORY, Issue, WARNING_CATEGORY}
-import com.nawforce.pkgforce.modifiers.{
-  INTEGRATION_TEST_ANNOTATION,
-  PRIVATE_MODIFIER,
-  TEST_VISIBLE_ANNOTATION
-}
+import com.nawforce.pkgforce.modifiers.{INTEGRATION_TEST_ANNOTATION, PRIVATE_MODIFIER}
 import com.nawforce.pkgforce.names.{EncodedName, Name, Names, TypeName}
 import com.nawforce.pkgforce.path.{Locatable, Location, PathLocation}
 import com.nawforce.runtime.parsers.CodeParser
@@ -448,13 +444,14 @@ final case class DotExpressionWithId(expression: Expression, safeNavigation: Boo
       DotExpression.findField(name, inputType, context.module, input.isStatic)
     if (field.nonEmpty) {
       if (
-        field.get.modifiers.contains(TEST_VISIBLE_ANNOTATION) &&
+        field.get.isTestVisible &&
         field.get.visibility.contains(PRIVATE_MODIFIER) &&
-        context.thisType.modifiers.contains(INTEGRATION_TEST_ANNOTATION)
+        !field.get.thisTypeIdOpt.contains(context.typeId) &&
+        !context.thisType.isUnitTest
       ) {
         context.logError(
           location,
-          "@IntegrationTest classes can not access private @TestVisible fields"
+          "Private @TestVisible fields can only be accessed from @IsTest classes"
         )
       }
       context.addDependency(field.get)
@@ -622,13 +619,14 @@ final case class MethodCallWithId(target: Id, arguments: ArraySeq[Expression]) e
       case Right(method) =>
         cachedMethod = Some(method)
         if (
-          method.modifiers.contains(TEST_VISIBLE_ANNOTATION) &&
+          method.isTestVisible &&
           method.visibility.contains(PRIVATE_MODIFIER) &&
-          context.thisType.modifiers.contains(INTEGRATION_TEST_ANNOTATION)
+          !method.thisTypeIdOpt.contains(context.typeId) &&
+          !context.thisType.isUnitTest
         ) {
           context.logError(
             location,
-            "@IntegrationTest classes can not access private @TestVisible methods"
+            "Private @TestVisible methods can only be accessed from @IsTest classes"
           )
         }
         if (

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
@@ -19,11 +19,7 @@ import com.nawforce.apexlink.org.Referenceable
 import com.nawforce.apexlink.types.apex.{ApexClassDeclaration, ApexFieldLike}
 import com.nawforce.apexlink.types.core.{FieldDeclaration, TypeDeclaration}
 import com.nawforce.apexlink.types.platform.PlatformTypes
-import com.nawforce.pkgforce.modifiers.{
-  INTEGRATION_TEST_ANNOTATION,
-  PRIVATE_MODIFIER,
-  TEST_VISIBLE_ANNOTATION
-}
+import com.nawforce.pkgforce.modifiers.PRIVATE_MODIFIER
 import com.nawforce.pkgforce.names._
 import com.nawforce.pkgforce.path.Location
 import com.nawforce.runtime.parsers.CodeParser
@@ -155,13 +151,14 @@ final case class IdPrimary(id: Id) extends Primary {
 
     if (field.nonEmpty && isAccessible(td, field.get, staticContext)) {
       if (
-        field.get.modifiers.contains(TEST_VISIBLE_ANNOTATION) &&
+        field.get.isTestVisible &&
         field.get.visibility.contains(PRIVATE_MODIFIER) &&
-        context.thisType.modifiers.contains(INTEGRATION_TEST_ANNOTATION)
+        !field.get.thisTypeIdOpt.contains(context.typeId) &&
+        !context.thisType.isUnitTest
       ) {
         context.logError(
           location,
-          "@IntegrationTest classes can not access private @TestVisible fields"
+          "Private @TestVisible fields can only be accessed from @IsTest classes"
         )
       }
       Referenceable.addReferencingLocation(field.get, location, context.thisType)

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
@@ -19,7 +19,6 @@ import com.nawforce.apexlink.org.Referenceable
 import com.nawforce.apexlink.types.apex.{ApexClassDeclaration, ApexFieldLike}
 import com.nawforce.apexlink.types.core.{FieldDeclaration, TypeDeclaration}
 import com.nawforce.apexlink.types.platform.PlatformTypes
-import com.nawforce.pkgforce.modifiers.PRIVATE_MODIFIER
 import com.nawforce.pkgforce.names._
 import com.nawforce.pkgforce.path.Location
 import com.nawforce.runtime.parsers.CodeParser
@@ -150,12 +149,7 @@ final case class IdPrimary(id: Id) extends Primary {
     cachedClassFieldDeclaration = field
 
     if (field.nonEmpty && isAccessible(td, field.get, staticContext)) {
-      if (
-        field.get.isTestVisible &&
-        field.get.visibility.contains(PRIVATE_MODIFIER) &&
-        !field.get.thisTypeIdOpt.contains(context.typeId) &&
-        !context.thisType.isUnitTest
-      ) {
+      if (TestVisibleAccess.isInvalidPrivateFieldAccess(field.get, context.thisType)) {
         context.logError(
           location,
           "Private @TestVisible fields can only be accessed from @IsTest classes"

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/TestVisibleAccess.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/TestVisibleAccess.scala
@@ -1,0 +1,52 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.apexlink.cst
+
+import com.nawforce.apexlink.types.apex.{ApexDeclaration, ApexFieldLike, ApexMethodLike}
+import com.nawforce.apexlink.types.core.{FieldDeclaration, MethodDeclaration, TypeDeclaration}
+import com.nawforce.pkgforce.modifiers.PRIVATE_MODIFIER
+
+object TestVisibleAccess {
+  def isInvalidPrivateFieldAccess(field: FieldDeclaration, calledFrom: TypeDeclaration): Boolean = {
+    field.isTestVisible &&
+    field.visibility.contains(PRIVATE_MODIFIER) &&
+    !isSameApexFile(field, calledFrom) &&
+    !calledFrom.isUnitTestContext
+  }
+
+  def isInvalidPrivateMethodAccess(
+    method: MethodDeclaration,
+    calledFrom: TypeDeclaration
+  ): Boolean = {
+    method.isTestVisible &&
+    method.visibility.contains(PRIVATE_MODIFIER) &&
+    !isSameApexFile(method, calledFrom) &&
+    !calledFrom.isUnitTestContext
+  }
+
+  private def isSameApexFile(field: FieldDeclaration, calledFrom: TypeDeclaration): Boolean = {
+    (field, calledFrom) match {
+      case (af: ApexFieldLike, ad: ApexDeclaration) => af.location.path == ad.location.path
+      case _                                        => false
+    }
+  }
+
+  private def isSameApexFile(method: MethodDeclaration, calledFrom: TypeDeclaration): Boolean = {
+    (method, calledFrom) match {
+      case (am: ApexMethodLike, ad: ApexDeclaration) => am.location.path == ad.location.path
+      case _                                         => false
+    }
+  }
+}

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/core/TypeDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/core/TypeDeclaration.scala
@@ -59,6 +59,8 @@ trait FieldDeclaration extends DependencyHolder with UnsafeLocatable with Depend
   def visibility: Option[Modifier] =
     modifiers.find(m => ApexModifiers.visibilityModifiers.contains(m))
 
+  lazy val isTestVisible: Boolean = modifiers.contains(TEST_VISIBLE_ANNOTATION)
+
   def isExternallyVisible: Boolean =
     modifiers.exists(FieldDeclaration.externalFieldModifiers.contains)
 
@@ -228,7 +230,7 @@ trait ConstructorDeclaration extends DependencyHolder with Dependent with Parame
 
   def visibility: Modifier =
     modifiers.find(m => ApexModifiers.visibilityModifiers.contains(m)).getOrElse(PRIVATE_MODIFIER)
-  def isTestVisible: Boolean = modifiers.contains(TEST_VISIBLE_ANNOTATION)
+  lazy val isTestVisible: Boolean = modifiers.contains(TEST_VISIBLE_ANNOTATION)
 
   /** Test if the passed constructor has params compatible with this method. Ideally this would just
     * be a comparison of type names but there is a quirk in how platform generic interfaces are
@@ -264,11 +266,11 @@ trait MethodDeclaration extends DependencyHolder with Dependent with Parameters 
   def nameAndParameterTypes: String = s"$name($parameterTypes)"
   def parameterTypes: String        = parameters.map(_.typeName).mkString(", ")
 
-  def isStatic: Boolean      = modifiers.contains(STATIC_MODIFIER)
-  def isAbstract: Boolean    = modifiers.contains(ABSTRACT_MODIFIER)
-  def isVirtual: Boolean     = modifiers.contains(VIRTUAL_MODIFIER)
-  def isOverride: Boolean    = modifiers.contains(OVERRIDE_MODIFIER)
-  def isTestVisible: Boolean = modifiers.contains(TEST_VISIBLE_ANNOTATION)
+  def isStatic: Boolean           = modifiers.contains(STATIC_MODIFIER)
+  def isAbstract: Boolean         = modifiers.contains(ABSTRACT_MODIFIER)
+  def isVirtual: Boolean          = modifiers.contains(VIRTUAL_MODIFIER)
+  def isOverride: Boolean         = modifiers.contains(OVERRIDE_MODIFIER)
+  lazy val isTestVisible: Boolean = modifiers.contains(TEST_VISIBLE_ANNOTATION)
 
   def visibility: Option[Modifier] =
     modifiers.find(m => ApexModifiers.visibilityModifiers.contains(m))
@@ -424,6 +426,7 @@ trait TypeDeclaration extends AbstractTypeDeclaration with Dependent with PreReV
   def visibility: Option[Modifier] = ApexModifiers.visibilityModifiers.find(modifiers.contains)
   def isAbstract: Boolean          = modifiers.contains(ABSTRACT_MODIFIER)
   def isVirtual: Boolean           = modifiers.contains(VIRTUAL_MODIFIER)
+  lazy val isUnitTest: Boolean     = modifiers.contains(ISTEST_ANNOTATION)
   def isExtensible: Boolean =
     nature == INTERFACE_NATURE || (nature == CLASS_NATURE && (isAbstract || isVirtual))
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/core/TypeDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/core/TypeDeclaration.scala
@@ -427,6 +427,8 @@ trait TypeDeclaration extends AbstractTypeDeclaration with Dependent with PreReV
   def isAbstract: Boolean          = modifiers.contains(ABSTRACT_MODIFIER)
   def isVirtual: Boolean           = modifiers.contains(VIRTUAL_MODIFIER)
   lazy val isUnitTest: Boolean     = modifiers.contains(ISTEST_ANNOTATION)
+  lazy val isUnitTestContext: Boolean =
+    isUnitTest || (inTest && outerTypeDeclaration.exists(_.isUnitTestContext))
   def isExtensible: Boolean =
     nature == INTERFACE_NATURE || (nature == CLASS_NATURE && (isAbstract || isVirtual))
 

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/ConstructorTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/ConstructorTest.scala
@@ -109,6 +109,30 @@ class ConstructorTest extends AnyFunSuite with TestHelper {
     assert(dummyIssues.isEmpty)
   }
 
+  test("Non-test class can not call private TestVisible constructors") {
+    typeDeclarations(
+      Map(
+        "Foo.cls"   -> "public class Foo { Foo(){} @TestVisible private Foo(Integer i) {}}",
+        "Dummy.cls" -> "public class Dummy { public Dummy(String s){new Foo(1);} }"
+      )
+    )
+    assert(
+      dummyIssues == "Error: line 1 at 51-54: Constructor is not visible: Foo.<constructor>(System.Integer)\n"
+    )
+  }
+
+  test("IntegrationTest class can not call private TestVisible constructors") {
+    typeDeclarations(
+      Map(
+        "Foo.cls" -> "public class Foo { Foo(){} @TestVisible private Foo(Integer i) {}}",
+        "Dummy.cls" -> "@IntegrationTest public class Dummy { @IntegrationTest public static void testA(){new Foo(1);} }"
+      )
+    )
+    assert(
+      dummyIssues == "Error: line 1 at 89-92: Constructor is not visible: Foo.<constructor>(System.Integer)\n"
+    )
+  }
+
   test("Call to invalid super constructor") {
     typeDeclarations(
       Map(

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/ConstructorTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/ConstructorTest.scala
@@ -109,6 +109,16 @@ class ConstructorTest extends AnyFunSuite with TestHelper {
     assert(dummyIssues.isEmpty)
   }
 
+  test("Nested class in IsTest class can call private TestVisible constructors") {
+    typeDeclarations(
+      Map(
+        "Foo.cls" -> "public class Foo { Foo(){} @TestVisible private Foo(Integer i) {}}",
+        "Dummy.cls" -> "@isTest public class Dummy { private class Inner { public Inner(){new Foo(1);} } }"
+      )
+    )
+    assert(dummyIssues.isEmpty)
+  }
+
   test("Non-test class can not call private TestVisible constructors") {
     typeDeclarations(
       Map(

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/FieldTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/FieldTest.scala
@@ -99,4 +99,59 @@ class FieldTest extends AnyFunSuite with TestHelper {
     )
   }
 
+  test("IntegrationTest can not access private TestVisible field") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {@TestVisible private static String helper;}",
+        "Dummy.cls" -> "@IntegrationTest public class Dummy {@IntegrationTest public static void f2() {String value = Target.helper;}}"
+      )
+    )
+    assert(
+      getMessages(
+        root.join("Dummy.cls")
+      ) == "Error: line 1 at 94-107: Private @TestVisible fields can only be accessed from @IsTest classes\n"
+    )
+  }
+
+  test("Non-test class can not access private TestVisible field") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {@TestVisible private static String helper;}",
+        "Dummy.cls" -> "public class Dummy {public static void f2() {String value = Target.helper;}}"
+      )
+    )
+    assert(
+      getMessages(
+        root.join("Dummy.cls")
+      ) == "Error: line 1 at 60-73: Private @TestVisible fields can only be accessed from @IsTest classes\n"
+    )
+  }
+
+  test("IsTest class can access private TestVisible field") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {@TestVisible private static String helper;}",
+        "Dummy.cls" -> "@IsTest public class Dummy {@IsTest public static void f2() {String value = Target.helper;}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).isEmpty)
+  }
+
+  test("Nested class in IsTest class can access private TestVisible field") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {@TestVisible private static String helper;}",
+        "Dummy.cls" -> "@IsTest public class Dummy {private class Inner {public void f2() {String value = Target.helper;}}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).isEmpty)
+  }
+
+  test("Same file class can access private TestVisible field") {
+    typeDeclaration(
+      "public class Dummy {@TestVisible private static String helper; public class Inner {public void f2() {String value = Dummy.helper;}}}"
+    )
+    assert(dummyIssues.isEmpty)
+  }
+
 }

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
@@ -170,61 +170,6 @@ class MethodTest extends AnyFunSuite with TestHelper {
     assert(dummyIssues.isEmpty)
   }
 
-  test("IntegrationTest can not access private TestVisible field") {
-    typeDeclarations(
-      Map(
-        "Target.cls" -> "public class Target {@TestVisible private static String helper;}",
-        "Dummy.cls" -> "@IntegrationTest public class Dummy {@IntegrationTest public static void f2() {String value = Target.helper;}}"
-      )
-    )
-    assert(
-      getMessages(
-        root.join("Dummy.cls")
-      ) == "Error: line 1 at 94-107: Private @TestVisible fields can only be accessed from @IsTest classes\n"
-    )
-  }
-
-  test("Non-test class can not access private TestVisible field") {
-    typeDeclarations(
-      Map(
-        "Target.cls" -> "public class Target {@TestVisible private static String helper;}",
-        "Dummy.cls" -> "public class Dummy {public static void f2() {String value = Target.helper;}}"
-      )
-    )
-    assert(
-      getMessages(
-        root.join("Dummy.cls")
-      ) == "Error: line 1 at 60-73: Private @TestVisible fields can only be accessed from @IsTest classes\n"
-    )
-  }
-
-  test("IsTest class can access private TestVisible field") {
-    typeDeclarations(
-      Map(
-        "Target.cls" -> "public class Target {@TestVisible private static String helper;}",
-        "Dummy.cls" -> "@IsTest public class Dummy {@IsTest public static void f2() {String value = Target.helper;}}"
-      )
-    )
-    assert(getMessages(root.join("Dummy.cls")).isEmpty)
-  }
-
-  test("Nested class in IsTest class can access private TestVisible field") {
-    typeDeclarations(
-      Map(
-        "Target.cls" -> "public class Target {@TestVisible private static String helper;}",
-        "Dummy.cls" -> "@IsTest public class Dummy {private class Inner {public void f2() {String value = Target.helper;}}}"
-      )
-    )
-    assert(getMessages(root.join("Dummy.cls")).isEmpty)
-  }
-
-  test("Same file class can access private TestVisible field") {
-    typeDeclaration(
-      "public class Dummy {@TestVisible private static String helper; public class Inner {public void f2() {String value = Dummy.helper;}}}"
-    )
-    assert(dummyIssues.isEmpty)
-  }
-
   test("Method call with non-ambiguous target") {
     FileSystemHelper.run(
       Map(

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
@@ -153,6 +153,23 @@ class MethodTest extends AnyFunSuite with TestHelper {
     assert(getMessages(root.join("Dummy.cls")).isEmpty)
   }
 
+  test("Nested class in IsTest class can access private TestVisible method") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {@TestVisible private static void helper(){}}",
+        "Dummy.cls" -> "@IsTest public class Dummy {private class Inner {public void f2() {Target.helper();}}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).isEmpty)
+  }
+
+  test("Same file class can access private TestVisible method") {
+    typeDeclaration(
+      "public class Dummy {@TestVisible private static void helper(){} public class Inner {public void f2() {Dummy.helper();}}}"
+    )
+    assert(dummyIssues.isEmpty)
+  }
+
   test("IntegrationTest can not access private TestVisible field") {
     typeDeclarations(
       Map(
@@ -189,6 +206,23 @@ class MethodTest extends AnyFunSuite with TestHelper {
       )
     )
     assert(getMessages(root.join("Dummy.cls")).isEmpty)
+  }
+
+  test("Nested class in IsTest class can access private TestVisible field") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {@TestVisible private static String helper;}",
+        "Dummy.cls" -> "@IsTest public class Dummy {private class Inner {public void f2() {String value = Target.helper;}}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).isEmpty)
+  }
+
+  test("Same file class can access private TestVisible field") {
+    typeDeclaration(
+      "public class Dummy {@TestVisible private static String helper; public class Inner {public void f2() {String value = Dummy.helper;}}}"
+    )
+    assert(dummyIssues.isEmpty)
   }
 
   test("Method call with non-ambiguous target") {

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
@@ -125,8 +125,32 @@ class MethodTest extends AnyFunSuite with TestHelper {
     assert(
       getMessages(
         root.join("Dummy.cls")
-      ) == "Error: line 1 at 79-94: @IntegrationTest classes can not access private @TestVisible methods\n"
+      ) == "Error: line 1 at 79-94: Private @TestVisible methods can only be accessed from @IsTest classes\n"
     )
+  }
+
+  test("Non-test class can not access private TestVisible method") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {@TestVisible private static void helper(){}}",
+        "Dummy.cls"  -> "public class Dummy {public static void f2() {Target.helper();}}"
+      )
+    )
+    assert(
+      getMessages(
+        root.join("Dummy.cls")
+      ) == "Error: line 1 at 45-60: Private @TestVisible methods can only be accessed from @IsTest classes\n"
+    )
+  }
+
+  test("IsTest class can access private TestVisible method") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {@TestVisible private static void helper(){}}",
+        "Dummy.cls" -> "@IsTest public class Dummy {@IsTest public static void f2() {Target.helper();}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).isEmpty)
   }
 
   test("IntegrationTest can not access private TestVisible field") {
@@ -139,8 +163,32 @@ class MethodTest extends AnyFunSuite with TestHelper {
     assert(
       getMessages(
         root.join("Dummy.cls")
-      ) == "Error: line 1 at 94-107: @IntegrationTest classes can not access private @TestVisible fields\n"
+      ) == "Error: line 1 at 94-107: Private @TestVisible fields can only be accessed from @IsTest classes\n"
     )
+  }
+
+  test("Non-test class can not access private TestVisible field") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {@TestVisible private static String helper;}",
+        "Dummy.cls" -> "public class Dummy {public static void f2() {String value = Target.helper;}}"
+      )
+    )
+    assert(
+      getMessages(
+        root.join("Dummy.cls")
+      ) == "Error: line 1 at 60-73: Private @TestVisible fields can only be accessed from @IsTest classes\n"
+    )
+  }
+
+  test("IsTest class can access private TestVisible field") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {@TestVisible private static String helper;}",
+        "Dummy.cls" -> "@IsTest public class Dummy {@IsTest public static void f2() {String value = Target.helper;}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).isEmpty)
   }
 
   test("Method call with non-ambiguous target") {


### PR DESCRIPTION
## Summary

- Restrict private `@TestVisible` method, field, and constructor access to `@IsTest` callers.
- Keep same-type private access intact while preventing `@IntegrationTest` and ordinary classes from using private `@TestVisible` members.
- Cache the relevant declaration checks used by the validation paths and add regression coverage for the new visibility behavior.
- Update the changelog for #471.

## Validation

- `sbt scalafmtAll`
- `sbt 'apexlsJVM/testOnly com.nawforce.apexlink.cst.MethodTest com.nawforce.apexlink.cst.ConstructorTest'`
- `sbt test`
