### PR TITLE
chore: standardize JDK 17 toolchain

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "17"

--- a/.github/workflows/BuildCrossPlatform.yml
+++ b/.github/workflows/BuildCrossPlatform.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: ${{ matrix.java_version }}

--- a/.github/workflows/BuildWin.yml
+++ b/.github/workflows/BuildWin.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: 8

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history/tags
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "17"

--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "17"

--- a/build.sbt
+++ b/build.sbt
@@ -23,9 +23,6 @@ ThisBuild / versionScheme          := Some("strict")
 ThisBuild / resolvers += Resolver.mavenLocal
 ThisBuild / resolvers += Resolver.sonatypeCentralSnapshots
 
-// Java 17 development with Java 8 runtime compatibility
-ThisBuild / javacOptions ++= Seq("-source", "8", "-target", "8")
-
 lazy val build      = taskKey[File]("Build artifacts")
 lazy val pack       = inputKey[Unit]("Publish specific local version")
 lazy val npmInstall = taskKey[Unit]("Install Node modules for Scala.js tasks")
@@ -55,6 +52,8 @@ lazy val apexls = crossProject(JSPlatform, JVMPlatform)
     )
   )
   .jvmSettings(
+    javacOptions ++= Seq("--release", "8"),
+    scalacOptions ++= Seq("-release", "8"),
     build       := buildJVM.value,
     Test / fork := true,
     Test / javaOptions ++= enableNativeAccessForJdk24Plus.value,


### PR DESCRIPTION
## Summary

- update every `actions/setup-java` use from v4 to v5 while preserving the deliberate Java 8 Windows check and Java 8/11/17 cross-platform matrix
- replace JVM `javac -source 8 -target 8` with `javac --release 8`
- add Scala 2.13 `-release 8` to the JVM project only, leaving Scala.js compiler settings unchanged

This keeps CI builds and publishing on JDK 17 while enforcing Java 8 platform API and bytecode compatibility for JVM artifacts.

No changelog entry is included because this changes build/CI enforcement and not user-facing behavior.

## Validation

Using JDK 17.0.20:

- `sbt build`
- `sbt test`
- `SAMPLES=/Users/kevinjones/adt/apex-samples npm run test-samples -- --silent` (pinned clean checkout at v1.4.0)
- inspected all 1,643 emitted production JVM class files: every class has major version 52

The sample test passed. Its normal non-silent run warned when optional temporary `sfdx-project.json` files could not be created in the intentionally read-only sample checkout; the checkout remained clean and detached at v1.4.0.
