### PR TITLE
docs: clarify package-directory handling differs from Salesforce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Documentation and clarified diagnostics for the deliberate difference between apex-ls package-directory handling and Salesforce's merged deployment behaviour (#339)
 - `dependencyCountAliases` `sfdx-project.json` option to define named (and optionally nested) presets for `// MaxDependencyCount(...)`, so `// MaxDependencyCount(med)` or `// MaxDependencyCount(group.name)` can be used instead of repeating raw numbers across files (#324)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The following arguments are available:
 
 The Apex Language Server can be configured through the `sfdx-project.json` file. There are two supported configuration styles:
 
+See [Differences From Salesforce Behaviour](doc/SalesforceDifferences.md) for details of how package directories are processed.
+
 #### Recommended: Namespaced Configuration
 
 The recommended approach is to configure apex-ls settings under the `plugins.apex-ls` section:

--- a/doc/SalesforceDifferences.md
+++ b/doc/SalesforceDifferences.md
@@ -1,0 +1,32 @@
+# Differences From Salesforce Behaviour
+
+This page records deliberate, known differences between how a project is
+analysed and how the Salesforce platform behaves at deploy or runtime. These
+are intentional design decisions, not defects; they are documented here so the
+behaviour is not mistakenly "corrected", and so a diagnostic that differs from a
+successful platform deploy can be understood.
+
+## Package Directories
+
+Each package directory listed in `sfdx-project.json` is treated as an
+independent, ordered layer. An object's fields are resolved from the directory
+that defines the object together with any earlier directories: a directory may
+extend an object defined in an earlier directory, but a fields-only fragment
+appearing before the directory that defines the object is not resolved (its
+fields are reported as unknown). Where the same object or field is defined in
+more than one directory, the last definition is used.
+
+Salesforce instead composes metadata across all package directories into a
+single deploy, merging field contributions regardless of directory order. That
+change removed a previously useful ability to split metadata across directories
+as separate deploys to work around the 10,000 component limit of a single
+Metadata API deploy. That composition is deliberately not emulated; each
+package directory is treated as if it were deployed independently and in order.
+
+Practical consequences:
+- Define an object before extending it: the directory containing the object's
+  `.object-meta.xml` must be listed before any directory that only adds fields.
+- Re-defining an object in a later directory replaces the earlier definition
+  (last wins) and produces a warning.
+
+Related issue: #339.

--- a/js/npm/snapshots/system/SampleCheckSys.ts.snap
+++ b/js/npm/snapshots/system/SampleCheckSys.ts.snap
@@ -389,11 +389,11 @@ exports[`Check samples Sample: Apex-Opensource-Library 1`] = `
     ],
     [
       "force-app/commons/httpMocks/objects/HttpCalloutMockVariable__mdt/HttpCalloutMockVariable__mdt.object-meta.xml",
-      "Warning: line 1: SObject appears to be re-defining an SObject that already exists 'HttpCalloutMockVariable__mdt', remove the 'label' field if it is extending the SObject",
+      "Warning: line 1: SObject appears to be re-defining an SObject that already exists 'HttpCalloutMockVariable__mdt'. Package directories are processed independently and the last definition is used; Salesforce instead merges package directory metadata on deploy. Remove the 'label' field if this is intended to extend the SObject",
     ],
     [
       "force-app/commons/httpMocks/objects/HttpCalloutMock__mdt/HttpCalloutMock__mdt.object-meta.xml",
-      "Warning: line 1: SObject appears to be re-defining an SObject that already exists 'HttpCalloutMock__mdt', remove the 'label' field if it is extending the SObject",
+      "Warning: line 1: SObject appears to be re-defining an SObject that already exists 'HttpCalloutMock__mdt'. Package directories are processed independently and the last definition is used; Salesforce instead merges package directory metadata on deploy. Remove the 'label' field if this is intended to extend the SObject",
     ],
     [
       "force-app/commons/localization/Localization.cls",
@@ -688,7 +688,7 @@ exports[`Check samples Sample: Apex-Opensource-Library 1`] = `
     ],
     [
       "force-app/commons/query/cache/objects/QueryCache__mdt/QueryCache__mdt.object-meta.xml",
-      "Warning: line 1: SObject appears to be re-defining an SObject that already exists 'QueryCache__mdt', remove the 'label' field if it is extending the SObject",
+      "Warning: line 1: SObject appears to be re-defining an SObject that already exists 'QueryCache__mdt'. Package directories are processed independently and the last definition is used; Salesforce instead merges package directory metadata on deploy. Remove the 'label' field if this is intended to extend the SObject",
     ],
     [
       "force-app/commons/schema/CustomMetadataService.cls",
@@ -791,7 +791,7 @@ exports[`Check samples Sample: Apex-Opensource-Library 1`] = `
     ],
     [
       "force-app/commons/triggerHandler/objects/LogicSwitch__c/LogicSwitch__c.object-meta.xml",
-      "Warning: line 1: SObject appears to be re-defining an SObject that already exists 'LogicSwitch__c', remove the 'label' field if it is extending the SObject",
+      "Warning: line 1: SObject appears to be re-defining an SObject that already exists 'LogicSwitch__c'. Package directories are processed independently and the last definition is used; Salesforce instead merges package directory metadata on deploy. Remove the 'label' field if this is intended to extend the SObject",
     ],
     [
       "force-app/commons/triggerHandlerMdt/classes/MetadataTriggerHandlerTest.cls",
@@ -803,7 +803,7 @@ exports[`Check samples Sample: Apex-Opensource-Library 1`] = `
     ],
     [
       "force-app/commons/triggerHandlerMdt/objects/TriggerLogic__mdt/TriggerLogic__mdt.object-meta.xml",
-      "Warning: line 1: SObject appears to be re-defining an SObject that already exists 'TriggerLogic__mdt', remove the 'label' field if it is extending the SObject",
+      "Warning: line 1: SObject appears to be re-defining an SObject that already exists 'TriggerLogic__mdt'. Package directories are processed independently and the last definition is used; Salesforce instead merges package directory metadata on deploy. Remove the 'label' field if this is intended to extend the SObject",
     ],
     [
       "force-app/commons/xml/XmlParser.cls",
@@ -14736,7 +14736,7 @@ exports[`Check samples Sample: MyTriggers 1`] = `
     ],
     [
       "MyTriggers/framework/objects/MyTriggerSetting__mdt/MyTriggerSetting__mdt.object-meta.xml",
-      "Warning: line 1: SObject appears to be re-defining an SObject that already exists 'MyTriggerSetting__mdt', remove the 'label' field if it is extending the SObject",
+      "Warning: line 1: SObject appears to be re-defining an SObject that already exists 'MyTriggerSetting__mdt'. Package directories are processed independently and the last definition is used; Salesforce instead merges package directory metadata on deploy. Remove the 'label' field if this is intended to extend the SObject",
     ],
   ],
   "status": 7,

--- a/jvm/src/main/scala/com/nawforce/apexlink/diagnostics/IssueOps.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/diagnostics/IssueOps.scala
@@ -124,7 +124,7 @@ object IssueOps {
       Diagnostic(
         ERROR_CATEGORY,
         location.location,
-        s"SObject appears to be extending an unknown SObject, '$name'"
+        s"SObject appears to be extending an unknown SObject, '$name'. The defining metadata must appear in an earlier package directory; package directories are processed in order rather than being merged on deploy as they are by Salesforce"
       )
     )
   }
@@ -151,7 +151,7 @@ object IssueOps {
       Diagnostic(
         WARNING_CATEGORY,
         location.location,
-        s"SObject appears to be re-defining an SObject that already exists '$name', remove the 'label' field if it is extending the SObject"
+        s"SObject appears to be re-defining an SObject that already exists '$name'. Package directories are processed independently and the last definition is used; Salesforce instead merges package directory metadata on deploy. Remove the 'label' field if this is intended to extend the SObject"
       )
     )
   }

--- a/jvm/src/test/scala/com/nawforce/apexlink/pkg/RefreshSObjectTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/pkg/RefreshSObjectTest.scala
@@ -313,7 +313,7 @@ class RefreshSObjectTest extends AnyFunSuite with TestHelper {
         org.unmanaged.refresh(basePath, highPriority = false)
         assert(org.flush())
         assert(
-          getMessages() == path"/ext/objects/Foo__c.object: Error: line 1: SObject appears to be extending an unknown SObject, 'Foo__c'" + "\n"
+          getMessages() == path"/ext/objects/Foo__c.object: Error: line 1: SObject appears to be extending an unknown SObject, 'Foo__c'. The defining metadata must appear in an earlier package directory; package directories are processed in order rather than being merged on deploy as they are by Salesforce" + "\n"
         )
       }
     }
@@ -338,7 +338,7 @@ class RefreshSObjectTest extends AnyFunSuite with TestHelper {
         org.unmanaged.refresh(basePath, highPriority = false)
         assert(org.flush())
         assert(
-          getMessages() == path"/ext/objects/Foo__c/fields/Baz__c.field-meta.xml: Error: line 1: SObject appears to be extending an unknown SObject, 'Foo__c'" + "\n"
+          getMessages() == path"/ext/objects/Foo__c/fields/Baz__c.field-meta.xml: Error: line 1: SObject appears to be extending an unknown SObject, 'Foo__c'. The defining metadata must appear in an earlier package directory; package directories are processed in order rather than being merged on deploy as they are by Salesforce" + "\n"
         )
       }
     }


### PR DESCRIPTION
## Summary

- clarify diagnostics for ordered, independent package-directory processing
- document the deliberate difference from Salesforce merged deployment behaviour
- link the new documentation from the README

Closes #339.

## Tests

- `sbt scalafmtAll`
- `sbt test`