### PR TITLE
[codex] fix compile warning noise

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import org.scalajs.linker.interface.Report
 
 import scala.sys.process._
+import scala.util.Try
 
 ThisBuild / scalaVersion         := "2.13.17"
 ThisBuild / description          := "Salesforce Apex static analysis toolkit"
@@ -8,7 +9,7 @@ ThisBuild / organization         := "io.github.apex-dev-tools"
 ThisBuild / organizationHomepage := Some(url("https://github.com/apex-dev-tools/apex-ls"))
 ThisBuild / homepage             := Some(url("https://github.com/apex-dev-tools/apex-ls"))
 ThisBuild / licenses := List(
-  "BSD-3-Clause" -> new URL("https://opensource.org/licenses/BSD-3-Clause")
+  "BSD-3-Clause" -> url("https://opensource.org/licenses/BSD-3-Clause")
 )
 ThisBuild / developers := List(
   Developer(
@@ -56,6 +57,7 @@ lazy val apexls = crossProject(JSPlatform, JVMPlatform)
   .jvmSettings(
     build       := buildJVM.value,
     Test / fork := true,
+    Test / javaOptions ++= enableNativeAccessForJdk24Plus.value,
     libraryDependencies ++= Seq(
       "org.scala-lang.modules"  %% "scala-xml"                      % "1.3.0",
       "org.scala-lang.modules"  %% "scala-parallel-collections"     % "1.0.0",
@@ -172,5 +174,21 @@ def run(log: ProcessLogger)(cmd: String, cwd: File): Unit = {
   if (exitCode > 0) {
     log.err(s"Process exited with non-zero exit code: $exitCode")
     sys.exit(exitCode)
+  }
+}
+
+def enableNativeAccessForJdk24Plus: Def.Initialize[Seq[String]] = Def.setting {
+  sys.props
+    .get("java.specification.version")
+    .flatMap(javaMajorVersion)
+    .filter(_ >= 24)
+    .fold(Seq.empty[String])(_ => Seq("--enable-native-access=ALL-UNNAMED"))
+}
+
+def javaMajorVersion(version: String): Option[Int] = {
+  val parts = version.split("[._-]")
+  parts.headOption.flatMap {
+    case "1" => parts.lift(1).flatMap(part => Try(part.toInt).toOption)
+    case part => Try(part.toInt).toOption
   }
 }

--- a/shared/src/main/scala/com/nawforce/pkgforce/names/TypeName.scala
+++ b/shared/src/main/scala/com/nawforce/pkgforce/names/TypeName.scala
@@ -30,7 +30,7 @@ import scala.collection.mutable.ArrayBuffer
 final case class TypeName(name: Name, params: Seq[TypeName], outer: Option[TypeName]) {
 
   /** Cache hash code as heavily used in collections */
-  override val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this)
+  override val hashCode: Int = scala.util.hashing.MurmurHash3.caseClassHash(this)
 
   /** Provide custom handling to toString to deal with internal type display */
   override def toString: String = {


### PR DESCRIPTION
## Summary
  - Enables native access for forked JVM tests on JDK 24+ to suppress JNA restricted native access warnings.
  - Replaces deprecated build URL construction and TypeName hash helper usage.

  ## Validation
  - sbt scalafmtAll
  - sbt 'apexlsJVM/Compile/compile' 'apexlsJS/Compile/compile'
  - sbt 'apexlsJVM/Test/testOnly com.nawforce.indexer.IndexerTest'