### PR TITLE
[codex] tolerate missing parser stop locations

### DIFF
--- a/jvm/src/main/scala/com/nawforce/runtime/parsers/Source.scala
+++ b/jvm/src/main/scala/com/nawforce/runtime/parsers/Source.scala
@@ -104,13 +104,8 @@ case class Source(
   }
 
   def stampLocation(positionable: Positionable, context: ParserRuleContext): Unit = {
-    // This is debug for https://github.com/nawforce/apex-link/issues/90
-    if (context.stop == null) {
-      val startLine = if (context.start == null) "null" else context.start.getLine
-      throw new Exception(
-        s"Apex parser context missing stop location, context at line $startLine, type ${context.getClass}"
-      )
-    }
+    val stop       = Option(context.stop).getOrElse(context.start)
+    val stopLength = Option(stop.getText).fold(0)(_.length)
 
     positionable.setLocation(
       path,
@@ -119,11 +114,11 @@ case class Source(
         context.start.getCharPositionInLine + columnOffset
       else
         context.start.getCharPositionInLine,
-      context.stop.getLine + lineOffset,
-      if (context.stop.getLine == 1)
-        context.stop.getCharPositionInLine + context.stop.getText.length + columnOffset
+      stop.getLine + lineOffset,
+      if (stop.getLine == 1)
+        stop.getCharPositionInLine + stopLength + columnOffset
       else
-        context.stop.getCharPositionInLine + context.stop.getText.length
+        stop.getCharPositionInLine + stopLength
     )
   }
 }

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/BlockTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/BlockTest.scala
@@ -5,8 +5,10 @@ package com.nawforce.apexlink.cst
 
 import com.nawforce.apexlink.TestHelper
 import com.nawforce.apexlink.api.OutlineParserSingleThreaded
-import com.nawforce.pkgforce.path.{Location, PathLike}
+import com.nawforce.pkgforce.path.{Location, PathLike, Positionable}
 import com.nawforce.runtime.FileSystemHelper
+import com.nawforce.runtime.parsers.{Source, SourceData}
+import org.antlr.v4.runtime.{CommonToken, ParserRuleContext}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -187,6 +189,37 @@ class BlockTest extends AnyFunSuite with Matchers with TestHelper {
     // Without the cluster suppression, the lexer reports the same escape error twice
     // on this line as recovery re-enters the string.
     assert(escapeErrors == 1, s"expected a single escape error, got:\n${dummyIssues}")
+  }
+
+  test("Parser context without stop location does not crash location stamping") {
+    FileSystemHelper.run(Map("Dummy.cls" -> "")) { root: PathLike =>
+      val file    = root.join("Dummy.cls")
+      val source  = new Source(file, SourceData(""), 0, 0, None)
+      val context = new ParserRuleContext()
+      val start   = new CommonToken(0, "bad")
+      start.setLine(3)
+      start.setCharPositionInLine(4)
+      context.start = start
+
+      val positioned = new Positionable
+      source.stampLocation(positioned, context)
+
+      assert(positioned.location.path == file)
+      assert(positioned.location.location == Location(3, 4, 3, 7))
+    }
+  }
+
+  test("Merge conflict text in method body does not crash") {
+    typeDeclaration("""public class Dummy {
+        |  public void m() {
+        |<<<<<<< HEAD
+        |    Integer a = 1;
+        |=======
+        |    Integer a = 2;
+        |>>>>>>> branch
+        |  }
+        |}""".stripMargin)
+    assert(dummyIssues.nonEmpty)
   }
 
 }


### PR DESCRIPTION
## Summary
- Stop throwing when ANTLR recovers a parser context with a missing `stop` token.
- Fall back to the start token for location stamping, matching the safer behavior already used by `Source.getLocation`.
- Add regression coverage for direct missing-stop contexts and merge-conflict marker text in method bodies.

## Root cause
`Source.stampLocation` treated a missing parser `stop` token as an exceptional debug condition. Some malformed Apex recovery paths can produce a context with a valid `start` token but no `stop`, causing validation to crash instead of reporting parser diagnostics.

## Validation
- `sbt scalafmtAll`
- `sbt 'apexlsJVM/Test/testOnly com.nawforce.apexlink.cst.BlockTest'`

Fixes #292
