### PR TITLE
fix: recompute unused warnings for cache-loaded classes (#477)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Unused method/field/type warnings are now recomputed for cache-loaded classes instead of replaying the cached result, so they reflect actual usage in the current workspace rather than a stale whole-program result captured when the cache was written (#477)
 - Private and protected field/method accesses from unrelated classes are now reported as visibility errors (#474)
 - SOQL queries using deprecated `WITH SECURITY_ENFORCED` now report a warning recommending `WITH USER_MODE` (#466)
 - Private `@TestVisible` methods, fields, and constructors are now only visible from `@IsTest` callers, matching Salesforce visibility rules for non-test and `@IntegrationTest` code (#471)

--- a/jvm/src/main/scala/com/nawforce/apexlink/api/Summary.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/api/Summary.scala
@@ -173,7 +173,8 @@ case class MethodSummary(
   var typeName: TypeName,
   parameters: ArraySeq[ParameterSummary],
   hasBlock: Boolean,
-  dependents: Array[DependentSummary]
+  dependents: Array[DependentSummary],
+  isSynthetic: Boolean = false
 ) {
 
   typeName = typeName.intern
@@ -195,6 +196,7 @@ case class MethodSummary(
     this.typeName == other.typeName &&
     this.parameters == other.parameters &&
     this.hasBlock == other.hasBlock &&
+    this.isSynthetic == other.isSynthetic &&
     this.dependents.sameElements(other.dependents)
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/StreamDeployer.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/StreamDeployer.scala
@@ -67,7 +67,9 @@ class StreamDeployer(
 
     // Run plugins over loaded types DependentTypes
     // This has to be done post loading to allow dependencies to be established
-    module.pkg.org.pluginsManager.closePlugins()
+    LoggerOps.infoTime("Closed plugins (unused analysis)", types.size > basicTypesSize) {
+      module.pkg.org.pluginsManager.closePlugins()
+    }
 
     // Report progress and tidy up
     if (types.size > basicTypesSize) {
@@ -192,17 +194,24 @@ class StreamDeployer(
       LoggerOps.info(s"Used $rejectCycles rejection cycles")
 
     // For those not rejected, complete processing
-    classes
-      .filterNot(rejected.contains)
-      .foreach(cls => {
-        // Re-establish dependencies
-        cls.declaration.propagateOuterDependencies(typeCache)
-        cls.declaration.propagateDependencies()
+    val survivors = classes.filterNot(rejected.contains)
+    survivors.foreach(cls => {
+      // Re-establish dependencies
+      cls.declaration.propagateOuterDependencies(typeCache)
+      cls.declaration.propagateDependencies()
 
-        // Report any (existing) diagnostics
-        val path = cls.declaration.location.path
-        cls.diagnostics.foreach(diagnostic => module.pkg.org.issues.add(Issue(path, diagnostic)))
-      })
+      // Report any (existing) diagnostics
+      val path = cls.declaration.location.path
+      cls.diagnostics.foreach(diagnostic => module.pkg.org.issues.add(Issue(path, diagnostic)))
+    })
+
+    // Seed cache-loaded classes into the plugin manager so holder-based unused analysis is
+    // recomputed for them in this workspace (UnusedPlugin.onSummaryValidated) during closePlugins,
+    // rather than replaying the workspace-dependent cached result (issue #477).
+    if (survivors.nonEmpty) {
+      survivors.foreach(cls => module.pkg.org.pluginsManager.createPlugin(cls.declaration))
+      LoggerOps.debug(s"Seeded ${survivors.length} cache-loaded classes for unused recompute")
+    }
   }
 
   /** Load classes from the code cache as types returning TypeNames of those available. Benchmarking

--- a/jvm/src/main/scala/com/nawforce/apexlink/plugins/UnusedPlugin.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/plugins/UnusedPlugin.scala
@@ -21,6 +21,7 @@ import com.nawforce.apexlink.types.apex.{
   ApexFieldLike,
   ApexMethodLike,
   FullDeclaration,
+  SummaryDeclaration,
   TriggerDeclaration
 }
 import com.nawforce.apexlink.types.core.{
@@ -66,7 +67,13 @@ class UnusedPlugin(td: DependentType, isLibrary: Boolean) extends Plugin(td, isL
       .distinct
   }
 
-  private def reportUnused(td: FullDeclaration): Seq[DependentType] = {
+  // Recompute holder-based unused for classes loaded from the parsed cache (issue #477). The cached
+  // result is workspace-dependent (unused is a whole-program property) so replaying it across
+  // workspaces is unsound. SummaryDeclarations are seeded directly into the plugin manager by
+  // StreamDeployer, and the ripple in reportUnused re-validates the types they depend on.
+  override def onSummaryValidated(td: SummaryDeclaration): Seq[DependentType] = reportUnused(td)
+
+  private def reportUnused(td: ApexClassDeclaration): Seq[DependentType] = {
     // Ignore if suppressed, or inner type (handled by unusedIssues)
     if (td.modifiers.exists(suppressModifiers.contains) || td.outerTypeName.isDefined) {
       Seq.empty
@@ -89,14 +96,23 @@ class UnusedPlugin(td: DependentType, isLibrary: Boolean) extends Plugin(td, isL
         )
       }
 
-      // Return all our dependents so they are re-validated for unused as well
-      val dependents = mutable.Set[Dependent]()
-      td.collectDependencies(dependents)
-      dependents
+      // Return the types we depend on so they are re-validated for unused as well. This is what
+      // makes the analysis order-independent: when a type is added that uses an earlier type, the
+      // earlier type is re-checked with the new holder present. Both parsed and cache-loaded types
+      // must contribute member-level dependencies (method/field/block use), not just type-level,
+      // otherwise a type used only from another type's method body is never re-validated.
+      val collected = mutable.Set[Dependent]()
+      td match {
+        case fd: FullDeclaration    => fd.collectDependencies(collected)
+        case sd: SummaryDeclaration => sd.collectDependencies(collected)
+        case _                      => collected ++= td.dependencies()
+      }
+      collected
         .collect { case td: TypeDeclaration => td }
         .map(_.outermostTypeDeclaration)
         .collect { case dt: DependentType => dt }
         .toSeq
+        .distinct
     }
   }
 
@@ -123,7 +139,7 @@ class UnusedPlugin(td: DependentType, isLibrary: Boolean) extends Plugin(td, isL
       })
   }
 
-  private implicit class DeclarationOps(td: FullDeclaration) {
+  private implicit class DeclarationOps(td: ApexClassDeclaration) {
 
     /** Generates unused issues for a type, see doc/Unused.md for details.
       *
@@ -222,13 +238,9 @@ class UnusedPlugin(td: DependentType, isLibrary: Boolean) extends Plugin(td, isL
     private def couldBeUnused(method: ApexMethodLike): Boolean = {
       // If we don't have complete interface information, public/global methods might be
       // implementing external interfaces that we don't have full type information for
-      td match {
-        case apexClass: ApexClassDeclaration =>
-          apexClass.hasAllInterfaces || !method.visibility.exists(m =>
-            m == PUBLIC_MODIFIER || m == GLOBAL_MODIFIER
-          )
-        case _ => true // Non-Apex types can always be checked for unused methods
-      }
+      td.hasAllInterfaces || !method.visibility.exists(m =>
+        m == PUBLIC_MODIFIER || m == GLOBAL_MODIFIER
+      )
     }
 
     def unusedMethods: ArraySeq[Issue] = {

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/apex/ApexDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/apex/ApexDeclaration.scala
@@ -163,7 +163,8 @@ trait ApexMethodLike extends ApexVisibleMethodLike with Referenceable {
       typeName,
       parameters.map(_.serialise),
       hasBlock,
-      dependencySummary()
+      dependencySummary(),
+      isSynthetic
     )
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/apex/FullDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/apex/FullDeclaration.scala
@@ -22,7 +22,7 @@ import com.nawforce.apexlink.names.TypeNames
 import com.nawforce.apexlink.names.TypeNames.TypeNameUtils
 import com.nawforce.apexlink.org.{OPM, OrgInfo, Referenceable}
 import com.nawforce.apexlink.types.core._
-import com.nawforce.pkgforce.diagnostics.LoggerOps
+import com.nawforce.pkgforce.diagnostics.{Diagnostic, LoggerOps, UNUSED_CATEGORY}
 import com.nawforce.pkgforce.documents._
 import com.nawforce.pkgforce.modifiers._
 import com.nawforce.pkgforce.names.{Name, Names, TypeIdentifier, TypeName}
@@ -125,10 +125,26 @@ abstract class FullDeclaration(
 
   override def flush(pc: ParsedCache, context: PackageContext): Unit = {
     if (!flushedToCache) {
-      val diagnostics = module.pkg.org.issueManager.getDiagnostics(location.path).toArray
+      val diagnostics = cacheableDiagnostics(
+        module.pkg.org.issueManager.getDiagnostics(location.path)
+      ).toArray
       pc.upsert(context, name.value, contentHash, writeBinary(ApexSummary(summary, diagnostics)))
       flushedToCache = true
     }
+  }
+
+  /** Filter diagnostics before they are written to the parsed cache.
+    *
+    * Holder-based unused warnings (unused methods/fields/types) are a whole-program property and so
+    * are workspace-dependent; caching them leads to stale results being replayed in other
+    * workspaces (issue #477). We drop them here and recompute on cache load instead (see
+    * StreamDeployer seeding + UnusedPlugin.onSummaryValidated). Unused *local variable* warnings are
+    * wholly determined within a single method body, so they remain safe to cache and are preserved.
+    */
+  private def cacheableDiagnostics(diagnostics: Seq[Diagnostic]): Seq[Diagnostic] = {
+    diagnostics.filterNot(d =>
+      d.category == UNUSED_CATEGORY && !d.message.startsWith("Unused local variable")
+    )
   }
 
   override protected def validate(): Unit = {

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/apex/SummaryDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/apex/SummaryDeclaration.scala
@@ -268,6 +268,8 @@ class SummaryMethod(
 
   override def hasBlock: Boolean = methodSummary.hasBlock
 
+  override def isSynthetic: Boolean = methodSummary.isSynthetic
+
 }
 
 class SummaryBlock(
@@ -415,6 +417,20 @@ class SummaryDeclaration(
     localConstructors.foreach(_.propagateDependencies())
     localMethods.foreach(_.propagateDependencies())
     nestedTypes.foreach(_.propagateDependencies())
+  }
+
+  /** Collect this type's dependencies together with those of all its members and nested types.
+    * Mirrors FullDeclaration.collectDependencies; the type-level `dependencies` alone omits
+    * member-level use (method/field/block/constructor dependencies), which unused re-analysis
+    * needs in order to ripple to every type this one uses.
+    */
+  def collectDependencies(dependsOn: mutable.Set[Dependent]): Unit = {
+    dependencies.foreach(dependsOn.add)
+    blocks.foreach(_.dependencies.foreach(dependsOn.add))
+    localFields.foreach(_.dependencies.foreach(dependsOn.add))
+    localConstructors.foreach(_.dependencies.foreach(dependsOn.add))
+    localMethods.foreach(_.dependencies.foreach(dependsOn.add))
+    nestedTypes.foreach(_.collectDependencies(dependsOn))
   }
 
   override def gatherDependencies(

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/SummaryTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/SummaryTest.scala
@@ -156,7 +156,8 @@ class SummaryTest extends AnyFunSuite with TestHelper {
               TypeNames.Boolean,
               ArraySeq(ParameterSummary("other", TypeNames.InternalObject)),
               hasBlock = true,
-              Array()
+              Array(),
+              isSynthetic = true
             ),
             MethodSummary(
               idLocation,
@@ -166,7 +167,8 @@ class SummaryTest extends AnyFunSuite with TestHelper {
               TypeNames.Integer,
               ArraySeq(),
               hasBlock = true,
-              Array()
+              Array(),
+              isSynthetic = true
             ),
             MethodSummary(
               idLocation,
@@ -176,7 +178,8 @@ class SummaryTest extends AnyFunSuite with TestHelper {
               TypeNames.String,
               ArraySeq(),
               hasBlock = true,
-              Array()
+              Array(),
+              isSynthetic = true
             ),
             MethodSummary(
               idLocation,
@@ -186,7 +189,8 @@ class SummaryTest extends AnyFunSuite with TestHelper {
               TypeNames.Integer,
               ArraySeq(),
               hasBlock = true,
-              Array()
+              Array(),
+              isSynthetic = true
             ),
             MethodSummary(
               idLocation,
@@ -196,7 +200,8 @@ class SummaryTest extends AnyFunSuite with TestHelper {
               TypeNames.String,
               ArraySeq(),
               hasBlock = true,
-              Array()
+              Array(),
+              isSynthetic = true
             ),
             MethodSummary(
               idLocation,
@@ -206,7 +211,8 @@ class SummaryTest extends AnyFunSuite with TestHelper {
               dummyTypeName,
               ArraySeq(ParameterSummary("name", TypeNames.String)),
               hasBlock = true,
-              Array()
+              Array(),
+              isSynthetic = true
             ),
             MethodSummary(
               idLocation,
@@ -216,7 +222,8 @@ class SummaryTest extends AnyFunSuite with TestHelper {
               TypeNames.listOf(dummyTypeName),
               ArraySeq(),
               hasBlock = true,
-              Array()
+              Array(),
+              isSynthetic = true
             )
           ),
           ArraySeq(),
@@ -586,7 +593,8 @@ class SummaryTest extends AnyFunSuite with TestHelper {
               TypeNames.Boolean,
               ArraySeq(ParameterSummary("other", TypeNames.InternalObject)),
               hasBlock = true,
-              Array()
+              Array(),
+              isSynthetic = true
             ),
             MethodSummary(
               idLocation,
@@ -596,7 +604,8 @@ class SummaryTest extends AnyFunSuite with TestHelper {
               TypeNames.Integer,
               ArraySeq(),
               hasBlock = true,
-              Array()
+              Array(),
+              isSynthetic = true
             ),
             MethodSummary(
               idLocation,
@@ -606,7 +615,8 @@ class SummaryTest extends AnyFunSuite with TestHelper {
               TypeNames.String,
               ArraySeq(),
               hasBlock = true,
-              Array()
+              Array(),
+              isSynthetic = true
             ),
             MethodSummary(
               idLocation,
@@ -616,7 +626,8 @@ class SummaryTest extends AnyFunSuite with TestHelper {
               TypeNames.Integer,
               ArraySeq(),
               hasBlock = true,
-              Array()
+              Array(),
+              isSynthetic = true
             ),
             MethodSummary(
               idLocation,
@@ -626,7 +637,8 @@ class SummaryTest extends AnyFunSuite with TestHelper {
               TypeNames.String,
               ArraySeq(),
               hasBlock = true,
-              Array()
+              Array(),
+              isSynthetic = true
             ),
             MethodSummary(
               idLocation,
@@ -636,7 +648,8 @@ class SummaryTest extends AnyFunSuite with TestHelper {
               dummyTypeName,
               ArraySeq(ParameterSummary("name", TypeNames.String)),
               hasBlock = true,
-              Array()
+              Array(),
+              isSynthetic = true
             ),
             MethodSummary(
               idLocation,
@@ -646,7 +659,8 @@ class SummaryTest extends AnyFunSuite with TestHelper {
               TypeNames.listOf(dummyTypeName),
               ArraySeq(),
               hasBlock = true,
-              Array()
+              Array(),
+              isSynthetic = true
             )
           ),
           ArraySeq(),

--- a/jvm/src/test/scala/com/nawforce/apexlink/pkg/CachedTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/pkg/CachedTest.scala
@@ -18,6 +18,7 @@ import com.nawforce.apexlink.api.ServerOps
 import com.nawforce.apexlink.names.TypeNames
 import com.nawforce.apexlink.names.TypeNames.TypeNameUtils
 import com.nawforce.apexlink.org.OPM
+import com.nawforce.apexlink.plugins.UnusedPlugin
 import com.nawforce.apexlink.types.apex.{FullDeclaration, SummaryDeclaration}
 import com.nawforce.pkgforce.PathInterpolator.PathInterpolator
 import com.nawforce.pkgforce.names.{Name, TypeIdentifier, TypeName}
@@ -310,6 +311,42 @@ class CachedTest extends AnyFunSuite with TestHelper with BeforeAndAfter {
         getMessages(org3) ==
           path"/Dummy.cls: Missing: line 1 at 33-55: Unknown field or type 'TestLabel' on 'System.Label'" + "\n"
       )
+    }
+  }
+
+  test("Holder-based unused is recomputed for cache-loaded classes (#477)") {
+    FileSystemHelper.run(
+      Map(
+        "Service.cls" ->
+          "public class Service { public void doWork() {} public void stillUsed() {} }",
+        "Keeper.cls" ->
+          "public class Keeper { public void keep() { new Service().stillUsed(); } }",
+        "Client.cls" ->
+          "public class Client { public void run() { new Service().doWork(); } }"
+      )
+    ) { root: PathLike =>
+      def serviceIssues(org: OPM.OrgImpl): String =
+        org.issues
+          .issuesForFileInternal(root.join("Service.cls"))
+          .map(_.asString())
+          .mkString("\n")
+
+      // Cache with Service.doWork used by Client, so it is not flagged unused
+      val org1 = createOrgWithPlugin(root, classOf[UnusedPlugin])
+      assert(serviceIssues(org1).isEmpty)
+      org1.flush()
+
+      // Remove the only caller of Service.doWork; Service stays held via Keeper.stillUsed()
+      root.join("Client.cls").delete()
+      root.join("Client.cls-meta.xml").delete()
+
+      // Service loads from cache; recompute-on-load reports the now-unused method rather than
+      // replaying the stale (clean) cached result - this is the #477 fix
+      val org2 = createOrgWithPlugin(root, classOf[UnusedPlugin])
+      assertIsSummaryDeclaration(org2.unmanaged, "Service")
+      assert(serviceIssues(org2).contains("Unused public method 'void doWork()'"))
+      // stillUsed() remains held via Keeper, so it must not be flagged
+      assert(!serviceIssues(org2).contains("stillUsed"))
     }
   }
 

--- a/jvm/src/test/scala/com/nawforce/apexlink/plugin/UnusedTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/plugin/UnusedTest.scala
@@ -793,6 +793,37 @@ class UnusedTest extends AnyFunSuite with TestHelper {
     )
   }
 
+  /** Asserts holder-based unused analysis for cache-loaded (summary) classes produces exactly the
+    * same diagnostics as a full parse of the same workspace. This is the core invariant behind
+    * issue #477: unused is a whole-program property, so a cache-loaded result must match what a cold
+    * parse of the same sources would report rather than replaying a stale cached result.
+    */
+  def assertCachedUnusedMatchesFullParse(sources: Map[String, String], files: Seq[String]): Unit = {
+    withManualFlush {
+      FileSystemHelper.run(sources) { root: PathLike =>
+        // Full parse establishes the ground-truth diagnostics
+        val cold = createOrgWithUnused(root)
+        files.foreach(f => assertIsFullDeclaration(cold.unmanaged, f.stripSuffix(".cls")))
+        val coldIssues = files.map(f => f -> orgIssuesFor(cold, root.join(f))).toMap
+        cold.flush()
+
+        // Reload from cache and require identical diagnostics
+        val warm = createOrgWithUnused(root)
+        files.foreach(f => assertIsSummaryDeclaration(warm.unmanaged, f.stripSuffix(".cls")))
+        OrgInfo.current.withValue(warm) {
+          files.foreach(f => {
+            val warmIssues = orgIssuesFor(warm, root.join(f))
+            assert(
+              warmIssues == coldIssues(f),
+              s"cache-loaded unused for $f differs from full parse: " +
+                s"cold='${coldIssues(f)}' warm='$warmIssues'"
+            )
+          })
+        }
+      }
+    }
+  }
+
   test("Used method on summary type") {
     withManualFlush {
       FileSystemHelper.run(
@@ -844,6 +875,86 @@ class UnusedTest extends AnyFunSuite with TestHelper {
             orgIssuesFor(org2, root.join("Dummy.cls")) ==
               "Unused: line 1 at 32-35: Unused public method 'void foo()'\n"
           )
+        }
+      }
+    }
+  }
+
+  test("Enum synthetic methods are not flagged on summary type (#477)") {
+    // values/valueOf/name/ordinal/equals/hashCode/toString are synthetic and must stay excluded
+    // when the enum is loaded from cache, just as on a full parse
+    assertCachedUnusedMatchesFullParse(
+      Map(
+        "Color.cls" -> "public enum Color {RED, GREEN}",
+        "Foo.cls"   -> "public class Foo { {Color c = Color.RED; System.debug(c == Color.GREEN);} }"
+      ),
+      Seq("Color.cls", "Foo.cls")
+    )
+  }
+
+  test("Method used only from a cache-loaded method body is not flagged (#477)") {
+    // Within a single module, member-level holders are established by propagateDependencies before
+    // recompute, so doWork is held via Client.run()'s body. (The cross-module ripple is covered
+    // separately below where re-validation ordering actually matters.)
+    assertCachedUnusedMatchesFullParse(
+      Map(
+        "Service.cls" -> "public class Service {public void doWork() {}}",
+        "Client.cls"  -> "public class Client {public void run() {new Service().doWork();}}"
+      ),
+      Seq("Service.cls", "Client.cls")
+    )
+  }
+
+  test("Field used only from a cache-loaded method body is not flagged (#477)") {
+    assertCachedUnusedMatchesFullParse(
+      Map(
+        "Holder.cls" -> "public class Holder {public String value;}",
+        "Reader.cls" -> "public class Reader {public void read() {System.debug(new Holder().value);}}"
+      ),
+      Seq("Holder.cls", "Reader.cls")
+    )
+  }
+
+  test("Type used only from a cache-loaded method body is not flagged (#477)") {
+    assertCachedUnusedMatchesFullParse(
+      Map(
+        "Widget.cls"  -> "public class Widget {}",
+        "Factory.cls" -> "public class Factory {public Object make() {return new Widget();}}"
+      ),
+      Seq("Widget.cls", "Factory.cls")
+    )
+  }
+
+  test("Cross-module method use from a cache-loaded body is re-validated (#477)") {
+    // base loads before ext, so when both are cache-loaded Service.doWork is first analysed without
+    // a holder (flagged) and must be re-validated once ext's cache-loaded Client - which uses
+    // doWork only inside a method body - is loaded. This exercises member-level dependency ripple
+    // for summary types, which type-level ripple alone would miss.
+    withManualFlush {
+      FileSystemHelper.run(
+        Map(
+          "sfdx-project.json" -> """{"packageDirectories": [{"path": "base"}, {"path": "ext"}]}""",
+          "base/Service.cls"  -> "public class Service {public void doWork() {}}",
+          "ext/Client.cls"    -> "public class Client {public void run() {new Service().doWork();}}"
+        )
+      ) { root: PathLike =>
+        val servicePath = root.join("base").join("Service.cls")
+
+        def isSummary(org: OPM.OrgImpl, name: String): Boolean =
+          org.unmanaged.orderedModules.exists(m =>
+            m.findModuleType(TypeName(Name(name))).exists(_.isInstanceOf[SummaryDeclaration])
+          )
+
+        // Full parse: doWork is held by Client.run, so it is not flagged
+        val cold = createOrgWithUnused(root)
+        assert(orgIssuesFor(cold, servicePath).isEmpty)
+        cold.flush()
+
+        // Reload: both come from cache; doWork must remain unflagged after cross-module ripple
+        val warm = createOrgWithUnused(root)
+        assert(isSummary(warm, "Service") && isSummary(warm, "Client"))
+        OrgInfo.current.withValue(warm) {
+          assert(orgIssuesFor(warm, servicePath).isEmpty)
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes #477. Holder-based unused warnings (unused methods/fields/types) are a **whole-program property** and therefore workspace-dependent. Previously they were written to the parsed cache and replayed verbatim when a class was loaded from cache — so a method that is genuinely used in one workspace could be reported as unused in another (and vice-versa), depending on what was present when the cache was written.

Cache-loaded classes are now seeded into the plugin manager so unused analysis is **recomputed for them in the current workspace** during plugin close, and holder-based unused diagnostics are no longer cached. Unused *local-variable* warnings are wholly determined within a single method body, so they remain safe to cache and are preserved.

## Why this is now correct (and cheap)

Two supporting fixes make the recomputed result identical to a full parse:

- **Member-level dependency ripple** — `SummaryDeclaration` now contributes member-level dependencies (method/field/block use) to the unused ripple, mirroring `FullDeclaration.collectDependencies`. The previous type-level-only ripple meant a type used only from another type's *method body* was never re-validated when its user loaded, leaving it falsely flagged.
- **Synthetic-method preservation** — `MethodSummary` now carries an `isSynthetic` flag through the cache. Synthetic enum methods (`values`/`valueOf`/`name`/`ordinal`/`equals`/`hashCode`/`toString`) have a block, so `hasBlock` could not distinguish them; without the flag they were treated as real methods and flagged unused on the cache-loaded path.

There is no feature flag — recompute-on-load is the default and only behaviour. The parsed-cache key is derived from the build version, so existing caches (which still contain holder-unused diagnostics) auto-invalidate on the next published build.

## Validation

- `sbt scalafmtCheckAll` — clean
- `sbt apexlsJVM/test` — all 2454 tests pass, including a new `CachedTest` case (`Holder-based unused is recomputed for cache-loaded classes (#477)`) and updated `SummaryTest` expectations for the synthetic-method flag
- Sample-project regression (`apex-samples`) is left for CI to run

## Benchmark (large internal workspace, ~14.6k types / 14 modules, anonymized)

- Warm recompute now matches the full-parse ground truth exactly, where the prior cached behaviour over-reported by roughly 2×.
- The current cached behaviour was measurably wrong even within a single workspace (per-module cache-write timing) — a direct demonstration of #477.
- Added analysis cost is a few hundred ms of plugin-close time, overlapping the I/O-bound load; warm end-to-end wall-clock is statistically unchanged (~11s).