### PR TITLE
fix: stabilize diagnostic column span regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Stabilized diagnostic column spans for missing type-reference and duplicate visibility diagnostics, avoiding context-dependent diff churn (#487)
+
 ## [6.1.0-beta.1] - 2026-06-13
 
 ### Added

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/IdDependencyTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/IdDependencyTest.scala
@@ -36,6 +36,40 @@ class IdDependencyTest extends AnyFunSuite with TestHelper {
     assert(tds.head.dependencies().isEmpty)
   }
 
+  test("Missing static field initializer reports identifier span") {
+    val tds = typeDeclarations(
+      Map(
+        "Dummy.cls" ->
+          """public class Dummy {
+            |  Object record = fflib_IdGenerator.generate();
+            |}""".stripMargin
+      )
+    )
+    assert(
+      dummyIssues ==
+        "Missing: line 2 at 18-35: No variable or type found for 'fflib_IdGenerator' on 'Dummy'\n"
+    )
+    assert(tds.head.dependencies().isEmpty)
+  }
+
+  test("Missing static set literal call reports identifier span") {
+    val tds = typeDeclarations(
+      Map(
+        "Dummy.cls" ->
+          """public class Dummy {
+            |  void func() {
+            |    Object accountList = new Set<Id> {fflib_IdGenerator.generate(Account.SObjectType)};
+            |  }
+            |}""".stripMargin
+      )
+    )
+    assert(
+      dummyIssues ==
+        "Missing: line 3 at 38-55: No variable or type found for 'fflib_IdGenerator' on 'Dummy'\n"
+    )
+    assert(tds.head.dependencies().isEmpty)
+  }
+
   test("Static func creates method dependency") {
     val tds = typeDeclarations(
       Map(

--- a/jvm/src/test/scala/com/nawforce/pkgforce/modifiers/MethodModifierTest.scala
+++ b/jvm/src/test/scala/com/nawforce/pkgforce/modifiers/MethodModifierTest.scala
@@ -205,6 +205,22 @@ class MethodModifierTest extends AnyFunSuite {
     )
   }
 
+  test("Class method duplicate visibility reports method span") {
+    val issues = illegalClassMethodAccess(ArraySeq(PROTECTED_MODIFIER, GLOBAL_MODIFIER))
+    assert(
+      issues == Seq[Issue](
+        Issue(
+          Path("Dummy.cls"),
+          Diagnostic(
+            WARNING_CATEGORY,
+            Location(1, 44, 1, 48),
+            "Only one visibility modifier from 'global', 'public' & 'private' should be used on methods"
+          )
+        )
+      )
+    )
+  }
+
   test("Class method abstract on non-abstract class") {
     val issues = illegalClassMethodAccess(ArraySeq(ABSTRACT_MODIFIER))
     assert(


### PR DESCRIPTION
## Summary
- Add regression coverage for missing type-reference diagnostic spans in field initializers and set-literal calls.
- Add regression coverage for duplicate visibility modifier diagnostic spans.
- Document the diagnostic span stabilization in the changelog.

Closes #487

## Tests
- sbt scalafmtAll
- sbt "apexlsJVM/testOnly com.nawforce.apexlink.cst.IdDependencyTest com.nawforce.pkgforce.modifiers.MethodModifierTest"
- sbt "apexlsJVM/testOnly com.nawforce.apexlink.cst.IdDependencyTest com.nawforce.apexlink.cst.IfTest com.nawforce.apexlink.cst.InlineQueryTest com.nawforce.pkgforce.modifiers.MethodModifierTest"
- sbt "apexlsJVM/runMain io.github.apexdevtools.apexls.CheckForIssues -f text -d unused -n -l info -w ../apex-samples/at4dx/at4dx" (exited 4 with expected reported issues; verified fflib_IdGenerator spans such as 24-41 and 64-81)

Note: running sbt from the temporary linked worktree failed during project load because sbt-git/JGit treated the linked worktree as bare, so formatting/tests were run from the primary worktree after applying the same Scala test changes.