### PR TITLE
fix: document ghosted overload visibility fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Private and protected overloaded methods called with ghosted-type arguments no longer report false `Method is not visible` diagnostics (#484)
+
 ## [6.1.0-beta.1] - 2026-06-13
 
 ### Added


### PR DESCRIPTION
## Summary

- Document the ghosted overload visibility fix under `[Unreleased]`
- Keep the issue-closing PR scoped to #484; the code fix and regression coverage are already present on current `main` via #485

Closes #484

## Tests

- `sbt "apexlsJVM/testOnly com.nawforce.apexlink.cst.MethodTest -- -z ghosted"`
