### PR TITLE
[codex] allow Batchable start to return Set

### DIFF
--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/MethodMap.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/MethodMap.scala
@@ -612,9 +612,9 @@ object MethodMap {
       case None => ()
     }
 
-    // Batch allows an Iterable<T> start method instead of usual QueryLocator return
+    // Batch allows some collection start methods instead of usual QueryLocator return
     if (
-      isBatchableStartWithListOrIterable(method) &&
+      isBatchableStartWithCollection(method) &&
       isBatchableStartWithQueryLocator(matchedMethod) &&
       td.implements(TypeName(Seq(Names.Batchable, Names.Database)), ignoreGenerics = true)
     ) {
@@ -826,7 +826,7 @@ object MethodMap {
     } else if (isEqualsLike(interfaceMethod) && isEqualsLike(implMethod))
       true
     else if (
-      isBatchableStartWithQueryLocator(interfaceMethod) && isBatchableStartWithListOrIterable(
+      isBatchableStartWithQueryLocator(interfaceMethod) && isBatchableStartWithCollection(
         implMethod
       )
     )
@@ -864,9 +864,9 @@ object MethodMap {
     method.parameters.length == 1 && method.parameters.head.typeName == TypeNames.BatchableContext
   }
 
-  private def isBatchableStartWithListOrIterable(method: MethodDeclaration): Boolean = {
+  private def isBatchableStartWithCollection(method: MethodDeclaration): Boolean = {
     method.name == XNames.Start &&
-    (method.typeName.isIterable || method.typeName.isList) &&
+    (method.typeName.isIterable || method.typeName.isList || method.typeName.isSet) &&
     !method.isStatic &&
     method.parameters.length == 1 && method.parameters.head.typeName == TypeNames.BatchableContext
   }

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/ImplementsTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/ImplementsTest.scala
@@ -165,6 +165,57 @@ class ImplementsTest extends AnyFunSuite with TestHelper {
     assert(dummyIssues == "")
   }
 
+  test("Class implements Database.Batchable<sObject> with Set start") {
+    typeDeclarations(
+      Map(
+        "Dummy.cls" ->
+          """
+          | global class Dummy implements Database.Batchable<sObject> {
+          |   public Set<sObject> start(Database.BatchableContext param1) { return new Set<SObject>(); }
+          |   public void execute(Database.BatchableContext param1, List<SObject> param2) {}
+          |   public void finish(Database.BatchableContext param1) {}
+          | }
+          |""".stripMargin
+      )
+    )
+    assert(dummyIssues == "")
+  }
+
+  test("Class implements Database.Batchable<Account> with Set start") {
+    typeDeclarations(
+      Map(
+        "Dummy.cls" ->
+          """
+          | global class Dummy implements Database.Batchable<Account> {
+          |   public Set<Account> start(Database.BatchableContext param1) { return new Set<Account>(); }
+          |   public void execute(Database.BatchableContext param1, List<Account> param2) {}
+          |   public void finish(Database.BatchableContext param1) {}
+          | }
+          |""".stripMargin
+      )
+    )
+    assert(dummyIssues == "")
+  }
+
+  test("Class implements Database.Batchable<Account> does not allow Set execute") {
+    typeDeclarations(
+      Map(
+        "Dummy.cls" ->
+          """
+          | global class Dummy implements Database.Batchable<Account> {
+          |   public Set<Account> start(Database.BatchableContext param1) { return new Set<Account>(); }
+          |   public void execute(Database.BatchableContext param1, Set<Account> param2) {}
+          |   public void finish(Database.BatchableContext param1) {}
+          | }
+          |""".stripMargin
+      )
+    )
+    assert(
+      dummyIssues ==
+        "Missing: line 2 at 14-19: Non-abstract class must implement method 'void execute(Database.BatchableContext, System.List<Schema.Account>)' from interface 'Database.Batchable<Schema.Account>'\n"
+    )
+  }
+
   test("Interface method overload validation - GitHub issue #329") {
     typeDeclarations(
       Map(


### PR DESCRIPTION
## Summary
- Allow `Database.Batchable<T>.start(Database.BatchableContext)` implementations to return `Set<T>` in the same special-case path as `List<T>` and `Iterable<T>`.
- Add regression coverage for both `Set<sObject>` and concrete `Set<Account>` start methods.
- Add a negative regression confirming `execute` still requires `List<T>` and does not accept `Set<T>`.

## Root cause
Salesforce accepts `Set<T>` as a `Batchable.start` collection return type, but the interface-fulfillment special case only recognized `List<T>` and `Iterable<T>`.

## Validation
- `sbt scalafmtAll`
- `sbt 'apexlsJVM/Test/testOnly com.nawforce.apexlink.cst.ImplementsTest'`
- `sf project deploy start --target-org pre-release --source-dir force-app --dry-run --test-level NoTestRun --json` with `Set<sObject>` start: succeeded
- Same dry-run with `Set<Account>` start: succeeded
- Same dry-run with `Set<Account>` execute: failed as expected, requiring `List<Account>`

Fixes #316
