### PR TITLE
[codex] tolerate leading XML whitespace

### DIFF
--- a/js/src/main/scala/com/nawforce/runtime/xml/XMLDocument.scala
+++ b/js/src/main/scala/com/nawforce/runtime/xml/XMLDocument.scala
@@ -66,14 +66,30 @@ object XMLDocument {
   var errors: List[Issue] = Nil
 
   def apply(path: PathLike, sourceData: SourceData): IssuesAnd[Option[XMLDocument]] = {
+    val source = sourceData.asString
+    if (source.nonEmpty && source.forall(isXmlWhitespace))
+      return IssuesAnd(None)
+
     errors = Nil
     val parser = new DOMParser(getOptions(path))
-    val doc    = parser.parseFromString(sourceData.asString, "text/xml")
+    val doc    = parser.parseFromString(trimLeadingXmlWhitespace(source), "text/xml")
     if (errors.nonEmpty) {
       IssuesAnd(ArraySeq(errors.last), None)
     } else {
       IssuesAnd(Some(new XMLDocument(path, doc)))
     }
+  }
+
+  private def trimLeadingXmlWhitespace(value: String): String = {
+    val start = value.indexWhere(!isXmlWhitespace(_))
+    if (start > 0)
+      value.drop(start)
+    else
+      value
+  }
+
+  private def isXmlWhitespace(char: Char): Boolean = {
+    char == ' ' || char == '\t' || char == '\r' || char == '\n'
   }
 
   private def getOptions(path: PathLike): Object with Dynamic = {

--- a/jvm/src/main/scala/com/nawforce/runtime/xml/XMLDocument.scala
+++ b/jvm/src/main/scala/com/nawforce/runtime/xml/XMLDocument.scala
@@ -48,9 +48,18 @@ object XMLDocument {
   val sfNamespace = "http://soap.sforce.com/2006/04/metadata"
 
   def apply(path: PathLike, sourceData: SourceData): IssuesAnd[Option[XMLDocument]] = {
+    val bytes = sourceData.asUTF8
+    if (bytes.nonEmpty && bytes.forall(isXmlWhitespace))
+      return IssuesAnd(None)
+
     try {
       IssuesAnd(
-        Some(new XMLDocument(path, XMLLineLoader.load(new ByteArrayInputStream(sourceData.asUTF8))))
+        Some(
+          new XMLDocument(
+            path,
+            XMLLineLoader.load(new ByteArrayInputStream(trimLeadingXmlWhitespace(bytes)))
+          )
+        )
       )
     } catch {
       case e: SAXParseException =>
@@ -69,6 +78,19 @@ object XMLDocument {
         )
     }
   }
+
+  private def trimLeadingXmlWhitespace(bytes: Array[Byte]): Array[Byte] = {
+    val start = bytes.indexWhere(!isXmlWhitespace(_))
+    if (start > 0)
+      bytes.drop(start)
+    else
+      bytes
+  }
+
+  private def isXmlWhitespace(byte: Byte): Boolean = {
+    byte == ' ' || byte == '\t' || byte == '\r' || byte == '\n'
+  }
+
 }
 
 trait WithLocation extends NoBindingFactoryAdapter {

--- a/jvm/src/test/scala/com/nawforce/pkgforce/workspace/WorkspaceTest.scala
+++ b/jvm/src/test/scala/com/nawforce/pkgforce/workspace/WorkspaceTest.scala
@@ -220,6 +220,66 @@ class WorkspaceTest extends AnyFunSuite with Matchers {
     }
   }
 
+  test("Label file event with leading whitespace before declaration") {
+    FileSystemHelper.run(
+      Map[String, String](
+        "force-app/main/default/labels/CustomLabels.labels" ->
+          """
+            |<?xml version="1.0" encoding="UTF-8"?>
+            |<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata"/>
+            |""".stripMargin
+      )
+    ) { root: PathLike =>
+      val (ws, logger) = Workspace(root)
+      assert(logger.isEmpty)
+      assert(ws.nonEmpty)
+      ws.get.events.toList should matchPattern {
+        case List(LabelFileEvent(SourceInfo(PathLocation(labelsPath, Location.all), _)))
+            if labelsPath == root
+              .join("force-app")
+              .join("main")
+              .join("default")
+              .join("labels")
+              .join("CustomLabels.labels") =>
+      }
+    }
+  }
+
+  test("Label file event with leading whitespace before root element") {
+    FileSystemHelper.run(
+      Map[String, String](
+        "force-app/main/default/labels/CustomLabels.labels" ->
+          """
+            |<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata"/>
+            |""".stripMargin
+      )
+    ) { root: PathLike =>
+      val (ws, logger) = Workspace(root)
+      assert(logger.isEmpty)
+      assert(ws.nonEmpty)
+      ws.get.events.toList should matchPattern {
+        case List(LabelFileEvent(SourceInfo(PathLocation(labelsPath, Location.all), _)))
+            if labelsPath == root
+              .join("force-app")
+              .join("main")
+              .join("default")
+              .join("labels")
+              .join("CustomLabels.labels") =>
+      }
+    }
+  }
+
+  test("Whitespace only label file has no parse error") {
+    FileSystemHelper.run(
+      Map[String, String]("force-app/main/default/labels/CustomLabels.labels" -> " \n\t \r\n  ")
+    ) { root: PathLike =>
+      val (ws, logger) = Workspace(root)
+      assert(logger.isEmpty)
+      assert(ws.nonEmpty)
+      assert(ws.get.events.collect { case event: IssuesEvent => event }.isEmpty)
+    }
+  }
+
   test("Label parse error") {
     FileSystemHelper.run(
       Map[String, String]("force-app/main/default/labels/CustomLabels.labels" -> "<CustomLabels")

--- a/shared/src/test/scala/com/nawforce/pkgforce/documents/XMLDocumentTest.scala
+++ b/shared/src/test/scala/com/nawforce/pkgforce/documents/XMLDocumentTest.scala
@@ -44,6 +44,10 @@ class XMLDocumentTest extends AnyFunSuite {
     }
   }
 
+  def parseOptional(path: PathLike): IssuesAnd[Option[XMLDocument]] = {
+    XMLFactory.parse(path)
+  }
+
   test("Simple doc is parsed") {
     FileSystemHelper.run(Map[String, String]("test.xml" -> "<test/>")) { root: PathLike =>
       parse(root.join("test.xml")) match {
@@ -57,7 +61,7 @@ class XMLDocumentTest extends AnyFunSuite {
     FileSystemHelper.run(Map[String, String]("test.xml" -> "\n  <test>")) { root: PathLike =>
       val file = root.join("test.xml")
       parse(file) match {
-        case Left(Issue(f, Diagnostic(ERROR_CATEGORY, Location(2, _, 2, _), _), _)) if f == file =>
+        case Left(Issue(f, Diagnostic(ERROR_CATEGORY, Location(1, _, 1, _), _), _)) if f == file =>
           ()
         case Left(err) => assert(false, err)
         case Right(_)  => assert(false)
@@ -77,6 +81,16 @@ class XMLDocumentTest extends AnyFunSuite {
     }
   }
 
+  test("whitespace only doc has no error") {
+    FileSystemHelper.run(Map[String, String]("test.xml" -> " \n\t \r\n  ")) { root: PathLike =>
+      parseOptional(root.join("test.xml")) match {
+        case IssuesAnd(errors, doc) =>
+          assert(errors.isEmpty)
+          assert(doc.isEmpty)
+      }
+    }
+  }
+
   test("root node") {
     FileSystemHelper.run(
       Map[String, String](
@@ -92,6 +106,41 @@ class XMLDocumentTest extends AnyFunSuite {
           assert(node.line == 1)
           assert(node.name == XMLName(XMLDocument.sfNamespace, "test"))
           assert(node.text == "Hello")
+      }
+    }
+  }
+
+  test("leading whitespace before declaration is parsed") {
+    FileSystemHelper.run(
+      Map[String, String](
+        "test.xml" ->
+          """
+            |<?xml version="1.0" encoding="UTF-8"?>
+            |<test xmlns="http://soap.sforce.com/2006/04/metadata">Hello</test>
+            |""".stripMargin
+      )
+    ) { root: PathLike =>
+      parse(root.join("test.xml")) match {
+        case Left(err) => assert(false, err)
+        case Right(doc) =>
+          assert(doc.rootElement.text == "Hello")
+      }
+    }
+  }
+
+  test("leading whitespace before root element is parsed") {
+    FileSystemHelper.run(
+      Map[String, String](
+        "test.xml" ->
+          """
+            |<test xmlns="http://soap.sforce.com/2006/04/metadata">Hello</test>
+            |""".stripMargin
+      )
+    ) { root: PathLike =>
+      parse(root.join("test.xml")) match {
+        case Left(err) => assert(false, err)
+        case Right(doc) =>
+          assert(doc.rootElement.text == "Hello")
       }
     }
   }


### PR DESCRIPTION
## Summary

- Trim leading XML whitespace before parsing metadata XML on JVM and Scala.js, whether or not an XML declaration is present.
- Treat non-empty whitespace-only XML input as no document and no parse error.
- Add XML parser and labels workspace regressions for leading whitespace before declarations, leading whitespace before root elements, and whitespace-only label files.

## Root cause

Salesforce metadata deploy accepts labels metadata with leading whitespace, including before XML declarations and before root elements when the declaration is omitted. Standard XML parsers reject leading whitespace before an XML declaration, which could make labels fail to load and cascade into missing-label diagnostics.

## Salesforce compatibility checks

Check-only deploys to `pre-release` succeeded for:

- blank line before XML declaration
- multiple blank/space/tab lines before XML declaration
- labels file without XML declaration
- whitespace-only labels file
- labels file without `xmlns`

The missing `xmlns` case is intentionally not handled here because namespace assumptions affect later analysis.

## Validation

- `sbt scalafmtAll`
- `sbt 'apexlsJVM/Test/testOnly com.nawforce.pkgforce.documents.XMLDocumentTest' 'apexlsJVM/Test/testOnly com.nawforce.pkgforce.workspace.WorkspaceTest' 'apexlsJS/Test/testOnly com.nawforce.pkgforce.documents.XMLDocumentTest'`

Fixes #331
