### PR TITLE
fix: remove deprecated parser stream usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed use of the deprecated Apex parser `CaseInsensitiveInputStream` from JVM parsing (#489)
+
 ## [6.1.0-beta.1] - 2026-06-13
 
 ### Added

--- a/jvm/src/main/scala/com/nawforce/runtime/parsers/CodeParser.scala
+++ b/jvm/src/main/scala/com/nawforce/runtime/parsers/CodeParser.scala
@@ -16,10 +16,9 @@ package com.nawforce.runtime.parsers
 import com.nawforce.pkgforce.diagnostics.IssuesAnd
 import com.nawforce.pkgforce.path.{PathLike, PathLocation}
 import com.nawforce.runtime.parsers.CodeParser.ParserRuleContext
-import io.github.apexdevtools.apexparser.{ApexLexer, ApexParser, CaseInsensitiveInputStream}
-import org.antlr.v4.runtime.{CharStreams, CommonTokenStream}
+import io.github.apexdevtools.apexparser.{ApexLexer, ApexParser}
+import org.antlr.v4.runtime.CommonTokenStream
 
-import java.io.ByteArrayInputStream
 import java.util
 import scala.collection.compat.immutable.ArraySeq
 import scala.jdk.CollectionConverters._
@@ -130,11 +129,7 @@ object CodeParser {
   }
 
   def clearCaches(): Unit = {
-    val lexer = new ApexLexer(
-      new CaseInsensitiveInputStream(
-        CharStreams.fromStream(new ByteArrayInputStream(Array[Byte]()))
-      )
-    )
+    val lexer  = new ApexLexer(SourceData.emptyInsensitiveStream)
     val parser = new ApexParser(new CommonTokenStream(lexer))
     lexer.clearCache()
     parser.clearCache()

--- a/jvm/src/main/scala/com/nawforce/runtime/parsers/PageParser.scala
+++ b/jvm/src/main/scala/com/nawforce/runtime/parsers/PageParser.scala
@@ -17,11 +17,9 @@ import com.nawforce.pkgforce.diagnostics.IssuesAnd
 import com.nawforce.pkgforce.path.{PathLike, PathLocation}
 import com.nawforce.runtime.parsers.PageParser.ParserRuleContext
 import com.nawforce.vfparser.{VFLexer, VFParser}
-import io.github.apexdevtools.apexparser.CaseInsensitiveInputStream
 import org.antlr.v4.runtime.tree.ParseTree
-import org.antlr.v4.runtime.{CharStreams, CommonTokenStream}
+import org.antlr.v4.runtime.CommonTokenStream
 
-import java.io.ByteArrayInputStream
 import java.util
 import scala.collection.compat.immutable.ArraySeq
 import scala.jdk.CollectionConverters._
@@ -73,11 +71,7 @@ object PageParser {
   }
 
   def clearCaches(): Unit = {
-    val lexer = new VFLexer(
-      new CaseInsensitiveInputStream(
-        CharStreams.fromStream(new ByteArrayInputStream(Array[Byte]()))
-      )
-    )
+    val lexer  = new VFLexer(SourceData.emptyInsensitiveStream)
     val parser = new VFParser(new CommonTokenStream(lexer))
     lexer.clearCache()
     parser.clearCache()

--- a/jvm/src/main/scala/com/nawforce/runtime/parsers/Source.scala
+++ b/jvm/src/main/scala/com/nawforce/runtime/parsers/Source.scala
@@ -16,7 +16,6 @@ package com.nawforce.runtime.parsers
 import com.nawforce.pkgforce.path.{Location, PathLike, PathLocation, Positionable}
 import com.nawforce.runtime.SourceBlob
 import com.nawforce.runtime.parsers.CodeParser.ParserRuleContext
-import io.github.apexdevtools.apexparser.CaseInsensitiveInputStream
 import org.antlr.v4.runtime.CharStream
 
 /** A block of source code loaded from a file
@@ -54,7 +53,7 @@ case class Source(
     code.asStream
   }
 
-  def asInsensitiveStream: CaseInsensitiveInputStream = {
+  def asInsensitiveStream: CharStream = {
     code.asInsensitiveStream
   }
 

--- a/jvm/src/main/scala/com/nawforce/runtime/parsers/SourceData.scala
+++ b/jvm/src/main/scala/com/nawforce/runtime/parsers/SourceData.scala
@@ -16,8 +16,8 @@ package com.nawforce.runtime.parsers
 
 import com.nawforce.pkgforce.parsers.UTF8Decode
 import com.nawforce.runtime.SourceBlob
-import io.github.apexdevtools.apexparser.CaseInsensitiveInputStream
-import org.antlr.v4.runtime.{CharStream, CharStreams}
+import org.antlr.v4.runtime.misc.Interval
+import org.antlr.v4.runtime.{CharStream, CharStreams, IntStream}
 
 import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
@@ -60,8 +60,8 @@ final case class SourceData(
     CharStreams.fromStream(new ByteArrayInputStream(source, offset, length), StandardCharsets.UTF_8)
   }
 
-  def asInsensitiveStream: CaseInsensitiveInputStream = {
-    new CaseInsensitiveInputStream(
+  def asInsensitiveStream: CharStream = {
+    SourceData.caseInsensitiveStream(
       CharStreams
         .fromStream(new ByteArrayInputStream(source, offset, length), StandardCharsets.UTF_8)
     )
@@ -80,6 +80,14 @@ final case class SourceData(
 }
 
 object SourceData {
+  private[parsers] def emptyInsensitiveStream: CharStream = {
+    caseInsensitiveStream(CharStreams.fromStream(new ByteArrayInputStream(Array[Byte]())))
+  }
+
+  private def caseInsensitiveStream(source: CharStream): CharStream = {
+    new CaseInsensitiveCharStream(source)
+  }
+
   def apply(value: String): SourceData = {
     apply(value.getBytes(StandardCharsets.UTF_8))
   }
@@ -87,4 +95,27 @@ object SourceData {
   def apply(value: SourceBlob): SourceData = {
     new SourceData(value, offset = 0, length = value.length)
   }
+}
+
+private final class CaseInsensitiveCharStream(source: CharStream) extends CharStream {
+  override def getText(interval: Interval): String = source.getText(interval)
+
+  override def consume(): Unit = source.consume()
+
+  override def getSourceName: String = source.getSourceName
+
+  override def index(): Int = source.index()
+
+  override def LA(i: Int): Int = {
+    val c = source.LA(i)
+    if (c == IntStream.EOF) c else Character.toLowerCase(c)
+  }
+
+  override def mark(): Int = source.mark()
+
+  override def release(marker: Int): Unit = source.release(marker)
+
+  override def seek(index: Int): Unit = source.seek(index)
+
+  override def size(): Int = source.size()
 }


### PR DESCRIPTION
## Summary
- replace deprecated Apex parser CaseInsensitiveInputStream usage with a local ANTLR CharStream adapter
- keep parser cache clearing on the same case-insensitive stream path
- update the unreleased changelog

Closes #489

## Tests
- sbt -Dsbt.server=false scalafmtAll
- sbt -Dsbt.server=false apexlsJVM/build

Note: apexlsJVM/build still reports the existing unrelated MurmurHash3.productHash deprecation warning in shared/src/main/scala/com/nawforce/pkgforce/names/TypeName.scala.