### PR TITLE
fix: enforce explicit member visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Private and protected field/method accesses from unrelated classes are now reported as visibility errors (#474)
 - Private `@TestVisible` methods, fields, and constructors are now only visible from `@IsTest` callers, matching Salesforce visibility rules for non-test and `@IntegrationTest` code (#471)
 - `@IntegrationTest` classes no longer reject ordinary helper members, and calls to `@IntegrationTest` methods from non-integration contexts are reported as warnings instead of deploy-blocking errors (#470)
 - Unused warnings for public static methods now call out their static nature and explain how to document intentional external entry points (#406)

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
@@ -443,12 +443,9 @@ final case class DotExpressionWithId(expression: Expression, safeNavigation: Boo
     val field: Option[FieldDeclaration] =
       DotExpression.findField(name, inputType, context.module, input.isStatic)
     if (field.nonEmpty) {
-      if (TestVisibleAccess.isInvalidPrivateFieldAccess(field.get, context.thisType)) {
-        context.logError(
-          location,
-          "Private @TestVisible fields can only be accessed from @IsTest classes"
-        )
-      }
+      TestVisibleAccess
+        .fieldAccessError(field.get, context.thisType)
+        .foreach(context.logError(location, _))
       context.addDependency(field.get)
       if (input.isStatic.contains(true) && !field.get.thisTypeIdOpt.contains(context.typeId))
         Referenceable.addReferencingLocation(inputType, field.get, location, context.thisType)
@@ -613,12 +610,9 @@ final case class MethodCallWithId(target: Id, arguments: ArraySeq[Expression]) e
     callee.findMethod(target.name, argTypes, staticContext, context) match {
       case Right(method) =>
         cachedMethod = Some(method)
-        if (TestVisibleAccess.isInvalidPrivateMethodAccess(method, context.thisType)) {
-          context.logError(
-            location,
-            "Private @TestVisible methods can only be accessed from @IsTest classes"
-          )
-        }
+        TestVisibleAccess
+          .methodAccessError(method, context.thisType)
+          .foreach(context.logError(location, _))
         if (
           method.modifiers.contains(INTEGRATION_TEST_ANNOTATION) &&
           !context.bodyModifiers(_ == INTEGRATION_TEST_ANNOTATION)

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
@@ -149,12 +149,9 @@ final case class IdPrimary(id: Id) extends Primary {
     cachedClassFieldDeclaration = field
 
     if (field.nonEmpty && isAccessible(td, field.get, staticContext)) {
-      if (TestVisibleAccess.isInvalidPrivateFieldAccess(field.get, context.thisType)) {
-        context.logError(
-          location,
-          "Private @TestVisible fields can only be accessed from @IsTest classes"
-        )
-      }
+      TestVisibleAccess
+        .fieldAccessError(field.get, context.thisType)
+        .foreach(context.logError(location, _))
       Referenceable.addReferencingLocation(field.get, location, context.thisType)
       context.addDependency(field.get)
       Some(

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/TestVisibleAccess.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/TestVisibleAccess.scala
@@ -16,9 +16,36 @@ package com.nawforce.apexlink.cst
 
 import com.nawforce.apexlink.types.apex.{ApexDeclaration, ApexFieldLike, ApexMethodLike}
 import com.nawforce.apexlink.types.core.{FieldDeclaration, MethodDeclaration, TypeDeclaration}
-import com.nawforce.pkgforce.modifiers.PRIVATE_MODIFIER
+import com.nawforce.pkgforce.modifiers.{
+  GLOBAL_MODIFIER,
+  Modifier,
+  PRIVATE_MODIFIER,
+  PROTECTED_MODIFIER,
+  PUBLIC_MODIFIER
+}
+import com.nawforce.pkgforce.names.TypeName
 
 object TestVisibleAccess {
+  def fieldAccessError(field: FieldDeclaration, calledFrom: TypeDeclaration): Option[String] = {
+    if (isInvalidPrivateFieldAccess(field, calledFrom)) {
+      Some("Private @TestVisible fields can only be accessed from @IsTest classes")
+    } else if (!isFieldAccessible(field, calledFrom)) {
+      Some(s"Field is not visible: ${field.name}")
+    } else {
+      None
+    }
+  }
+
+  def methodAccessError(method: MethodDeclaration, calledFrom: TypeDeclaration): Option[String] = {
+    if (isInvalidPrivateMethodAccess(method, calledFrom)) {
+      Some("Private @TestVisible methods can only be accessed from @IsTest classes")
+    } else if (!isMethodAccessible(method, calledFrom)) {
+      Some(s"Method is not visible: ${method.nameAndParameterTypes}")
+    } else {
+      None
+    }
+  }
+
   def isInvalidPrivateFieldAccess(field: FieldDeclaration, calledFrom: TypeDeclaration): Boolean = {
     field.isTestVisible &&
     field.visibility.contains(PRIVATE_MODIFIER) &&
@@ -34,6 +61,56 @@ object TestVisibleAccess {
     method.visibility.contains(PRIVATE_MODIFIER) &&
     !isSameApexFile(method, calledFrom) &&
     !calledFrom.isUnitTestContext
+  }
+
+  private def isFieldAccessible(field: FieldDeclaration, calledFrom: TypeDeclaration): Boolean = {
+    field.visibility
+      .forall(visibility =>
+        isAccessible(
+          visibility,
+          field.thisTypeIdOpt.map(_.typeName),
+          isSameApexFile(field, calledFrom),
+          field.isTestVisible,
+          calledFrom
+        )
+      )
+  }
+
+  private def isMethodAccessible(
+    method: MethodDeclaration,
+    calledFrom: TypeDeclaration
+  ): Boolean = {
+    method.visibility
+      .forall(visibility =>
+        isAccessible(
+          visibility,
+          method.thisTypeIdOpt.map(_.typeName),
+          isSameApexFile(method, calledFrom),
+          method.isTestVisible,
+          calledFrom
+        )
+      )
+  }
+
+  private def isAccessible(
+    visibility: Modifier,
+    ownerTypeName: Option[TypeName],
+    isSameApexFile: Boolean,
+    isTestVisible: Boolean,
+    calledFrom: TypeDeclaration
+  ): Boolean = {
+    lazy val isSameTypeOrSubtype =
+      ownerTypeName.exists(owner =>
+        calledFrom.typeName == owner || calledFrom.extendsOrImplements(owner)
+      )
+    lazy val isUnitTestVisible = isTestVisible && calledFrom.isUnitTestContext
+
+    visibility match {
+      case PUBLIC_MODIFIER | GLOBAL_MODIFIER => true
+      case PROTECTED_MODIFIER => isSameApexFile || isSameTypeOrSubtype || isUnitTestVisible
+      case PRIVATE_MODIFIER   => isSameApexFile || isUnitTestVisible
+      case _                  => false
+    }
   }
 
   private def isSameApexFile(field: FieldDeclaration, calledFrom: TypeDeclaration): Boolean = {

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/FieldTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/FieldTest.scala
@@ -81,6 +81,63 @@ class FieldTest extends AnyFunSuite with TestHelper {
     assert(dummyIssues == "Error: line 1 at 38-49: protected field 'foo' cannot be static\n")
   }
 
+  test("Unrelated class can not access private static field") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {private static String helper;}",
+        "Dummy.cls" -> "public class Dummy {public static void f2() {String value = Target.helper;}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).contains("Field is not visible"))
+  }
+
+  test("Unrelated class can not access private instance field") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {private String helper;}",
+        "Dummy.cls" -> "public class Dummy {public void f2(Target target) {String value = target.helper;}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).contains("Field is not visible"))
+  }
+
+  test("Unrelated class can not access protected instance field") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public virtual class Target {protected String helper;}",
+        "Dummy.cls" -> "public class Dummy {public void f2(Target target) {String value = target.helper;}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).contains("Field is not visible"))
+  }
+
+  test("Subclass can access protected instance field") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public virtual class Target {protected String helper;}",
+        "Dummy.cls" -> "public class Dummy extends Target {public void f2() {String value = helper;}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).isEmpty)
+  }
+
+  test("Subclass can not access private instance field") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public virtual class Target {private String helper;}",
+        "Dummy.cls" -> "public class Dummy extends Target {public void f2() {String value = helper;}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).contains("Field is not visible"))
+  }
+
+  test("Same file class can access private field") {
+    typeDeclaration(
+      "public class Dummy {private static String helper; public class Inner {public void f2() {String value = Dummy.helper;}}}"
+    )
+    assert(dummyIssues.isEmpty)
+  }
+
   test("Potentially recursive field lookup") {
     // The search order for 'a' here is Inner -> (Outer)Dummy -> (Superclass)Inner -> (Outer)Dummy
     // Unless we step in to stop the recursion by avoiding a repeat search of Inner
@@ -131,6 +188,16 @@ class FieldTest extends AnyFunSuite with TestHelper {
     typeDeclarations(
       Map(
         "Target.cls" -> "public class Target {@TestVisible private static String helper;}",
+        "Dummy.cls" -> "@IsTest public class Dummy {@IsTest public static void f2() {String value = Target.helper;}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).isEmpty)
+  }
+
+  test("IsTest class can access protected TestVisible field") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public virtual class Target {@TestVisible protected static String helper;}",
         "Dummy.cls" -> "@IsTest public class Dummy {@IsTest public static void f2() {String value = Target.helper;}}"
       )
     )

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
@@ -64,6 +64,63 @@ class MethodTest extends AnyFunSuite with TestHelper {
     assert(dummyIssues.isEmpty)
   }
 
+  test("Unrelated class can not call private static method") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {private static void helper(){}}",
+        "Dummy.cls"  -> "public class Dummy {public static void f2() {Target.helper();}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).contains("Method is not visible"))
+  }
+
+  test("Unrelated class can not call private instance method") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {private void helper(){}}",
+        "Dummy.cls"  -> "public class Dummy {public void f2(Target target) {target.helper();}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).contains("Method is not visible"))
+  }
+
+  test("Unrelated class can not call protected instance method") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public virtual class Target {protected void helper(){}}",
+        "Dummy.cls"  -> "public class Dummy {public void f2(Target target) {target.helper();}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).contains("Method is not visible"))
+  }
+
+  test("Subclass can call protected instance method") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public virtual class Target {protected void helper(){}}",
+        "Dummy.cls"  -> "public class Dummy extends Target {public void f2() {helper();}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).isEmpty)
+  }
+
+  test("Subclass can not resolve private instance method") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public virtual class Target {private void helper(){}}",
+        "Dummy.cls"  -> "public class Dummy extends Target {public void f2() {helper();}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).contains("No matching method found"))
+  }
+
+  test("Same file class can call private method") {
+    typeDeclaration(
+      "public class Dummy {private static void helper(){} public class Inner {public void f2() {Dummy.helper();}}}"
+    )
+    assert(dummyIssues.isEmpty)
+  }
+
   test("IntegrationTest method called from IntegrationTest method") {
     typeDeclaration(
       "@IntegrationTest public class Dummy {@IntegrationTest static void f1(){} @IntegrationTest static void f2() {f1();} }"
@@ -147,6 +204,16 @@ class MethodTest extends AnyFunSuite with TestHelper {
     typeDeclarations(
       Map(
         "Target.cls" -> "public class Target {@TestVisible private static void helper(){}}",
+        "Dummy.cls" -> "@IsTest public class Dummy {@IsTest public static void f2() {Target.helper();}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).isEmpty)
+  }
+
+  test("IsTest class can access protected TestVisible method") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public virtual class Target {@TestVisible protected static void helper(){}}",
         "Dummy.cls" -> "@IsTest public class Dummy {@IsTest public static void f2() {Target.helper();}}"
       )
     )


### PR DESCRIPTION
## Summary
- Report visibility errors for explicit private/protected field and method access from unrelated classes.
- Preserve same-file/subtype access rules and @TestVisible access from @IsTest contexts, including protected members.
- Add focused field and method regression coverage and document the fix in the changelog.

## Tests
- `sbt scalafmtAll`
- `sbt test`
- `sbt apexlsJVM/build`
- `cd js/npm && SAMPLES=$(cd ../../../apex-samples && pwd) npm run test-samples -- --runInBand`