### PR TITLE
docs: prepare CHANGELOG for 6.1.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.1.0-beta.1] - 2026-06-13
+
 ### Added
 
 - Recognition of Summer '26 test annotations `@IntegrationTest` and `@TearDown`, including test-class and unused-analysis handling (#468)
@@ -43,6 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Slimmed the JS module surface to the published apex-ls facades
 - Removed JS-portability shims `CodeParser.toScala(value)` and `CodeParser.getText(...)` from the CST construction layer; call sites now use `Option(...)` directly (#449)
 - Replaced cascading `Option(...).orElse(...)` chains in `Literal.construct` and `ClassBodyDeclaration.construct` with extractor-based pattern matching (#449)
+
+### Deprecated
+
+- The npm distribution (`@apexdevtools/apex-ls`) is no longer published by default and is planned for removal; the JVM artifact on Maven Central is the supported distribution. Contact the maintainers if you still require an npm build.
 
 ### Removed
 


### PR DESCRIPTION
## Summary

Prepares `CHANGELOG.md` for the **6.1.0-beta.1** release:

- Moves the accumulated `[Unreleased]` notes under a dated `## [6.1.0-beta.1] - 2026-06-13` heading.
- Leaves a fresh empty `## [Unreleased]` for fixes landing during the beta period.
- Adds a **Deprecated** note that the npm distribution (`@apexdevtools/apex-ls`) is no longer published by default and is planned for removal — the JVM artifact on Maven Central is the supported distribution. (Soft deprecation: npm will only be published on request.)

No code changes; documentation only, so no tests were run.

## Notes

- The `6.1.0-beta.1` heading collects the headline changes for this cycle: Summer '26 platform types, OutlineParser-only parsing (ANTLR-first removed), the member-visibility audit, and the #477 unused recompute-on-load fix.
- When 6.1.0 final ships, this heading can be renamed to `[6.1.0]` and any `[Unreleased]` additions folded in.