### PR TITLE
fix: inherit @TestVisible onto interface methods

### DIFF
--- a/jvm/src/main/scala/com/nawforce/pkgforce/modifiers/MethodModifiers.scala
+++ b/jvm/src/main/scala/com/nawforce/pkgforce/modifiers/MethodModifiers.scala
@@ -252,6 +252,18 @@ object MethodModifiers {
       .headOption
       .getOrElse(PUBLIC_MODIFIER)
 
-    ModifierResults(mods ++ ArraySeq(VIRTUAL_MODIFIER, interfaceVisibility), logger.issues).intern
+    // A @TestVisible interface exposes its (otherwise private) members to test code. Interface
+    // methods inherit the interface's visibility, so they must inherit @TestVisible too; without
+    // it the member-access check would reject legal calls from @IsTest classes.
+    val inheritedTestVisible =
+      if (ownerInfo.modifiers.contains(TEST_VISIBLE_ANNOTATION))
+        ArraySeq(TEST_VISIBLE_ANNOTATION)
+      else
+        ArraySeq.empty[Modifier]
+
+    ModifierResults(
+      mods ++ ArraySeq(VIRTUAL_MODIFIER, interfaceVisibility) ++ inheritedTestVisible,
+      logger.issues
+    ).intern
   }
 }

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
@@ -237,6 +237,29 @@ class MethodTest extends AnyFunSuite with TestHelper {
     assert(dummyIssues.isEmpty)
   }
 
+  test("IsTest class can call @TestVisible private interface method") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {@TestVisible private interface IThing {void run();} @TestVisible private static IThing make(){return null;}}",
+        "Dummy.cls" -> "@IsTest public class Dummy {@IsTest public static void f2() {Target.IThing t = Target.make(); t.run();}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).isEmpty)
+  }
+
+  test("Non-test class can not call @TestVisible private interface method") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {@TestVisible private interface IThing {void run();} @TestVisible private static IThing make(){return null;}}",
+        "Dummy.cls" -> "public class Dummy {public static void f2() {Target.IThing t = Target.make(); t.run();}}"
+      )
+    )
+    assert(
+      getMessages(root.join("Dummy.cls"))
+        .contains("Private @TestVisible methods can only be accessed from @IsTest classes")
+    )
+  }
+
   test("Method call with non-ambiguous target") {
     FileSystemHelper.run(
       Map(


### PR DESCRIPTION
## Problem

A `@TestVisible private interface` exposes its (otherwise private) members to `@IsTest` classes — this is legal Apex and compiles cleanly against a real org. However, apex-ls flagged calls to such members from test classes as false positives:

```
Private @TestVisible methods can only be accessed from @IsTest classes
```

## Cause

Interface methods don't carry their own modifiers — `MethodModifiers.interfaceMethodModifiers` synthesizes them, propagating the interface's visibility (an interface method inherits the interface's visibility). But it dropped the interface's `@TestVisible` annotation. The member-access check (`TestVisibleAccess`) then saw a `private` method that was *not* `@TestVisible`, so it rejected legal calls from `@IsTest` classes.

## Fix

Propagate `@TestVisible` from the interface owner onto its synthesized method modifiers, mirroring how visibility is already inherited. Both parser paths (main ApexParser and OutlineParser) route through this shared method, so both are covered.

## Tests

Added two cases to `MethodTest`:
- `@IsTest` class **can** call a `@TestVisible private interface` method (no error)
- a non-test class **cannot** (error still raised)

Verified against the real workspace that previously produced the false positives — all visibility false positives now clear. Org dry-run confirms the underlying Apex semantics.