### PR TITLE
[codex] clarify missing nested type diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Missing nested Apex type diagnostics now clarify when the outer type exists but the referenced nested type is not declared (#149)
+
 ## [6.1.0-beta.2] - 2026-06-18
 
 ### Fixed

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Creator.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Creator.scala
@@ -324,14 +324,14 @@ final case class MapCreatorRest(pairs: List[MapCreatorRestPair]) extends Creator
     val keyType = context.getTypeAndAddDependency(enclosedTypes.get._1, context.thisType)
     if (keyType.isLeft) {
       if (!context.module.isGhostedType(enclosedTypes.get._1))
-        context.log(keyType.swap.getOrElse(throw new NoSuchElementException).asIssue(location))
+        context.logTypeError(location, keyType.swap.getOrElse(throw new NoSuchElementException))
       return ExprContext.empty
     }
 
     val valueType = context.getTypeAndAddDependency(enclosedTypes.get._2, context.thisType)
     if (valueType.isLeft) {
       if (!context.module.isGhostedType(enclosedTypes.get._2))
-        context.log(valueType.swap.getOrElse(throw new NoSuchElementException).asIssue(location))
+        context.logTypeError(location, valueType.swap.getOrElse(throw new NoSuchElementException))
       return ExprContext.empty
     }
 
@@ -430,7 +430,7 @@ final case class SetOrListCreatorRest(parts: ArraySeq[Expression]) extends Creat
     context.getTypeAndAddDependency(enclosedType.get, context.thisType) match {
       case Left(error) =>
         if (!context.module.isGhostedType(enclosedType.get))
-          context.log(error.asIssue(location))
+          context.logTypeError(location, error)
         // Still verify parts for variable usage tracking, even though we can't type check
         parts.foreach(_.verify(input, context))
         ExprContext.empty

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
@@ -635,7 +635,7 @@ final case class MethodCallWithId(target: Id, arguments: ArraySeq[Expression]) e
           td match {
             case Left(error) =>
               if (!context.module.isGhostedType(method.typeName))
-                context.log(error.asIssue(location))
+                context.logTypeError(location, error)
               context.saveResult(this, target.location.location) {
                 ExprContext(None, None, method)
               }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/VerifyContext.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/VerifyContext.scala
@@ -16,7 +16,7 @@ package com.nawforce.apexlink.cst
 
 import com.nawforce.apexlink.cst.stmts.{ControlFlowContext, OuterControlFlowContext}
 import com.nawforce.apexlink.diagnostics.IssueOps
-import com.nawforce.apexlink.finding.TypeResolver
+import com.nawforce.apexlink.finding.{MissingType, TypeError, TypeResolver}
 import com.nawforce.apexlink.finding.TypeResolver.TypeResponse
 import com.nawforce.apexlink.memory.SkinnySet
 import com.nawforce.apexlink.names.TypeNames
@@ -95,7 +95,19 @@ trait VerifyContext {
 
   def missingType(location: PathLocation, typeName: TypeName): Unit = {
     if (!module.isGulped && !module.isGhostedType(typeName) && !suppressIssues)
-      OrgInfo.log(IssueOps.noTypeDeclaration(location, typeName))
+      OrgInfo.log(IssueOps.noTypeDeclaration(location, typeName, isApexType))
+  }
+
+  def typeErrorIssue(location: PathLocation, error: TypeError): Issue = {
+    error match {
+      case MissingType(typeName) =>
+        IssueOps.noTypeDeclaration(location, typeName, isApexType)
+      case _ => error.asIssue(location)
+    }
+  }
+
+  def logTypeError(location: PathLocation, error: TypeError): Unit = {
+    log(typeErrorIssue(location, error))
   }
 
   def missingIdentifier(location: PathLocation, typeName: TypeName, name: Name): Unit = {
@@ -116,6 +128,10 @@ trait VerifyContext {
   def log(issue: Issue): Unit = {
     if (!suppressIssues)
       OrgInfo.log(issue)
+  }
+
+  private def isApexType(typeName: TypeName): Boolean = {
+    getTypeFor(typeName, thisType).toOption.exists(_.isInstanceOf[ApexDeclaration])
   }
 }
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/diagnostics/IssueOps.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/diagnostics/IssueOps.scala
@@ -55,6 +55,26 @@ object IssueOps {
       Diagnostic(MISSING_CATEGORY, location.location, s"No type declaration found for '$typeName'")
     )
 
+  def noTypeDeclaration(
+    location: PathLocation,
+    typeName: TypeName,
+    isApexType: TypeName => Boolean
+  ): Issue = {
+    typeName.outer
+      .filter(isApexType)
+      .map(outerTypeName =>
+        Issue(
+          location.path,
+          Diagnostic(
+            MISSING_CATEGORY,
+            location.location,
+            s"No nested type '${typeName.name}' found on Apex type '$outerTypeName' while resolving '$typeName'; declare the nested type explicitly or use the actual type name"
+          )
+        )
+      )
+      .getOrElse(noTypeDeclaration(location, typeName))
+  }
+
   def noVariableOrType(location: PathLocation, name: Name, typeName: TypeName): Issue =
     Issue(
       location.path,

--- a/jvm/src/main/scala/com/nawforce/apexlink/finding/RelativeTypeName.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/finding/RelativeTypeName.scala
@@ -100,7 +100,7 @@ final case class RelativeTypeName(typeContext: RelativeTypeContext, relativeType
       typeContext.resolve(relativeTypeName) match {
         case Some(Left(error)) =>
           if (!context.module.isGulped)
-            context.log(error.asIssue(location))
+            context.logTypeError(location, error)
         case Some(Right(td)) =>
           context.addDependency(td)
           td.typeName.params.foreach(typeName =>

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/apex/TriggerDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/apex/TriggerDeclaration.scala
@@ -101,7 +101,7 @@ final case class TriggerDeclaration(
       tdOpt match {
         case Left(error) =>
           if (!module.isGhostedType(objectTypeName))
-            OrgInfo.log(error.asIssue(objectNameId.location))
+            context.logTypeError(objectNameId.location, error)
         case Right(_) =>
           val triggerContext = context
             .getTypeFor(TypeNames.trigger(objectTypeName), this)

--- a/jvm/src/test/scala/com/nawforce/apexlink/pkg/BugTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/pkg/BugTest.scala
@@ -338,6 +338,44 @@ class BugTest extends AnyFunSuite with TestHelper {
     }
   }
 
+  test("Issue 149: phantom inner class references have a clearer error") {
+    FileSystemHelper.run(
+      Map(
+        "Outer.cls" -> "public class Outer {}",
+        "Container.cls" ->
+          """
+            |public class Container {
+            |  class Outer {}
+            |  class Consumer {
+            |    Outer.Missing field;
+            |  }
+            |}
+            |""".stripMargin,
+        "Dummy.cls" ->
+          """
+            |public class Dummy extends Outer.Missing {
+            |  Outer.Missing field;
+            |  void func(Outer.Missing arg) {
+            |    Outer.Missing local = new Outer.Missing();
+            |  }
+            |}
+            |""".stripMargin
+      )
+    ) { root: PathLike =>
+      createOrg(root)
+
+      val messages = getMessages(root.join("Dummy.cls"))
+      assert(messages.contains("No nested type 'Missing' found on Apex type 'Outer'"))
+      assert(messages.contains("declare the nested type explicitly or use the actual type name"))
+      assert(!messages.contains("No type declaration found for 'Outer.Missing'"))
+
+      val relativeMessages = getMessages(root.join("Container.cls"))
+      assert(relativeMessages.contains("No nested type 'Missing' found on Apex type 'Outer'"))
+      assert(relativeMessages.contains("while resolving 'Outer.Missing'"))
+      assert(!relativeMessages.contains("No type declaration found for 'Outer.Missing'"))
+    }
+  }
+
   test("Interface equals") {
     FileSystemHelper.run(
       Map(

--- a/jvm/src/test/scala/com/nawforce/apexlink/pkg/RefreshTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/pkg/RefreshTest.scala
@@ -111,7 +111,7 @@ class RefreshTest extends AnyFunSuite with TestHelper {
         assert(org.flush())
         assert(
           getMessages(root.join("pkg").join("Foo.cls"))
-            == "Missing: line 1 at 28-29: No type declaration found for 'Bar.Inner'\n"
+            == "Missing: line 1 at 28-29: No nested type 'Inner' found on Apex type 'Bar' while resolving 'Bar.Inner'; declare the nested type explicitly or use the actual type name\n"
         )
       }
     }
@@ -129,7 +129,7 @@ class RefreshTest extends AnyFunSuite with TestHelper {
         val pkg = org.unmanaged
         assert(
           getMessages(root.join("pkg").join("Foo.cls"))
-            == "Missing: line 1 at 28-29: No type declaration found for 'Bar.Inner'\n"
+            == "Missing: line 1 at 28-29: No nested type 'Inner' found on Apex type 'Bar' while resolving 'Bar.Inner'; declare the nested type explicitly or use the actual type name\n"
         )
 
         refresh(pkg, root.join("pkg/Bar.cls"), "public class Bar {public class Inner {}}")
@@ -377,7 +377,7 @@ class RefreshTest extends AnyFunSuite with TestHelper {
         assert(org.flush())
         assert(
           getMessages(root.join("pkg").join("Foo.trigger"))
-            == "Missing: line 1 at 50-51: No type declaration found for 'Bar.Inner'\n"
+            == "Missing: line 1 at 50-51: No nested type 'Inner' found on Apex type 'Bar' while resolving 'Bar.Inner'; declare the nested type explicitly or use the actual type name\n"
         )
       }
     }
@@ -395,7 +395,7 @@ class RefreshTest extends AnyFunSuite with TestHelper {
         val pkg = org.unmanaged
         assert(
           getMessages(root.join("pkg").join("Foo.trigger"))
-            == "Missing: line 1 at 50-51: No type declaration found for 'Bar.Inner'\n"
+            == "Missing: line 1 at 50-51: No nested type 'Inner' found on Apex type 'Bar' while resolving 'Bar.Inner'; declare the nested type explicitly or use the actual type name\n"
         )
 
         refresh(pkg, root.join("pkg").join("Bar.cls"), "public class Bar {public class Inner {}}")
@@ -1112,7 +1112,7 @@ class RefreshTest extends AnyFunSuite with TestHelper {
         refresh(pkg, root.join("pkg/Bar.cls"), "public class Bar {}", highPriority = true)
         assert(
           getMessages(root.join("pkg").join("Foo.cls"))
-            == "Missing: line 1 at 28-29: No type declaration found for 'Bar.Inner'\n"
+            == "Missing: line 1 at 28-29: No nested type 'Inner' found on Apex type 'Bar' while resolving 'Bar.Inner'; declare the nested type explicitly or use the actual type name\n"
         )
       }
     }
@@ -1130,7 +1130,7 @@ class RefreshTest extends AnyFunSuite with TestHelper {
         val pkg = org.unmanaged
         assert(
           getMessages(root.join("pkg").join("Foo.cls"))
-            == "Missing: line 1 at 28-29: No type declaration found for 'Bar.Inner'\n"
+            == "Missing: line 1 at 28-29: No nested type 'Inner' found on Apex type 'Bar' while resolving 'Bar.Inner'; declare the nested type explicitly or use the actual type name\n"
         )
 
         refresh(


### PR DESCRIPTION
## Summary

- Add a contextual missing-type diagnostic for Apex nested type references when the outer Apex type exists but the nested type is not declared.
- Route validation-time `MissingType` logging through the shared contextual formatter so field, local, argument, creator, return-type, trigger, and relative-type paths get consistent wording.
- Add regression coverage for issue 149 and update refresh tests that remove and restore nested types.
- Document the user-facing diagnostic improvement in `CHANGELOG.md`.

## Root cause

References such as `Outer.Missing` previously reported the generic `No type declaration found for 'Outer.Missing'` even when `Outer` was present. That made the Apex platform quirk around apparent inner-type equivalency hard to diagnose from apex-ls output.

## User impact

The diagnostic now reports that the outer Apex type was found but the nested type was not declared, and suggests declaring the nested type explicitly or using the actual type name.

## Validation

- `sbt scalafmtAll`
- `sbt 'apexlsJVM/Test/testOnly com.nawforce.apexlink.pkg.BugTest com.nawforce.apexlink.pkg.RefreshTest'`

Fixes #149
