### PR TITLE
fix: resolve nested inherited private field shadowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Nested subclasses now resolve unqualified names to accessible enclosing static fields before inherited private superclass fields, avoiding false `Field is not visible` diagnostics (#488)
+
 ## [6.1.0-beta.1] - 2026-06-13
 
 ### Added

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
@@ -147,6 +147,7 @@ final case class IdPrimary(id: Id) extends Primary {
     val staticContext = Some(true).filter(input.isStatic.contains)
 
     val field = findField(id.name, td, staticContext)
+      .flatMap(field => fallbackToOuterStaticField(id.name, td, staticContext, field, context))
     cachedClassFieldDeclaration = field
 
     if (field.nonEmpty && isAccessible(td, field.get, staticContext)) {
@@ -190,6 +191,35 @@ final case class IdPrimary(id: Id) extends Primary {
       .orElse({
         if (encodedName != namespaceName)
           td.findField(encodedName.fullName, staticContext)
+        else None
+      })
+  }
+
+  private def fallbackToOuterStaticField(
+    name: Name,
+    td: TypeDeclaration,
+    staticContext: Option[Boolean],
+    field: FieldDeclaration,
+    context: ExpressionVerifyContext
+  ): Option[FieldDeclaration] = {
+    TestVisibleAccess.fieldAccessError(field, context.thisType) match {
+      case Some(message) if message == s"Field is not visible: ${field.name}" =>
+        findOuterStaticField(name, td, staticContext).orElse(Some(field))
+      case _ => Some(field)
+    }
+  }
+
+  private def findOuterStaticField(
+    name: Name,
+    td: TypeDeclaration,
+    staticContext: Option[Boolean]
+  ): Option[FieldDeclaration] = {
+    val encodedName   = EncodedName(name)
+    val namespaceName = encodedName.defaultNamespace(td.moduleDeclaration.flatMap(_.namespace))
+    td.findOuterStaticField(namespaceName.fullName, staticContext)
+      .orElse({
+        if (encodedName != namespaceName)
+          td.findOuterStaticField(encodedName.fullName, staticContext)
         else None
       })
   }

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/core/TypeDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/core/TypeDeclaration.scala
@@ -487,6 +487,14 @@ trait TypeDeclaration extends AbstractTypeDeclaration with Dependent with PreReV
     }
   }
 
+  def findOuterStaticField(name: Name, staticContext: Option[Boolean]): Option[FieldDeclaration] = {
+    val matches = findOuterStaticField(name)
+    staticContext match {
+      case Some(x) => matches.find(f => f.isStatic == x)
+      case None    => matches
+    }
+  }
+
   /* Find a field just from its name. We need to be careful here about recursion between types, e.g. an outer class
    * having a super class which is an inner of the outer class. To handle this we just exclude declarations from
    * being searched a second time. */
@@ -525,6 +533,16 @@ trait TypeDeclaration extends AbstractTypeDeclaration with Dependent with PreReV
           .filterNot(exclude.contains)
           .flatMap(_.findField(name, exclude).filter(_.isStatic))
       )
+  }
+
+  private def findOuterStaticField(
+    name: Name,
+    exclude: mutable.HashSet[TypeDeclaration] = new mutable.HashSet()
+  ): Option[FieldDeclaration] = {
+    exclude.add(this)
+    outerTypeDeclaration
+      .filterNot(exclude.contains)
+      .flatMap(_.findField(name, exclude).filter(_.isStatic))
   }
 
   private lazy val methodMap: MethodMap =

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/FieldTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/FieldTest.scala
@@ -248,6 +248,35 @@ class FieldTest extends AnyFunSuite with TestHelper {
     assert(getMessages(root.join("Consumer.cls")).isEmpty)
   }
 
+  test("Nested subclass resolves enclosing static field over inherited private field") {
+    typeDeclarations(
+      Map(
+        "Base1.cls" ->
+          """public virtual class Base1 {
+            |  private final Integer bec;
+            |  public Base1(Integer bec) {
+            |    this.bec = bec;
+            |  }
+            |}""".stripMargin,
+        "Outer1.cls" ->
+          """public class Outer1 {
+            |  private static final Integer BEC = 5;
+            |
+            |  public class Inner1 extends Base1 {
+            |    public Inner1() {
+            |      super(BEC);
+            |    }
+            |
+            |    public Integer value() {
+            |      return BEC;
+            |    }
+            |  }
+            |}""".stripMargin
+      )
+    )
+    assert(getMessages(root.join("Outer1.cls")).isEmpty)
+  }
+
   test("Nested class resolves unqualified static through superclass enclosing type") {
     // Verified against the platform: a nested class extending an externally nested base may
     // resolve an unqualified static field name through the base class's enclosing type when


### PR DESCRIPTION
## Summary

- Resolve unqualified nested-class field lookup to an accessible enclosing static field when an inherited private superclass field has the same name.
- Add a regression covering both `super(BEC)` and plain `return BEC` in a nested subclass.
- Document the fix in the unreleased changelog.

## Tests

- `sbt scalafmtAll`
- `sbt "apexlsJVM/testOnly com.nawforce.apexlink.cst.FieldTest"`
- `sbt "apexlsJVM/testOnly com.nawforce.apexlink.cst.*"`

Closes #488
