### PR TITLE
fix: false 'must implement' error for interface methods with ghosted parameter types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `dependencyCountAliases` `sfdx-project.json` option to define named (and optionally nested) presets for `// MaxDependencyCount(...)`, so `// MaxDependencyCount(med)` or `// MaxDependencyCount(group.name)` can be used instead of repeating raw numbers across files (#324)
 
+### Fixed
+
+- Classes implementing an interface method whose parameter or return type is a ghosted (unavailable dependency package) type no longer report a false `Non-abstract class must implement method` diagnostic when the implementation uses a different, project-local type (#327)
+
 ### Removed
 
 - Internal Service Provider Interface (SPI) support used to integrate external analysis tools such as the now-deprecated apex-ls-pmd has been removed. Public APIs that configured external analysis (`ServerOps.getExternalAnalysis`/`setExternalAnalysis`, `OpenOptions.withExternalAnalysisMode`, and the RPC method `setExternalAnalysisMode`) are retained as deprecated no-op stubs for backward compatibility, and now log a deprecation notice (#439)

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/MethodMap.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/MethodMap.scala
@@ -539,7 +539,7 @@ object MethodMap {
                 method :: methods
                   .filterNot(_.hasSameSignature(method, allowPlatformGenericEquivalence = true))
               )
-            } else if (!module.isGulped && !hasGhostedMethods(module, methods)) {
+            } else if (!module.isGulped && !hasGhostedMethods(module, method :: methods)) {
               location.foreach(l =>
                 errors.append(
                   new Issue(

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/ImplementsTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/ImplementsTest.scala
@@ -15,6 +15,8 @@
 package com.nawforce.apexlink.cst
 
 import com.nawforce.apexlink.TestHelper
+import com.nawforce.pkgforce.path.PathLike
+import com.nawforce.runtime.FileSystemHelper
 import org.scalatest.funsuite.AnyFunSuite
 
 class ImplementsTest extends AnyFunSuite with TestHelper {
@@ -231,6 +233,29 @@ class ImplementsTest extends AnyFunSuite with TestHelper {
       )
     )
     assert(dummyIssues.isEmpty)
+  }
+
+  test(
+    "Interface method with ghosted parameter type implemented with a derived type - GitHub issue #327"
+  ) {
+    FileSystemHelper.run(
+      Map(
+        "sfdx-project.json" ->
+          """{
+          |"packageDirectories": [{"path": "force-app"}],
+          |"plugins": {"dependencies": [{"namespace": "ext"}]}
+          |}""".stripMargin,
+        "force-app/DerivedType.cls" -> "public class DerivedType extends ext.Something {}",
+        "force-app/IFoo.cls"        -> "public interface IFoo { void foo(ext.Something a); }",
+        "force-app/Impl.cls" ->
+          """public class Impl implements IFoo {
+            |  public void foo(DerivedType b) {}
+            |}""".stripMargin
+      )
+    ) { root: PathLike =>
+      createOrg(root)
+      assert(getMessages(root.join("force-app").join("Impl.cls")).isEmpty)
+    }
   }
 
 }


### PR DESCRIPTION
## Summary

- Fixes the scenario from #327: a non-abstract class implementing an interface method whose parameter (or return) type is a *ghosted* type (declared in an unavailable package dependency) was incorrectly flagged with `Non-abstract class must implement method '...' from interface '...'` when the implementation used a different, project-local type instead. apex-ls cannot verify that relationship precisely because the ghosted type's real hierarchy is unknown, so this should be treated leniently rather than reported as an error, consistent with how ghosted types are already handled elsewhere (assignability, missing-type suppression, etc.).
- Root cause: `MethodMap.hasGhostedMethods` (used to suppress this diagnostic when ghosting makes fulfillment unverifiable) only inspected the already-collected implementation bucket for ghosted types, never the interface method actually being checked. When the *interface* method's own signature was the one referencing a ghosted type (as in the reported case), the check missed it and the false positive fired.
- Fix: include the interface method under test in the ghosted-type check.

Note: the original issue also described this producing an "ambiguous call" at call sites, and a related comment described a similar issue for constructors. I was not able to reproduce either of those symptoms against current `main` after extensive testing (direct, interface-based, abstract-base, and ghosted-SObject variants) — the existing `Any`-argument handling in `MethodMap`/`Expressions.scala` already avoids ambiguity for method calls, and constructor calls skip validation entirely when an argument's type can't be resolved (`Creator.scala`/`Expressions.scala` `args.forall(_.isDefined)` guard), so `ConstructorMap` never actually sees an unresolved argument today. The false "must implement" diagnostic fixed here was the one concretely, deterministically reproducible defect matching the issue's example. Per the maintainer's own comment on the issue, a full resolution of ghosted-type modelling is expected to be a larger effort tied to 2GP prep work.

## Test plan

- Added `ImplementsTest`: "Interface method with ghosted parameter type implemented with a derived type - GitHub issue #327" — fails without the fix (`Non-abstract class must implement method ...`), passes with it. Verified both ways.
- `sbt scalafmtAll` (via `scalafmtCheckAll`, clean)
- `sbt apexlsJVM/test` — full JVM suite green (2489/2489; one unrelated `ParsedCacheTest` failure only appeared when overriding `APEXLINK_CACHE_DIR` for test isolation and is expected there)
- Sample-project regression tests were not run (no `apex-samples` checkout available in this environment); this change is narrowly scoped to interface-fulfillment checking against ghosted types, exercised by the new unit test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)