### PR TITLE
[codex] cover unicode label values

### DIFF
--- a/jvm/src/test/scala/com/nawforce/apexlink/pkg/CachedTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/pkg/CachedTest.scala
@@ -314,6 +314,33 @@ class CachedTest extends AnyFunSuite with TestHelper with BeforeAndAfter {
     }
   }
 
+  test("Label with replacement token and unicode ellipsis value is available") {
+    FileSystemHelper.run(
+      Map(
+        "CustomLabels.labels" ->
+          """<?xml version="1.0" encoding="UTF-8"?>
+          |<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
+          |    <labels>
+          |        <fullName>TestLabel</fullName>
+          |        <language>en_US</language>
+          |        <protected>false</protected>
+          |        <shortDescription>TestLabel Description</shortDescription>
+          |        <value>{0}…</value>
+          |    </labels>
+          |</CustomLabels>
+          |""".stripMargin,
+        "Dummy.cls" -> "public class Dummy { {String a = System.label.TestLabel;} }"
+      )
+    ) { root: PathLike =>
+      val org = createOrg(root)
+      val pkg = org.unmanaged
+
+      assert(org.issues.isEmpty)
+      assert(pkg.orderedModules.head.labels.fields.exists(_.name.value == "TestLabel"))
+      assertIsFullDeclaration(pkg, "Dummy")
+    }
+  }
+
   test("Holder-based unused is recomputed for cache-loaded classes (#477)") {
     FileSystemHelper.run(
       Map(

--- a/shared/src/test/scala/com/nawforce/pkgforce/documents/XMLDocumentTest.scala
+++ b/shared/src/test/scala/com/nawforce/pkgforce/documents/XMLDocumentTest.scala
@@ -96,6 +96,21 @@ class XMLDocumentTest extends AnyFunSuite {
     }
   }
 
+  test("unicode text after replacement token is parsed") {
+    FileSystemHelper.run(
+      Map[String, String](
+        "test.xml" -> "<test xmlns=\"http://soap.sforce.com/2006/04/metadata\">{0}…</test>"
+      )
+    ) { root: PathLike =>
+      val file = root.join("test.xml")
+      parse(file) match {
+        case Left(err) => assert(false, err)
+        case Right(doc) =>
+          assert(doc.rootElement.text == "{0}…")
+      }
+    }
+  }
+
   test("single child node") {
     FileSystemHelper.run(
       Map[String, String](


### PR DESCRIPTION
## Summary
- Add shared XML coverage for text containing a replacement token followed by a Unicode ellipsis: `{0}…`.
- Add package-level coverage that a custom label with `<value>{0}…</value>` is still indexed and available through `System.label`.

## Notes
The reported Slack case does not reproduce as a failure on current `main`; the parser and label indexer both handle the value. This PR preserves that behavior with focused regression coverage.

## Validation
- `sbt scalafmtAll`
- `sbt 'apexlsJVM/Test/testOnly com.nawforce.pkgforce.documents.XMLDocumentTest' 'apexlsJVM/Test/testOnly com.nawforce.apexlink.pkg.CachedTest'`
- `sbt 'apexlsJS/Test/testOnly com.nawforce.pkgforce.documents.XMLDocumentTest'`

Refs #382
