### PR TITLE
fix: guard SOQL model build against malformed queries (#295)

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
@@ -278,6 +278,12 @@ final case class SOQL(
         s"Expecting SOQL to query only a single SObject, found '${fromNames.mkString(", ")}'"
       )
     }
+
+    // Guard against a malformed query that yielded no FROM names; nothing more we can verify
+    if (fromNames.isEmpty) {
+      return ExprContext(isStatic = Some(false), context.module.any)
+    }
+
     val sobjectType = TypeName(fromNames.head.names.head, Nil, Some(TypeNames.Schema))
 
     if (queryResultType == COUNT_RESULT_QUERY) {
@@ -302,8 +308,9 @@ final case class SOQL(
 
 object SOQL {
   def apply(query: QueryContext): SOQL = {
-    val entries = CodeParser
-      .toScala(query.selectList().selectEntry())
+    val entries = Option(query.selectList())
+      .map(selectList => CodeParser.toScala(selectList.selectEntry()))
+      .getOrElse(ArraySeq.empty[SelectEntryContext])
 
     val aggregateFunctions = entries
       .flatMap(se => Option(se.soqlFunction()))
@@ -333,8 +340,9 @@ object SOQL {
     // is available so currently model as an expression
     val boundedExpressions = new BoundExprVisitor().visit(query).map(ec => Expression.construct(ec))
     val fromNames =
-      CodeParser
-        .toScala(query.fromNameList().fieldName())
+      Option(query.fromNameList())
+        .map(fromNameList => CodeParser.toScala(fromNameList.fieldName()))
+        .getOrElse(ArraySeq.empty[FieldNameContext])
         .map(nameList =>
           DotName(
             CodeParser

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/InlineQueryTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/InlineQueryTest.scala
@@ -151,4 +151,11 @@ class InlineQueryTest extends AnyFunSuite with TestHelper {
     )
   }
 
+  test("SOQL malformed bind reports syntax error without crashing") {
+    // Regression guard for #295: a malformed bind variable (missing colon) must surface a
+    // syntax error rather than throwing while building the SOQL model (see SOQL.apply guards).
+    typeDeclaration("public class Dummy {{ Object a = [Select Id from Account where Id = aId]; }}")
+    assert(dummyIssues.contains("Syntax: line 1 at 68: no viable alternative at input 'Id = aId'"))
+  }
+
 }


### PR DESCRIPTION
## Summary

Issue #295 reported an NPE crash analysing an inline SOQL query with a malformed bind variable (missing colon). The crash is no longer reproducible on `main` under either parser — clean syntax errors now prevent `SOQL.apply` from being reached with null children. This PR adds defensive guards as hardening so the model-build path is robust even if a future grammar/parser change lets a partially-formed query through.

## Changes

- `SOQL.apply`: wrap `query.selectList()` and `query.fromNameList()` in `Option(...)`, falling back to an empty `ArraySeq` when null.
- `SOQL.verify`: when `fromNames` is empty, log the existing "single SObject" error and return the `any` type instead of dereferencing `fromNames.head`.
- Add an `InlineQueryTest` regression test asserting a malformed bind variable surfaces a syntax error rather than crashing.

## Testing

- `sbt scalafmtCheck` — clean
- `sbt "apexlsJVM/testOnly *InlineQueryTest"` — 25 passed
- `sbt "apexlsJVM/testOnly com.nawforce.apexlink.cst.*"` — 859 passed

Closes #295.