### PR TITLE
chore: prepare 6.1.0-beta.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.1.0-beta.2] - 2026-06-18
+
 ### Fixed
 
 - Stabilized diagnostic column spans for missing type-reference and duplicate visibility diagnostics, avoiding context-dependent diff churn (#487)


### PR DESCRIPTION
Prepares the `6.1.0-beta.2` release.

## Changes
Moves the four `[Unreleased]` fixes into a dated `[6.1.0-beta.2] - 2026-06-18` section in `CHANGELOG.md`:

- Stabilized diagnostic column spans for missing type-reference and duplicate visibility diagnostics (#487)
- Nested subclasses resolve unqualified names to accessible enclosing static fields before inherited private superclass fields (#488)
- Removed use of the deprecated `CaseInsensitiveInputStream` from JVM parsing (#489)
- Private/protected overloaded methods called with ghosted-type arguments no longer report false `Method is not visible` diagnostics (#484)

The published version is derived from the git tag (sbt-ci-release/dynver), so no version file changes are needed. After merge, `v6.1.0-beta.2` will be tagged on the merge commit to trigger publishing.

## Tests
Documentation-only change; no code modified, no tests run.