### PR TITLE
feat: Config - dependency count alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `dependencyCountAliases` `sfdx-project.json` option to define named (and optionally nested) presets for `// MaxDependencyCount(...)`, so `// MaxDependencyCount(med)` or `// MaxDependencyCount(group.name)` can be used instead of repeating raw numbers across files (#324)
+
 ### Removed
 
 - Internal Service Provider Interface (SPI) support used to integrate external analysis tools such as the now-deprecated apex-ls-pmd has been removed. Public APIs that configured external analysis (`ServerOps.getExternalAnalysis`/`setExternalAnalysis`, `OpenOptions.withExternalAnalysisMode`, and the RPC method `setExternalAnalysisMode`) are retained as deprecated no-op stubs for backward compatibility, and now log a deprecation notice (#439)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ The recommended approach is to configure apex-ls settings under the `plugins.ape
       "externalMetadata": [...],
       "library": true,
       "maxDependencyCount": 10,
+      "dependencyCountAliases": {
+        "low": 10,
+        "med": 50,
+        "high": 100,
+        "group": {
+          "name": 23
+        }
+      },
       "options": {
         "forceIgnoreVersion": "v2"
       }
@@ -115,8 +123,34 @@ For backward compatibility, the legacy configuration style is still supported:
 | `externalMetadata`  | Array         | `[]`    | External metadata directories to include in analysis. |
 | `library`           | Boolean       | `false` | Whether this project should be treated as a library. |
 | `maxDependencyCount` | Integer      | None    | Maximum number of dependencies allowed. |
+| `dependencyCountAliases` | Object    | `{}`    | Named aliases for `maxDependencyCount` values, referenced from the `//MaxDependencyCount(name)` comment. Nested objects create dotted keys, e.g. `group.name`. |
 
 The `options` section supports additional configuration options that may be added in future releases.
+
+##### `dependencyCountAliases`
+
+Repeating `// MaxDependencyCount(number)` across many files is a maintenance burden, especially when the limit needs to change project-wide. `dependencyCountAliases` lets you define named presets (optionally grouped in nested objects) that the `//MaxDependencyCount(...)` comment can reference by name instead of by number:
+
+```json
+"dependencyCountAliases": {
+  "low": 10,
+  "med": 50,
+  "high": 100,
+  "group": {
+    "name": 23
+  }
+}
+```
+
+```apex
+// MaxDependencyCount(med)
+public class MyClass {}
+
+// MaxDependencyCount(group.name)
+public class MyOtherClass {}
+```
+
+Plain numbers, e.g. `// MaxDependencyCount(50)`, are still supported for one-off cases. If a referenced name is not found in `dependencyCountAliases`, an error is reported.
 
 ## Development
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/deps/MaxDependencyCountParser.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/deps/MaxDependencyCountParser.scala
@@ -27,9 +27,10 @@ class MaxDependencyCountParser(org: Org) {
 
   def count(td: ApexDeclaration): Either[Option[String], Int] = {
     val dependencyLimitParseExceptions = mutable.Queue[String]()
+    val aliases = org.getProjectConfig().map(_.dependencyCountAliases).getOrElse(Map.empty)
 
     def parseTokenToDependencyLimit(t: Token): Option[Int] = {
-      getDependencyLimit(t) match {
+      getDependencyLimit(t, aliases) match {
         case Right(result) => Some(result)
         case Left(value) =>
           if (value.nonEmpty)
@@ -62,7 +63,10 @@ class MaxDependencyCountParser(org: Org) {
     }
   }
 
-  private def getDependencyLimit(token: Token): Either[Option[String], Int] = {
+  private def getDependencyLimit(
+    token: Token,
+    aliases: Map[String, Int]
+  ): Either[Option[String], Int] = {
     val tokenText = token.getText.filterNot((x: Char) => x.isWhitespace)
     val start     = tokenText.indexOf(maxCountMarker)
     if (start == -1) return Left(None)
@@ -73,7 +77,12 @@ class MaxDependencyCountParser(org: Org) {
     Try(text.toInt) match {
       case Success(value) if value >= 0 => Right(value)
       case Success(_)                   => Left(Some(s"'$text' must be >=0"))
-      case Failure(_)                   => Left(Some(s"'$text' is not an integer value"))
+      case Failure(_) =>
+        aliases.get(text) match {
+          case Some(value) => Right(value)
+          case None =>
+            Left(Some(s"'$text' is not an integer value or a known dependencyCountAliases entry"))
+        }
     }
   }
 }

--- a/jvm/src/test/scala/com/nawforce/apexlink/rpc/OrgAPITest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/rpc/OrgAPITest.scala
@@ -687,9 +687,113 @@ class OrgAPITest extends AsyncFunSuite with BeforeAndAfterEach with TestHelper {
             excludeTestClasses = true
           )
           .map(_.maxDependencyCount)
-          .forall(d => d.isLeft && d.swap.toOption.flatten.get == "'abc' is not an integer value")
+          .forall(d =>
+            d.isLeft && d.swap.toOption.flatten.get ==
+              "'abc' is not an integer value or a known dependencyCountAliases entry"
+          )
       )
 
+    }
+  }
+
+  test("Get DependencyCounts with MaxDependencyCount comment using a configured alias") {
+    FileSystemHelper.runWithCopy(samplesDir.join("dependency-counts")) { root: PathLike =>
+      root.createFile(
+        "sfdx-project.json",
+        """
+          |{
+          |  "packageDirectories": [
+          |    {
+          |      "path": "force-app",
+          |      "default": true
+          |    }
+          |  ],
+          |  "namespace": "",
+          |  "sfdcLoginUrl": "https://login.salesforce.com",
+          |  "sourceApiVersion": "48.0",
+          |  "plugins" : {
+          |     "dependencyCountAliases": {
+          |       "med": 50,
+          |       "group": {
+          |         "name": 23
+          |       }
+          |     }
+          |  }
+          |}
+          |""".stripMargin
+      )
+      root.createFile(
+        root.join("force-app/main/default/classes/Test.cls").toString,
+        """
+        |//MaxDependencyCount(med)
+        |public class Test {}""".stripMargin
+      )
+      root.createFile(
+        root.join("force-app/main/default/classes/Test2.cls").toString,
+        """
+        |//MaxDependencyCount(group.name)
+        |public class Test2 {}""".stripMargin
+      )
+
+      val orgAPI = createOrg(root)
+      val counts = orgAPI
+        .getDependencyCounts(
+          Array(
+            root.join("force-app/main/default/classes/Test.cls").toString,
+            root.join("force-app/main/default/classes/Test2.cls").toString
+          ),
+          excludeTestClasses = true
+        )
+        .map(c => c.path -> c.maxDependencyCount)
+        .toMap
+      assert(counts(root.join("force-app/main/default/classes/Test.cls").toString) == Right(50))
+      assert(counts(root.join("force-app/main/default/classes/Test2.cls").toString) == Right(23))
+    }
+  }
+
+  test("Get DependencyCounts with MaxDependencyCount comment using an unknown alias") {
+    FileSystemHelper.runWithCopy(samplesDir.join("dependency-counts")) { root: PathLike =>
+      root.createFile(
+        "sfdx-project.json",
+        """
+          |{
+          |  "packageDirectories": [
+          |    {
+          |      "path": "force-app",
+          |      "default": true
+          |    }
+          |  ],
+          |  "namespace": "",
+          |  "sfdcLoginUrl": "https://login.salesforce.com",
+          |  "sourceApiVersion": "48.0",
+          |  "plugins" : {
+          |     "dependencyCountAliases": {
+          |       "med": 50
+          |     }
+          |  }
+          |}
+          |""".stripMargin
+      )
+      root.createFile(
+        root.join("force-app/main/default/classes/Test.cls").toString,
+        """
+        |//MaxDependencyCount(unknown)
+        |public class Test {}""".stripMargin
+      )
+
+      val orgAPI = createOrg(root)
+      assert(
+        orgAPI
+          .getDependencyCounts(
+            Array(root.join("force-app/main/default/classes/Test.cls").toString),
+            excludeTestClasses = true
+          )
+          .map(_.maxDependencyCount)
+          .forall(d =>
+            d.isLeft && d.swap.toOption.flatten.get ==
+              "'unknown' is not an integer value or a known dependencyCountAliases entry"
+          )
+      )
     }
   }
 

--- a/shared/src/main/scala/com/nawforce/pkgforce/sfdx/ApexConfig.scala
+++ b/shared/src/main/scala/com/nawforce/pkgforce/sfdx/ApexConfig.scala
@@ -32,6 +32,7 @@ case class ApexConfig(
   val unpackagedMetadata: Seq[PackageDirectory] = computeUnpackagedMetadata()
   val additionalNamespaces: Array[Option[Name]] = computeAdditionalNamespaces()
   val maxDependencyCount: Option[Int]           = computeMaxDependencyCount()
+  val dependencyCountAliases: Map[String, Int]  = computeDependencyCountAliases()
   val isLibrary: Boolean                        = computeIsLibrary()
   val externalMetadata: Seq[String]             = computeExternalMetadata()
   val options: Map[String, String]              = computeOptions()
@@ -161,6 +162,54 @@ case class ApexConfig(
         throw SFDXProjectError(lineAndOffset, message)
       })
       .getOrElse(None)
+  }
+
+  private def computeDependencyCountAliases(): Map[String, Int] = {
+    configSource.get("dependencyCountAliases") match {
+      case None => Map.empty
+      case Some(value: ujson.Obj) =>
+        flattenDependencyCountAliases("dependencyCountAliases", "", value)
+      case Some(value) =>
+        config
+          .lineAndOffsetOf(value)
+          .map(lineAndOffset => {
+            throw SFDXProjectError(lineAndOffset, "'dependencyCountAliases' should be an object")
+          })
+          .getOrElse(Map.empty)
+    }
+  }
+
+  private def flattenDependencyCountAliases(
+    errorPath: String,
+    keyPrefix: String,
+    obj: ujson.Obj
+  ): Map[String, Int] = {
+    obj.value.toSeq.flatMap { case (key, value) =>
+      val fullKey       = if (keyPrefix.isEmpty) key else s"$keyPrefix.$key"
+      val fullErrorPath = s"$errorPath.$key"
+      value match {
+        case nested: ujson.Obj =>
+          flattenDependencyCountAliases(fullErrorPath, fullKey, nested).toSeq
+        case _ =>
+          parseAliasCount(fullErrorPath, value).map(fullKey -> _).toSeq
+      }
+    }.toMap
+  }
+
+  private def parseAliasCount(errorPath: String, value: ujson.Value): Option[Int] = {
+    value match {
+      case num: ujson.Num if num.toString.matches("[0-9]+") =>
+        Try(num.toString().toInt) match {
+          case Success(parsedValue) => Some(parsedValue)
+          case Failure(_) =>
+            throwCountError(value, s"'$errorPath' value '${num.toString}' is not an integer")
+        }
+      case _ =>
+        throwCountError(
+          value,
+          s"'$errorPath' value '${value.toString}' should be a positive integer or nested object"
+        )
+    }
   }
 
   private def computeIsLibrary(): Boolean = {

--- a/shared/src/main/scala/com/nawforce/pkgforce/sfdx/SFDXProject.scala
+++ b/shared/src/main/scala/com/nawforce/pkgforce/sfdx/SFDXProject.scala
@@ -115,6 +115,7 @@ class SFDXProject(val projectPath: PathLike, config: ValueWithPositions) {
   def unpackagedMetadata: Seq[PackageDirectory] = apexConfig.unpackagedMetadata
   def additionalNamespaces: Array[Option[Name]] = apexConfig.additionalNamespaces
   def maxDependencyCount: Option[Int]           = apexConfig.maxDependencyCount
+  def dependencyCountAliases: Map[String, Int]  = apexConfig.dependencyCountAliases
   def isLibrary: Boolean                        = apexConfig.isLibrary
   def externalMetadata: Seq[String]             = apexConfig.externalMetadata
   def options: Map[String, String]              = apexConfig.options

--- a/shared/src/main/scala/com/nawforce/pkgforce/workspace/Workspace.scala
+++ b/shared/src/main/scala/com/nawforce/pkgforce/workspace/Workspace.scala
@@ -21,7 +21,11 @@ import com.nawforce.pkgforce.sfdx.SFDXProject
 
 /** Contains any config option that can be used by the Org
   */
-case class ProjectConfig(maxDependencyCount: Option[Int], isLibrary: Boolean = false)
+case class ProjectConfig(
+  maxDependencyCount: Option[Int],
+  isLibrary: Boolean = false,
+  dependencyCountAliases: Map[String, Int] = Map.empty
+)
 
 /** Metadata workspace, maintains information on available metadata within a project/package.
   *
@@ -70,7 +74,7 @@ object Workspace {
         new Workspace(
           issueManager,
           layers,
-          Some(ProjectConfig(proj.maxDependencyCount, proj.isLibrary)),
+          Some(ProjectConfig(proj.maxDependencyCount, proj.isLibrary, proj.dependencyCountAliases)),
           proj.externalMetadataPaths
         )
       }

--- a/shared/src/test/scala/com/nawforce/pkgforce/sfdx/ApexConfigTest.scala
+++ b/shared/src/test/scala/com/nawforce/pkgforce/sfdx/ApexConfigTest.scala
@@ -72,6 +72,112 @@ class ApexConfigTest extends AnyFunSuite with BeforeAndAfter {
     }
   }
 
+  test("Legacy configuration - with dependencyCountAliases") {
+    FileSystemHelper.run(
+      Map(
+        "sfdx-project.json" ->
+          """{
+            |  "plugins": {
+            |    "dependencyCountAliases": {
+            |      "low": 10,
+            |      "med": 50,
+            |      "high": 100,
+            |      "group": {
+            |        "name": 23
+            |      }
+            |    }
+            |  },
+            |  "packageDirectories": []
+            |}""".stripMargin
+      )
+    ) { root: PathLike =>
+      val project = SFDXProject(root, logger)
+      assert(logger.issues.isEmpty)
+      assert(project.nonEmpty)
+      assert(
+        project.get.apexConfig.dependencyCountAliases ==
+          Map("low" -> 10, "med" -> 50, "high" -> 100, "group.name" -> 23)
+      )
+    }
+  }
+
+  test("dependencyCountAliases - defaults to empty map when absent") {
+    FileSystemHelper.run(
+      Map("sfdx-project.json" -> "{\"plugins\": {}, \"packageDirectories\": []}")
+    ) { root: PathLike =>
+      val project = SFDXProject(root, logger)
+      assert(logger.issues.isEmpty)
+      assert(project.nonEmpty)
+      assert(project.get.apexConfig.dependencyCountAliases.isEmpty)
+    }
+  }
+
+  test("dependencyCountAliases - precedence apex-ls over legacy") {
+    FileSystemHelper.run(
+      Map(
+        "sfdx-project.json" ->
+          """{
+            |  "plugins": {
+            |    "dependencyCountAliases": {"low": 10},
+            |    "apex-ls": {
+            |      "dependencyCountAliases": {"low": 20}
+            |    }
+            |  },
+            |  "packageDirectories": []
+            |}""".stripMargin
+      )
+    ) { root: PathLike =>
+      val project = SFDXProject(root, logger)
+      assert(logger.issues.isEmpty)
+      assert(project.nonEmpty)
+      assert(project.get.apexConfig.dependencyCountAliases == Map("low" -> 20)) // apex-ls wins
+    }
+  }
+
+  test("Error handling - dependencyCountAliases not an object") {
+    FileSystemHelper.run(
+      Map(
+        "sfdx-project.json" -> "{\"plugins\": {\"dependencyCountAliases\": \"invalid\"}, \"packageDirectories\": []}"
+      )
+    ) { root: PathLike =>
+      val project = SFDXProject(root, logger)
+      assert(project.isEmpty) // Should fail
+      assert(
+        logger.issues
+          .exists(_.diagnostic.message.contains("'dependencyCountAliases' should be an object"))
+      )
+    }
+  }
+
+  test("Error handling - dependencyCountAliases entry not a number") {
+    FileSystemHelper.run(
+      Map(
+        "sfdx-project.json" -> "{\"plugins\": {\"dependencyCountAliases\": {\"low\": \"ten\"}}, \"packageDirectories\": []}"
+      )
+    ) { root: PathLike =>
+      val project = SFDXProject(root, logger)
+      assert(project.isEmpty) // Should fail
+      assert(
+        logger.issues.exists(_.diagnostic.message.contains("'dependencyCountAliases.low' value"))
+      )
+    }
+  }
+
+  test("Error handling - dependencyCountAliases nested entry not a number") {
+    FileSystemHelper.run(
+      Map(
+        "sfdx-project.json" -> "{\"plugins\": {\"dependencyCountAliases\": {\"group\": {\"name\": true}}}, \"packageDirectories\": []}"
+      )
+    ) { root: PathLike =>
+      val project = SFDXProject(root, logger)
+      assert(project.isEmpty) // Should fail
+      assert(
+        logger.issues
+          .exists(_.diagnostic.message.contains("'dependencyCountAliases.group.name' value"))
+      )
+    }
+  }
+
   test("Legacy configuration - with options") {
     FileSystemHelper.run(
       Map(


### PR DESCRIPTION
## Summary
- Add a `dependencyCountAliases` `sfdx-project.json` option (supported under both the legacy `plugins` and namespaced `plugins.apex-ls` sections) that maps names — optionally nested for grouping, e.g. `group.name` — to `maxDependencyCount` values.
- `// MaxDependencyCount(...)` comments can now reference an alias by name (e.g. `// MaxDependencyCount(med)`, `// MaxDependencyCount(group.name)`) in addition to the existing plain-number syntax, so limits can be changed project-wide from one config location instead of editing every file.
- Referencing an unknown name reports a clear error (`'<name>' is not an integer value or a known dependencyCountAliases entry`).
- Updated README configuration docs and added a CHANGELOG entry under `[Unreleased]`.

Closes #324

## Test plan
- [x] `sbt scalafmtAll`
- [x] `sbt apexlsJVM/compile` / `sbt apexlsJVM/Test/compile`
- [x] `sbt apexlsJS/compile` (verifies shared config code cross-compiles for Scala.js)
- [x] `sbt apexlsJVM/testOnly com.nawforce.pkgforce.sfdx.ApexConfigTest` — 29/29 passed, including new `dependencyCountAliases` parsing/precedence/error cases
- [x] `sbt apexlsJVM/testOnly com.nawforce.apexlink.rpc.OrgAPITest` — 37/37 passed, including new alias-resolution and unknown-alias tests
- [x] `sbt test` (full JVM suite) — 377/377 passed
- [ ] Sample-project regression tests (`apex-samples`) — not run; no sibling `apex-samples` checkout available in this environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)