### PR TITLE
chore: upgrade to Summer '26 standard-types and sobject-types 67.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Upgraded platform types to Salesforce Summer '26 via standard-types and sobject-types 67.0.0
 - Removed the ANTLR-first parsing mode; OutlineParser is now the sole parser path. The `--antlr` / ANTLR parser option is deprecated and a no-op (#433)
 - Upgraded to apex-parser 5.1.0 and the antlr4 4.13 runtime
 - Slimmed the JS module surface to the published apex-ls facades

--- a/build.sbt
+++ b/build.sbt
@@ -62,8 +62,8 @@ lazy val apexls = crossProject(JSPlatform, JVMPlatform)
       "org.scala-js"            %% "scalajs-stubs"                  % "1.0.0",
       "io.github.apex-dev-tools" % "apex-parser"                    % "5.1.0-beta.1",
       "io.github.apex-dev-tools" % "vf-parser"                      % "2.0.0-beta.1",
-      "io.github.apex-dev-tools" % "sobject-types"                  % "65.0.0",
-      "io.github.apex-dev-tools" % "standard-types"                 % "65.0.0",
+      "io.github.apex-dev-tools" % "sobject-types"                  % "67.0.0",
+      "io.github.apex-dev-tools" % "standard-types"                 % "67.0.0",
       "io.methvin"              %% "directory-watcher-better-files" % "0.18.0",
       "com.github.nawforce"      % "uber-apex-jorje"                % "1.0.0" % Test,
       "com.google.jimfs"         % "jimfs"                          % "1.1"   % Test

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/platform/PlatformTypeDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/platform/PlatformTypeDeclaration.scala
@@ -32,7 +32,7 @@ import com.nawforce.pkgforce.modifiers.{Modifier, PUBLIC_MODIFIER}
 import com.nawforce.pkgforce.names.{DotName, Name, Names, TypeName}
 import com.nawforce.pkgforce.parsers.{CLASS_NATURE, ENUM_NATURE, INTERFACE_NATURE, Nature}
 import com.nawforce.pkgforce.path.{Location, PathLike, PathLocation}
-import com.nawforce.runforce.Internal.Object$
+import io.github.apexdevtools.standardtypes.Internal.Object$
 
 import java.nio.file.{FileSystemNotFoundException, FileSystems, Files, Paths}
 import java.util
@@ -119,7 +119,7 @@ class PlatformTypeDeclaration(val native: Any, val outer: Option[PlatformTypeDec
     cls: Class[_],
     accum: mutable.Map[Name, PlatformField] = mutable.Map()
   ): mutable.Map[Name, PlatformField] = {
-    if (cls.getCanonicalName.startsWith(PlatformTypeDeclaration.platformPackage)) {
+    if (PlatformTypeDeclaration.isPlatformClassName(cls.getCanonicalName)) {
       cls.getDeclaredFields
         .filterNot(_.isSynthetic)
         .foreach(f => {
@@ -163,8 +163,8 @@ class PlatformTypeDeclaration(val native: Any, val outer: Option[PlatformTypeDec
   protected def getMethods: ArraySeq[PlatformMethod] = {
     val localMethods =
       cls.getMethods
-        .filter(
-          _.getDeclaringClass.getCanonicalName.startsWith(PlatformTypeDeclaration.platformPackage)
+        .filter(m =>
+          PlatformTypeDeclaration.isPlatformClassName(m.getDeclaringClass.getCanonicalName)
         )
         .filterNot(_.isSynthetic)
     nature match {
@@ -298,9 +298,15 @@ class PlatformMethod(
 
 object PlatformTypeDeclaration {
   /* Java package prefix for platform types */
-  private val platformPackage = "com.nawforce.runforce"
+  private val platformPackage = "io.github.apexdevtools.standardtypes"
   /* Java package prefix for SObject types */
-  private val sObjectPackage = "com.nawforce.runforce.SObjects"
+  private val sObjectPackage = "io.github.apexdevtools.sobjecttypes"
+  /* Java package prefix for SObject stubs bundled with the platform types */
+  private val sObjectStubsPackage = s"$platformPackage.SObjectStubs"
+
+  /* Test if a Java class name is from one of the platform type packages */
+  private def isPlatformClassName(cname: String): Boolean =
+    cname.startsWith(platformPackage) || cname.startsWith(sObjectPackage)
 
   /* Cache of loaded platform declarations */
   private val declarationCache = mutable.Map[DotName, Option[PlatformTypeDeclaration]]()
@@ -310,7 +316,7 @@ object PlatformTypeDeclaration {
   lazy val platformPackagePath: java.nio.file.Path = getPathFromPackage(
     s"$platformPackage.System"
   ).getParent
-  lazy val sObjectPackagePath: java.nio.file.Path = getPathFromPackage(sObjectPackage).getParent
+  lazy val sObjectPackagePath: java.nio.file.Path = getPathFromPackage(sObjectPackage)
 
   private def getPathFromPackage(packagePath: String) = {
     val path = "/" + packagePath.replaceAll("\\.", "/")
@@ -357,13 +363,20 @@ object PlatformTypeDeclaration {
         assert(matched.size < 2, s"Found multiple platform type matches for $name")
         matched.map(name =>
           new PlatformTypeDeclaration(
-            classOf[PlatformTypeDeclaration].getClassLoader
-              .loadClass(platformPackage + "." + name),
+            classOf[PlatformTypeDeclaration].getClassLoader.loadClass(javaClassNameFor(name)),
             None
           )
         )
       }
     )
+  }
+
+  /* Java class name for an indexed platform or SObject type */
+  private def javaClassNameFor(name: DotName): String = {
+    if (name.firstName == Names.SObjects)
+      sObjectPackage + "." + DotName(name.names.tail).toString
+    else
+      platformPackage + "." + name.toString
   }
 
   /* Valid platform class names */
@@ -381,7 +394,7 @@ object PlatformTypeDeclaration {
   private lazy val classNameMap: HashMap[DotName, DotName] = {
     val names = mutable.HashMap[DotName, DotName]()
     indexDir(platformPackagePath, DotName(Seq()), names)
-    indexDir(sObjectPackagePath, DotName(Seq()), names)
+    indexDir(sObjectPackagePath, DotName(Seq(Names.SObjects)), names)
     HashMap[DotName, DotName]() ++ names
   }
 
@@ -462,12 +475,15 @@ object PlatformTypeDeclaration {
       } else if (cname == "void") {
         TypeNames.Void
       } else if (
-        cname.startsWith(platformPackage + ".SObjects") ||
-        cname.startsWith(platformPackage + ".SObjectStubs")
+        cname.startsWith(sObjectPackage + ".") ||
+        cname.startsWith(sObjectStubsPackage + ".")
       ) {
-        val names = cname
-          .replace("SObjectStubs", "SObjects")
-          .drop(platformPackage.length + 10)
+        val localName =
+          if (cname.startsWith(sObjectStubsPackage + "."))
+            cname.drop(sObjectStubsPackage.length + 1)
+          else
+            cname.drop(sObjectPackage.length + 1)
+        val names = localName
           .split('.')
           .map(n => Name(n))
           .reverse

--- a/jvm/src/test/scala/com/nawforce/apexlink/types/PlatformTypesValidationTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/types/PlatformTypesValidationTest.scala
@@ -42,7 +42,7 @@ class PlatformTypesValidationTest extends AnyFunSuite with TestHelper {
   )
 
   test("Right number of types (should exclude inners)") {
-    assert(PlatformTypeDeclaration.classNames.size == 6174)
+    assert(PlatformTypeDeclaration.classNames.size == 6510)
   }
 
   test("SObject type is visible") {


### PR DESCRIPTION
## Summary

Upgrades the platform type libraries to the Salesforce Summer '26 release:

- `standard-types` 65.0.0 → 67.0.0
- `sobject-types` 65.0.0 → 67.0.0

The v67 libraries relocate their Java packages. Standard types moved from `com.nawforce.runforce.*` to `io.github.apexdevtools.standardtypes.*`, and SObjects moved from the `com.nawforce.runforce.SObjects` subpackage to sit flat at the root of `io.github.apexdevtools.sobjecttypes`. The two libraries no longer share a common package root, so `PlatformTypeDeclaration` has been updated to:

- Index SObject classes from the new package root, seeding them with an `SObjects` prefix so the existing Schema namespace remapping is unchanged
- Load classes from the correct root per entry (standard types vs SObjects)
- Accept both roots in field/method collection and `typeNameFromClass` Schema mapping, including the `SObjectStubs` stub package bundled with standard-types

The expected type count in `PlatformTypesValidationTest` is updated from 6174 to 6510 for the Summer '26 additions.

## Testing

- `sbt test` — JVM 2453/2453 passed, Scala.js 367/367 passed
- `sbt scalafmtCheck` — clean
- `PlatformTypesValidationTest` type validation tests ("All outer types are valid", "Exceptions are valid") pass against the new jars without changes

The apex-samples system regression tests were not run locally; relying on CI for those.