### PR TITLE
fix: warn on security enforced soql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- SOQL queries using deprecated `WITH SECURITY_ENFORCED` now report a warning recommending `WITH USER_MODE` (#466)
 - Private `@TestVisible` methods, fields, and constructors are now only visible from `@IsTest` callers, matching Salesforce visibility rules for non-test and `@IntegrationTest` code (#471)
 - `@IntegrationTest` classes no longer reject ordinary helper members, and calls to `@IntegrationTest` methods from non-integration contexts are reported as warnings instead of deploy-blocking errors (#470)
 - Unused warnings for public static methods now call out their static nature and explain how to document intentional external entry points (#406)

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
@@ -19,8 +19,9 @@ import com.nawforce.apexlink.org.Referenceable
 import com.nawforce.apexlink.types.apex.{ApexClassDeclaration, ApexFieldLike}
 import com.nawforce.apexlink.types.core.{FieldDeclaration, TypeDeclaration}
 import com.nawforce.apexlink.types.platform.PlatformTypes
+import com.nawforce.pkgforce.diagnostics.{Issue, WARNING_CATEGORY}
 import com.nawforce.pkgforce.names._
-import com.nawforce.pkgforce.path.Location
+import com.nawforce.pkgforce.path.{Location, PathLocation}
 import com.nawforce.runtime.parsers.CodeParser
 import io.github.apexdevtools.apexparser.ApexParser._
 import io.github.apexdevtools.apexparser.ApexParserBaseVisitor
@@ -224,7 +225,8 @@ case object AGGREGATE_RESULT_QUERY extends QueryResultType
 final case class SOQL(
   queryResultType: QueryResultType,
   fromNames: Array[DotName],
-  boundExpressions: ArraySeq[Expression]
+  boundExpressions: ArraySeq[Expression],
+  deprecatedSecurityEnforcedLocation: Option[PathLocation]
 ) extends Primary {
 
   override def verify(input: ExprContext, context: ExpressionVerifyContext): ExprContext = {
@@ -232,6 +234,16 @@ final case class SOQL(
     boundExpressions.foreach(expr => {
       expr.verify(input, context)
     })
+
+    deprecatedSecurityEnforcedLocation.foreach(location =>
+      context.log(
+        Issue(
+          WARNING_CATEGORY,
+          location,
+          "WITH SECURITY_ENFORCED is deprecated, use WITH USER_MODE instead"
+        )
+      )
+    )
 
     if (fromNames.length != 1 || fromNames.head.names.size != 1) {
       context.logError(
@@ -303,7 +315,13 @@ object SOQL {
               .map(name => Name(Option(name).map(_.getText).getOrElse("")))
           )
         )
-    new SOQL(resultType, fromNames.toArray, boundedExpressions)
+
+    val deprecatedSecurityEnforcedLocation =
+      Option(query.withClause())
+        .filter(withClause => Option(withClause.SECURITY_ENFORCED()).nonEmpty)
+        .map(withClause => CST.sourceContext.value.get.getLocation(withClause))
+
+    new SOQL(resultType, fromNames.toArray, boundedExpressions, deprecatedSecurityEnforcedLocation)
   }
 }
 

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/InlineQueryTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/InlineQueryTest.scala
@@ -37,6 +37,19 @@ class InlineQueryTest extends AnyFunSuite with TestHelper {
     }
   }
 
+  test("SOQL security enforced warning") {
+    typeDeclaration(
+      "public class Dummy {{ Object a = [Select Id from Account WITH SECURITY_ENFORCED]; }}"
+    )
+    assert(dummyIssues.contains("WITH SECURITY_ENFORCED is deprecated, use WITH USER_MODE instead"))
+  }
+
+  test("SOQL user mode no warning") {
+    happyTypeDeclaration(
+      "public class Dummy {{ Object a = [Select Id from Account WITH USER_MODE]; }}"
+    )
+  }
+
   test("SOQL list assignment") {
     happyTypeDeclaration("public class Dummy {{ List<Account> a = [Select Id from Account]; }}")
   }

--- a/jvm/src/test/scala/com/nawforce/pkgforce/parsers/SOQLParserTest.scala
+++ b/jvm/src/test/scala/com/nawforce/pkgforce/parsers/SOQLParserTest.scala
@@ -58,6 +58,14 @@ class SOQLParserTest extends AnyFunSuite with Matchers {
     assert(SOQLParser.parse("Select A from Table").isRight)
   }
 
+  test("With Security Enforced") {
+    assert(SOQLParser.parse("Select A from Table WITH SECURITY_ENFORCED").isRight)
+  }
+
+  test("With User Mode") {
+    assert(SOQLParser.parse("Select A from Table WITH USER_MODE").isRight)
+  }
+
   test("Single field, multi-table") {
     assert(SOQLParser.parse("Select A from Table1, Table2").isRight)
   }


### PR DESCRIPTION
## Summary

- Adds a warning for inline SOQL queries using deprecated `WITH SECURITY_ENFORCED`, recommending `WITH USER_MODE`.
- Keeps `WITH USER_MODE` accepted without diagnostics.
- Adds parser/CST regression coverage and updates sample snapshots for the new warning.

## Validation

- `sbt scalafmtAll`
- `sbt "apexlsJVM/testOnly com.nawforce.pkgforce.parsers.SOQLParserTest com.nawforce.apexlink.cst.InlineQueryTest"`
- `sbt test`
- `sbt apexlsJVM/build`
- `cd js/npm && SAMPLES=$(cd ../../../apex-samples && pwd) npm run test-snapshot -- --runInBand`
- `cd js/npm && SAMPLES=$(cd ../../../apex-samples && pwd) npm run test-samples -- --runInBand`
