### PR TITLE
fix: reject invalid List/Set collection initialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Set assignments and List/Set constructor initializers now enforce the platform's collection element-type compatibility rules (#318)
 - Classes implementing an interface method whose parameter or return type is a ghosted (unavailable dependency package) type no longer report a false `Non-abstract class must implement method` diagnostic when the implementation uses a different, project-local type (#327)
 
 ### Removed

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/AssignableSupport.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/AssignableSupport.scala
@@ -25,13 +25,20 @@ object AssignableSupport {
     * @param strictConversions limit implicit type conversions
     * @param narrowSObjects narrowing of SObject conversions, i.e. SObject cast to Account
     */
-  case class AssignableOptions(strictConversions: Boolean, narrowSObjects: Boolean)
+  case class AssignableOptions(
+    strictConversions: Boolean,
+    narrowSObjects: Boolean,
+    invariantSet: Boolean = false
+  )
 
   object AssignableOptions {
 
     /** Most commonly used options */
     val default: AssignableOptions =
       AssignableOptions(strictConversions = false, narrowSObjects = true)
+
+    val assignment: AssignableOptions =
+      AssignableOptions(strictConversions = false, narrowSObjects = true, invariantSet = true)
   }
 
   /** Determine if two values could be equal based on type
@@ -100,7 +107,7 @@ object AssignableSupport {
     } else if (!options.strictConversions && fromType.typeName.isRecordSet) {
       isRecordSetAssignable(toType, fromType.typeName)
     } else if (toType.params.nonEmpty || fromType.typeName.params.nonEmpty) {
-      isAssignableGeneric(toType, fromType, context)
+      isAssignableGeneric(toType, fromType, context, options)
     } else {
       (if (options.strictConversions)
          strictAssignable.contains(toType, fromType.typeName)
@@ -114,13 +121,15 @@ object AssignableSupport {
   private def isAssignableGeneric(
     toType: TypeName,
     fromType: TypeDeclaration,
-    context: VerifyContext
+    context: VerifyContext,
+    options: AssignableOptions
   ): Boolean = {
     if (toType.params.size == fromType.typeName.params.size) {
       isAssignableName(toType, fromType) && hasAssignableGenericParams(
         toType,
         fromType.typeName,
-        context
+        context,
+        options
       )
     } else if (toType.params.isEmpty || fromType.typeName.params.isEmpty) {
       // e.g. Object a = List<A> | Iterable<A> a = new CustomIterator() | Iterable<A> a = QueryLocator
@@ -150,9 +159,10 @@ object AssignableSupport {
   private def hasAssignableGenericParams(
     toType: TypeName,
     fromType: TypeName,
-    context: VerifyContext
+    context: VerifyContext,
+    options: AssignableOptions
   ): Boolean = {
-    if (toType.name == Names.Set$ && fromType.name == Names.Set$)
+    if (options.invariantSet && toType.name == Names.Set$ && fromType.name == Names.Set$)
       return toType.params == fromType.params
 
     // SObject narrowing is supported on List & Set but not Map

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/AssignableSupport.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/AssignableSupport.scala
@@ -152,6 +152,9 @@ object AssignableSupport {
     fromType: TypeName,
     context: VerifyContext
   ): Boolean = {
+    if (toType.name == Names.Set$ && fromType.name == Names.Set$)
+      return toType.params == fromType.params
+
     // SObject narrowing is supported on List & Set but not Map
     checkGenericParameterAssignability(
       toType.params,

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/AssignableSupport.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/AssignableSupport.scala
@@ -24,6 +24,7 @@ object AssignableSupport {
   /** Options for determining assignability
     * @param strictConversions limit implicit type conversions
     * @param narrowSObjects narrowing of SObject conversions, i.e. SObject cast to Account
+    * @param invariantSet require identical Set type parameters
     */
   case class AssignableOptions(
     strictConversions: Boolean,
@@ -37,6 +38,9 @@ object AssignableSupport {
     val default: AssignableOptions =
       AssignableOptions(strictConversions = false, narrowSObjects = true)
 
+    /** Options for assignment and return validation, where Apex treats Set type parameters as
+      * invariant.
+      */
     val assignment: AssignableOptions =
       AssignableOptions(strictConversions = false, narrowSObjects = true, invariantSet = true)
   }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/ConstructorMap.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/ConstructorMap.scala
@@ -5,6 +5,7 @@
 package com.nawforce.apexlink.cst
 import com.nawforce.apexlink.cst.AssignableSupport.{AssignableOptions, isAssignable}
 import com.nawforce.apexlink.names.TypeNames
+import com.nawforce.apexlink.names.TypeNames.TypeNameUtils
 import com.nawforce.apexlink.types.apex.{ApexClassDeclaration, ApexConstructorLike, ApexDeclaration}
 import com.nawforce.apexlink.types.core.{ConstructorDeclaration, TypeDeclaration}
 import com.nawforce.apexlink.types.synthetic.{
@@ -38,9 +39,26 @@ final case class ConstructorMap(
     params: ArraySeq[TypeName],
     context: VerifyContext
   ): Either[String, ConstructorDeclaration] = {
+    if (!hasCompatibleCollectionInitializer(params))
+      return Left(s"Constructor not defined: ${getConstructorString(params)}")
+
     constructorsByParam.get(params.length) match {
       case Some(potential) => findPotentialMatch(potential, params, context)
       case None            => Left(s"No constructor defined with ${params.length} arguments")
+    }
+  }
+
+  private def hasCompatibleCollectionInitializer(params: ArraySeq[TypeName]): Boolean = {
+    val createdElement = typeName.flatMap(_.getSetOrListType)
+    val sourceElement  = params.headOption.flatMap(_.getSetOrListType)
+    params.length != 1 || createdElement.isEmpty || sourceElement.isEmpty ||
+    createdElement == sourceElement
+  }
+
+  private def getConstructorString(params: ArraySeq[TypeName]): String = {
+    typeName match {
+      case Some(name) => s"$name.<constructor>(${params.mkString(",")})"
+      case None       => s"<constructor>(${params.mkString(",")})"
     }
   }
 
@@ -49,14 +67,6 @@ final case class ConstructorMap(
     params: ArraySeq[TypeName],
     context: VerifyContext
   ): Either[String, ConstructorDeclaration] = {
-    def getCtorString: String = {
-      typeName match {
-        case Some(name) =>
-          s"$name.<constructor>(${params.mkString(",")})"
-        case None => s"<constructor>(${params.mkString(",")})"
-      }
-    }
-
     val potential = findMostSpecificMatch(strict = true, matches, params, context)
       .orElse(findMostSpecificMatch(strict = false, matches, params, context))
 
@@ -68,11 +78,11 @@ final case class ConstructorMap(
           // Check the rest of assignable for accessible ctors, if not return the original error
           findPotentialMatch(matches.filterNot(_ == ctor), params, context) match {
             case Right(ctor) => Right(ctor)
-            case _           => Left(s"Constructor is not visible: $getCtorString")
+            case _           => Left(s"Constructor is not visible: ${getConstructorString(params)}")
           }
         }
-      case Some(Left(error)) => Left(s"$error: $getCtorString")
-      case None              => Left(s"Constructor not defined: $getCtorString")
+      case Some(Left(error)) => Left(s"$error: ${getConstructorString(params)}")
+      case None              => Left(s"Constructor not defined: ${getConstructorString(params)}")
     }
   }
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/ConstructorMap.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/ConstructorMap.scala
@@ -39,7 +39,7 @@ final case class ConstructorMap(
     params: ArraySeq[TypeName],
     context: VerifyContext
   ): Either[String, ConstructorDeclaration] = {
-    if (!hasCompatibleCollectionInitializer(params))
+    if (hasMismatchedCollectionInitializer(params))
       return Left(s"Constructor not defined: ${getConstructorString(params)}")
 
     constructorsByParam.get(params.length) match {
@@ -48,11 +48,11 @@ final case class ConstructorMap(
     }
   }
 
-  private def hasCompatibleCollectionInitializer(params: ArraySeq[TypeName]): Boolean = {
+  private def hasMismatchedCollectionInitializer(params: ArraySeq[TypeName]): Boolean = {
     val createdElement = typeName.flatMap(_.getSetOrListType)
     val sourceElement  = params.headOption.flatMap(_.getSetOrListType)
-    params.length != 1 || createdElement.isEmpty || sourceElement.isEmpty ||
-    createdElement == sourceElement
+    params.length == 1 && createdElement.nonEmpty && sourceElement.nonEmpty &&
+    createdElement != sourceElement
   }
 
   private def getConstructorString(params: ArraySeq[TypeName]): String = {

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Operations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Operations.scala
@@ -14,7 +14,11 @@
 
 package com.nawforce.apexlink.cst
 
-import com.nawforce.apexlink.cst.AssignableSupport.{couldBeEqual, isAssignableDeclaration}
+import com.nawforce.apexlink.cst.AssignableSupport.{
+  AssignableOptions,
+  couldBeEqual,
+  isAssignableDeclaration
+}
 import com.nawforce.apexlink.names.TypeNames
 import com.nawforce.apexlink.types.core.TypeDeclaration
 import com.nawforce.apexlink.types.platform.PlatformTypes
@@ -238,7 +242,12 @@ case object AssignmentOperation extends Operation {
     if (rightContext.typeName == TypeNames.Null) {
       Right(leftContext)
     } else if (
-      isAssignableDeclaration(leftContext.typeName, rightContext.typeDeclaration, context)
+      isAssignableDeclaration(
+        leftContext.typeName,
+        rightContext.typeDeclaration,
+        context,
+        AssignableOptions.assignment
+      )
     ) {
       Right(leftContext)
     } else {

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
@@ -15,7 +15,7 @@
 package com.nawforce.apexlink.cst
 
 import io.github.apexdevtools.types.base.{Location => OPLocation}
-import com.nawforce.apexlink.cst.AssignableSupport.isAssignableDeclaration
+import com.nawforce.apexlink.cst.AssignableSupport.{AssignableOptions, isAssignableDeclaration}
 import com.nawforce.apexlink.cst.stmts._
 import com.nawforce.apexlink.names.TypeNames
 import com.nawforce.apexlink.names.TypeNames.TypeNameUtils
@@ -658,7 +658,14 @@ final case class ReturnStatement(expression: Option[Expression]) extends Stateme
       Some(s"Void method can not return a value")
     } else {
       expr.flatMap(e => {
-        if (e.isDefined && !isAssignableDeclaration(expectedType, e.typeDeclaration, context))
+        if (
+          e.isDefined && !isAssignableDeclaration(
+            expectedType,
+            e.typeDeclaration,
+            context,
+            AssignableOptions.assignment
+          )
+        )
           Some(s"Incompatible return type, '${e.typeName}' is not assignable to '$expectedType'")
         else
           None

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Variables.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Variables.scala
@@ -14,7 +14,7 @@
 
 package com.nawforce.apexlink.cst
 
-import com.nawforce.apexlink.cst.AssignableSupport.isAssignableDeclaration
+import com.nawforce.apexlink.cst.AssignableSupport.{AssignableOptions, isAssignableDeclaration}
 import com.nawforce.apexlink.org.Referenceable
 import com.nawforce.pkgforce.diagnostics.{Diagnostic, ERROR_CATEGORY, Issue, WARNING_CATEGORY}
 import com.nawforce.pkgforce.modifiers.{ApexModifiers, FINAL_MODIFIER, ModifierResults}
@@ -47,7 +47,14 @@ final case class VariableDeclarator(
               location,
               s"Expecting instance for operation, not type '${rhsCtx.typeName}'"
             )
-          } else if (!isAssignableDeclaration(lhsType.typeName, rhsCtx.typeDeclaration, context)) {
+          } else if (
+            !isAssignableDeclaration(
+              lhsType.typeName,
+              rhsCtx.typeDeclaration,
+              context,
+              AssignableOptions.assignment
+            )
+          ) {
             context.log(
               Issue(
                 ERROR_CATEGORY,

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/CreationTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/CreationTest.scala
@@ -194,6 +194,12 @@ class CreationTest extends AnyFunSuite with TestHelper {
     )
   }
 
+  test("Set equals accepts same element type") {
+    happyTypeDeclaration(
+      "public class Dummy {{Boolean value = new Set<Id>().equals(new Set<Id>());}}"
+    )
+  }
+
   test("List with map constructor") {
     typeDeclaration("public class Dummy {{Object a = new List<Address>{1 => 2};}}")
     assert(

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/CreationTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/CreationTest.scala
@@ -128,6 +128,72 @@ class CreationTest extends AnyFunSuite with TestHelper {
     assert(dummyIssues.isEmpty)
   }
 
+  test("List Id constructor assigned to List Object") {
+    happyTypeDeclaration(
+      "public class Dummy {{Set<Id> ids = new Set<Id>(); List<Object> value = new List<Id>(ids);}}"
+    )
+  }
+
+  test("Set Id constructor rejected when assigned to Set Object") {
+    typeDeclaration(
+      "public class Dummy {{Set<Id> ids = new Set<Id>(); Set<Object> value = new Set<Id>(ids);}}"
+    )
+    assert(
+      dummyIssues.contains(
+        "Incompatible types in assignment, from 'System.Set<System.Id>' to 'System.Set<Object>'"
+      )
+    )
+  }
+
+  test("Set Object constructor rejects Set Id initializer") {
+    typeDeclaration(
+      "public class Dummy {{Set<Id> ids = new Set<Id>(); Set<Object> value = new Set<Object>(ids);}}"
+    )
+    assert(
+      dummyIssues.contains(
+        "Constructor not defined: System.Set<Object>.<constructor>(System.Set<System.Id>)"
+      )
+    )
+  }
+
+  test("List Object constructor rejects Set Id initializer") {
+    typeDeclaration(
+      "public class Dummy {{Set<Id> ids = new Set<Id>(); List<Object> value = new List<Object>(ids);}}"
+    )
+    assert(
+      dummyIssues.contains(
+        "Constructor not defined: System.List<Object>.<constructor>(System.Set<System.Id>)"
+      )
+    )
+  }
+
+  test("Set Id constructor accepts Set Id initializer") {
+    happyTypeDeclaration(
+      "public class Dummy {{Set<Id> ids = new Set<Id>(); Set<Id> value = new Set<Id>(ids);}}"
+    )
+  }
+
+  test("Set Id rejected when directly assigned to Set Object") {
+    typeDeclaration("public class Dummy {{Set<Id> ids = new Set<Id>(); Set<Object> value = ids;}}")
+    assert(
+      dummyIssues.contains(
+        "Incompatible types in assignment, from 'System.Set<System.Id>' to 'System.Set<Object>'"
+      )
+    )
+  }
+
+  test("List Id accepted when directly assigned to List Object") {
+    happyTypeDeclaration(
+      "public class Dummy {{List<Id> ids = new List<Id>(); List<Object> value = ids;}}"
+    )
+  }
+
+  test("List Id constructor accepts Set Id initializer") {
+    happyTypeDeclaration(
+      "public class Dummy {{Set<Id> ids = new Set<Id>(); List<Id> value = new List<Id>(ids);}}"
+    )
+  }
+
   test("List with map constructor") {
     typeDeclaration("public class Dummy {{Object a = new List<Address>{1 => 2};}}")
     assert(


### PR DESCRIPTION
## Summary

- make `Set` generic assignments invariant, rejecting `Set<Id>` to `Set<Object>` while retaining `List` covariance
- require List/Set copy constructors to use the constructor's exact element type
- add regression coverage for the complete eight-case platform validation matrix
- document the user-facing validation fix in the changelog

## Root cause

Generic collection parameters shared one covariant assignability path. This incorrectly treated Set assignment and collection-copy constructor element types like List assignment, despite the Apex platform applying different rules.

## User impact

apex-ls now reports invalid Set assignments and mismatched List/Set constructor initializers consistently with the platform, without flagging the accepted List covariance and matching-element cases.

Fixes #318.

## Validation

- `sbt scalafmtAll`
- `sbt 'apexlsJVM/testOnly com.nawforce.apexlink.cst.CreationTest'` (45 passed)
- `sbt test` (2,492 JVM tests and 377 JS/shared tests passed)
