### PR TITLE
fix: keep Any-return method wrapper transparent to method identity

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/TestVisibleAccess.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/TestVisibleAccess.scala
@@ -15,7 +15,12 @@
 package com.nawforce.apexlink.cst
 
 import com.nawforce.apexlink.types.apex.{ApexDeclaration, ApexFieldLike, ApexMethodLike}
-import com.nawforce.apexlink.types.core.{FieldDeclaration, MethodDeclaration, TypeDeclaration}
+import com.nawforce.apexlink.types.core.{
+  AnyReturnMethodDeclaration,
+  FieldDeclaration,
+  MethodDeclaration,
+  TypeDeclaration
+}
 import com.nawforce.pkgforce.modifiers.{
   GLOBAL_MODIFIER,
   Modifier,
@@ -37,10 +42,17 @@ object TestVisibleAccess {
   }
 
   def methodAccessError(method: MethodDeclaration, calledFrom: TypeDeclaration): Option[String] = {
-    if (isInvalidPrivateMethodAccess(method, calledFrom)) {
+    // Resolve through any Any-return wrapper so the checks below see the real declaration; the
+    // wrapper is not an ApexMethodLike and carries no owning type, which would otherwise make a
+    // same-file private/protected call appear inaccessible.
+    val resolved = method match {
+      case wrapped: AnyReturnMethodDeclaration => wrapped.method
+      case other                               => other
+    }
+    if (isInvalidPrivateMethodAccess(resolved, calledFrom)) {
       Some("Private @TestVisible methods can only be accessed from @IsTest classes")
-    } else if (!isMethodAccessible(method, calledFrom)) {
-      Some(s"Method is not visible: ${method.nameAndParameterTypes}")
+    } else if (!isMethodAccessible(resolved, calledFrom)) {
+      Some(s"Method is not visible: ${resolved.nameAndParameterTypes}")
     } else {
       None
     }

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/core/TypeDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/core/TypeDeclaration.scala
@@ -346,14 +346,19 @@ object MethodDeclaration {
     )
 }
 
-/** Method wrapper that enforces an Any return type on the provided method */
-class AnyReturnMethodDeclaration(method: MethodDeclaration) extends MethodDeclaration {
+/** Method wrapper that enforces an Any return type on the provided method. The wrapper is
+  * transparent to the wrapped method's identity: it forwards thisTypeIdOpt and exposes the
+  * underlying method (via 'method') so that visibility and reference resolution operate on the
+  * real declaration rather than the wrapper (which is not an ApexMethodLike).
+  */
+class AnyReturnMethodDeclaration(val method: MethodDeclaration) extends MethodDeclaration {
   override val name: Name                                 = method.name
   override val modifiers: ArraySeq[Modifier]              = method.modifiers
   override val parameters: ArraySeq[ParameterDeclaration] = method.parameters
 
   override def typeName: TypeName = TypeName.Any
   override def hasBlock: Boolean  = method.hasBlock
+  override def thisTypeIdOpt      = method.thisTypeIdOpt
 }
 
 trait AbstractTypeDeclaration {

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
@@ -642,6 +642,35 @@ class MethodTest extends AnyFunSuite with TestHelper {
     }
   }
 
+  test("Same class private overloaded method call with ghosted argument") {
+    // The ghosted argument resolves to Any, so overload resolution wraps the chosen method in an
+    // AnyReturnMethodDeclaration. That wrapper must remain transparent to the method's identity,
+    // otherwise a legal same-file private call is wrongly reported as 'Method is not visible'.
+    FileSystemHelper.run(
+      Map(
+        "sfdx-project.json" ->
+          """{
+          |"packageDirectories": [{"path": "force-app"}],
+          |"plugins": {"dependencies": [{"namespace": "ext"}]}
+          |}""".stripMargin,
+        "force-app/Dummy.cls" ->
+          """public class Dummy {
+            |  public void run(ext.Something thing) {
+            |    getStatus(thing);
+            |  }
+            |  private static String getStatus(ext.Something thing) {
+            |    return getStatus(thing.status);
+            |  }
+            |  private static String getStatus(String status) {
+            |    return status;
+            |  }
+            |}""".stripMargin
+      )
+    ) { root: PathLike =>
+      createHappyOrg(root)
+    }
+  }
+
   test("Static method on inner class") {
     typeDeclaration("public class Dummy { class Inner { static void m() {} } }")
     assert(dummyIssues.toLowerCase.contains("static") && dummyIssues.toLowerCase.contains("inner"))


### PR DESCRIPTION
## Problem

A false `Method is not visible` error is reported for a legal call to a **private/protected overloaded** method when one of the call arguments has an **unknown/ghosted type** (e.g. a type from a managed-package dependency). The code compiles and runs on-platform.

The false positive fires only when all of these hold:
1. the called method is **overloaded** (≥2 candidates), and
2. it is **`private`** (or `protected`) — `public`/`global` are fine, and
3. it is called with an argument whose type resolves to **`Any`** (e.g. a ghosted dependency type).

### Minimal reproduction

```apex
public class DocStatus {
    public void run(fferpcore__BillingDocument__c billDoc) {
        getStatus(billDoc);                                  // <- false "not visible"
    }
    private static String getStatus(fferpcore__BillingDocument__c billDoc) {
        return getStatus(billDoc.fferpcore__DocumentStatus__c); // <- false "not visible"
    }
    private static String getStatus(String status) { return status; }
}
```

## Root cause

When an argument is `Any` and multiple overloads match, `MethodMap.mostSpecificMatch` wraps the chosen method in `AnyReturnMethodDeclaration` to coerce the return type to `Any`. That wrapper dropped the method's identity:

- it is **not** an `ApexMethodLike`, so `TestVisibleAccess.isSameApexFile` fell through to `false`;
- it inherited the default `thisTypeIdOpt = None`, so it carried no owning type.

For a `private` method `isAccessible` only accepts `isSameApexFile || isUnitTestVisible` — both false — so even a same-class call was rejected. `public`/`global` short-circuit to `true`, which is why only private/protected overloads were affected.

## Fix

Make the wrapper transparent to identity:
- `AnyReturnMethodDeclaration` exposes the wrapped method and forwards `thisTypeIdOpt`;
- `TestVisibleAccess.methodAccessError` resolves through the wrapper before checking visibility.

Cross-class private/protected calls remain correctly reported as not visible.

## Testing

- New regression test: same-file private overloaded call with a ghosted argument (`MethodTest`).
- Full JVM suite green (2460 tests).
- Manually verified against the minimal repro (now clean) and a cross-class negative control (still correctly errors).

