### PR TITLE
Validate duplicate annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Duplicate annotations on declarations are now reported as errors, including annotations with different or unrecognized arguments (#287)
 - Set assignments and List/Set constructor initializers now enforce the platform's collection element-type compatibility rules (#318)
 - Classes implementing an interface method whose parameter or return type is a ghosted (unavailable dependency package) type no longer report a false `Non-abstract class must implement method` diagnostic when the implementation uses a different, project-local type (#327)
 - `addAll`/`removeAll`/`retainAll` on `List`/`Set` (e.g. `Set<Id>.addAll(List<String>)`, such as the result of `String.split`) now require the collection argument's type parameter to exactly match, requiring an explicit cast, matching the Apex compiler; the sole exception, `List<T>.addAll(List<T>)`, is unaffected (#293)

--- a/jvm/src/main/scala/com/nawforce/pkgforce/modifiers/FieldModifiers.scala
+++ b/jvm/src/main/scala/com/nawforce/pkgforce/modifiers/FieldModifiers.scala
@@ -51,7 +51,7 @@ object FieldModifiers {
     idContext: IdContext
   ): ModifierResults = {
     val logger = new ModifierLogger()
-    val mods   = toModifiers(parser, modifierContexts)
+    val mods   = toModifiers(parser, modifierContexts, logger)
     fieldModifiers(logger, mods, outer, LogEntryContext(parser, idContext))
   }
 

--- a/jvm/src/main/scala/com/nawforce/pkgforce/modifiers/MethodModifiers.scala
+++ b/jvm/src/main/scala/com/nawforce/pkgforce/modifiers/MethodModifiers.scala
@@ -78,7 +78,7 @@ object MethodModifiers {
   ): ModifierResults = {
 
     val logger = new ModifierLogger()
-    val mods   = toModifiers(parser, modifierContexts)
+    val mods   = toModifiers(parser, modifierContexts, logger)
     classMethodModifiers(logger, mods, LogEntryContext(parser, context), ownerInfo, isOuter)
   }
 
@@ -227,7 +227,7 @@ object MethodModifiers {
     ownerInfo: InterfaceOwnerInfo
   ): ModifierResults = {
     val logger = new ModifierLogger()
-    val mods   = toModifiers(parser, modifierContexts)
+    val mods   = toModifiers(parser, modifierContexts, logger)
     interfaceMethodModifiers(logger, mods, LogEntryContext(parser, context), ownerInfo)
   }
 

--- a/jvm/src/main/scala/com/nawforce/pkgforce/modifiers/Modifier.scala
+++ b/jvm/src/main/scala/com/nawforce/pkgforce/modifiers/Modifier.scala
@@ -272,10 +272,21 @@ object ApexModifiers {
 
   def toModifiers(
     parser: CodeParser,
-    modifierContexts: ArraySeq[ModifierContext]
+    modifierContexts: ArraySeq[ModifierContext],
+    logger: ModifierLogger
   ): ArraySeq[(Modifier, LogEntryContext, String)] = {
 
-    modifierContexts.flatMap(modifierContext => {
+    validateDuplicateAnnotations(
+      modifierContexts
+        .flatMap(modifierContext =>
+          Option(modifierContext.annotation()).map(annotation =>
+            (annotation.qualifiedName().getText, LogEntryContext(parser, modifierContext))
+          )
+        ),
+      logger
+    )
+
+    val modifiers = modifierContexts.flatMap(modifierContext => {
       val annotation = Option(modifierContext.annotation())
       val modifiers =
         annotation
@@ -299,6 +310,31 @@ object ApexModifiers {
         )
       )
     })
+
+    deduplicateAnnotationModifiers(modifiers)
+  }
+
+  private[nawforce] def validateDuplicateAnnotations(
+    annotations: ArraySeq[(String, LogEntryContext)],
+    logger: ModifierLogger
+  ): Unit = {
+    annotations
+      .duplicates(_._1.toLowerCase)
+      .headOption
+      .foreach { case ((name, context), _) =>
+        logger.logError(context, s"Duplicate modifier: $name")
+      }
+  }
+
+  private[nawforce] def deduplicateAnnotationModifiers(
+    modifiers: ArraySeq[(Modifier, LogEntryContext, String)]
+  ): ArraySeq[(Modifier, LogEntryContext, String)] = {
+    modifiers.foldLeft(ArraySeq.empty[(Modifier, LogEntryContext, String)]) {
+      case (result, (value, _, "Annotation"))
+          if result.exists(existing => existing._1 == value && existing._3 == "Annotation") =>
+        result
+      case (result, modifier) => result :+ modifier
+    }
   }
 
   def allowableModifiers(
@@ -378,7 +414,7 @@ object ApexModifiers {
     idContext: IdContext
   ): ModifierResults = {
     val logger = new ModifierLogger()
-    val mods   = toModifiers(parser, modifierContexts)
+    val mods   = toModifiers(parser, modifierContexts, logger)
     classModifiers(logger, mods, outer, LogEntryContext(parser, idContext))
   }
 
@@ -439,7 +475,7 @@ object ApexModifiers {
   ): ModifierResults = {
 
     val logger = new ModifierLogger()
-    val mods   = toModifiers(parser, modifierContexts)
+    val mods   = toModifiers(parser, modifierContexts, logger)
     interfaceModifiers(logger, mods, outer, LogEntryContext(parser, idContext))
   }
 
@@ -488,7 +524,7 @@ object ApexModifiers {
   ): ModifierResults = {
 
     val logger = new ModifierLogger()
-    val mods   = toModifiers(parser, modifierContexts)
+    val mods   = toModifiers(parser, modifierContexts, logger)
     enumModifiers(logger, mods, outer, LogEntryContext(parser, idContext))
   }
 
@@ -535,7 +571,7 @@ object ApexModifiers {
 
     val logger = new ModifierLogger()
 
-    val modifiers = toModifiers(parser, modifierContexts)
+    val modifiers = toModifiers(parser, modifierContexts, logger)
     val allowedModifiers =
       allowableModifiers(modifiers, visibilityModifiers.toSet, "property set/get", logger)
 
@@ -556,7 +592,7 @@ object ApexModifiers {
     context: ParserRuleContext
   ): ModifierResults = {
     val logger = new ModifierLogger()
-    val mods   = toModifiers(parser, modifierContexts)
+    val mods   = toModifiers(parser, modifierContexts, logger)
     constructorModifiers(logger, mods, LogEntryContext(parser, context))
   }
 
@@ -592,7 +628,7 @@ object ApexModifiers {
     context: ParserRuleContext
   ): ModifierResults = {
     val logger = new ModifierLogger()
-    val mods   = toModifiers(parser, modifierContexts)
+    val mods   = toModifiers(parser, modifierContexts, logger)
     parameterModifiers(logger, mods, LogEntryContext(parser, context))
   }
 
@@ -623,7 +659,7 @@ object ApexModifiers {
 
     val logger = new ModifierLogger()
 
-    val modifiers = toModifiers(parser, modifierContexts)
+    val modifiers = toModifiers(parser, modifierContexts, logger)
 
     val allowedModifiers =
       allowableModifiers(modifiers, legalCatchModifiersAndAnnotations, "catch variables", logger)
@@ -649,7 +685,7 @@ object ApexModifiers {
 
     val logger = new ModifierLogger()
 
-    val modifiers = toModifiers(parser, modifierContexts)
+    val modifiers = toModifiers(parser, modifierContexts, logger)
 
     val allowedModifiers =
       allowableModifiers(

--- a/jvm/src/main/scala/com/nawforce/runtime/platform/OutlineParserModifierOps.scala
+++ b/jvm/src/main/scala/com/nawforce/runtime/platform/OutlineParserModifierOps.scala
@@ -19,7 +19,8 @@ object OutlineParserModifierOps {
     path: PathLike,
     declarationLocation: OPLocation,
     annotations: Array[OPAnnotation],
-    src: Array[OPModifier]
+    src: Array[OPModifier],
+    logger: ModifierLogger
   ): ArraySeq[(Modifier, LogEntryContext, String)] = {
 
     def normaliseModifierLocation(modifier: OPModifier): OPLocation = {
@@ -29,6 +30,13 @@ object OutlineParserModifierOps {
     def normaliseAnnotationLocation(annotation: OPAnnotation): OPLocation = {
       annotation.location.getOrElse(declarationLocation)
     }
+
+    val annotationContexts = ArraySeq.from(
+      annotations.map(annotation =>
+        (annotation.name, OPLogEntryContext(path, normaliseAnnotationLocation(annotation)))
+      )
+    )
+    ApexModifiers.validateDuplicateAnnotations(annotationContexts, logger)
 
     val modifiers = {
       annotations.flatMap(opA =>
@@ -41,7 +49,7 @@ object OutlineParserModifierOps {
         )
     }
 
-    ArraySeq.from(modifiers)
+    ApexModifiers.deduplicateAnnotationModifiers(ArraySeq.from(modifiers))
   }
 
   def fieldModifiers(
@@ -52,7 +60,7 @@ object OutlineParserModifierOps {
     outer: Boolean
   ): ModifierResults = {
     val logger = new ModifierLogger()
-    val mods   = toModifiers(path, id.location, annotations, src)
+    val mods   = toModifiers(path, id.location, annotations, src, logger)
     FieldModifiers.fieldModifiers(logger, mods, outer, OPLogEntryContext(path, id.location))
   }
 
@@ -66,7 +74,7 @@ object OutlineParserModifierOps {
   ): ModifierResults = {
 
     val logger = new ModifierLogger()
-    val mods   = toModifiers(path, declarationLocation, annotations, src)
+    val mods   = toModifiers(path, declarationLocation, annotations, src, logger)
     ApexModifiers.classModifiers(logger, mods, outer, OPLogEntryContext(path, id.location))
   }
 
@@ -80,7 +88,7 @@ object OutlineParserModifierOps {
   ): ModifierResults = {
 
     val logger = new ModifierLogger()
-    val mods   = toModifiers(path, declarationLocation, annotations, src)
+    val mods   = toModifiers(path, declarationLocation, annotations, src, logger)
     ApexModifiers.interfaceModifiers(logger, mods, outer, OPLogEntryContext(path, id.location))
   }
 
@@ -94,7 +102,7 @@ object OutlineParserModifierOps {
   ): ModifierResults = {
 
     val logger = new ModifierLogger()
-    val mods   = toModifiers(path, declarationLocation, annotations, src)
+    val mods   = toModifiers(path, declarationLocation, annotations, src, logger)
     ApexModifiers.enumModifiers(logger, mods, outer, OPLogEntryContext(path, id.location))
   }
 
@@ -105,7 +113,7 @@ object OutlineParserModifierOps {
     src: Array[OPModifier]
   ): ModifierResults = {
     val logger = new ModifierLogger()
-    val mods   = toModifiers(path, id.location, annotations, src)
+    val mods   = toModifiers(path, id.location, annotations, src, logger)
     ApexModifiers.constructorModifiers(logger, mods, OPLogEntryContext(path, id.location))
   }
 
@@ -117,7 +125,7 @@ object OutlineParserModifierOps {
   ): ModifierResults = {
 
     val logger = new ModifierLogger()
-    val mods   = toModifiers(path, idLocation, annotations, src)
+    val mods   = toModifiers(path, idLocation, annotations, src, logger)
     ApexModifiers.parameterModifiers(logger, mods, OPLogEntryContext(path, idLocation))
   }
 
@@ -131,7 +139,7 @@ object OutlineParserModifierOps {
   ): ModifierResults = {
 
     val logger = new ModifierLogger()
-    val mods   = toModifiers(path, id.location, annotations, src)
+    val mods   = toModifiers(path, id.location, annotations, src, logger)
 
     MethodModifiers.classMethodModifiers(
       logger,
@@ -150,7 +158,7 @@ object OutlineParserModifierOps {
     ownerInfo: InterfaceOwnerInfo
   ): ModifierResults = {
     val logger = new ModifierLogger()
-    val mods   = toModifiers(path, id.location, annotations, src)
+    val mods   = toModifiers(path, id.location, annotations, src, logger)
     MethodModifiers.interfaceMethodModifiers(
       logger,
       mods,

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/PropertyTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/PropertyTest.scala
@@ -360,7 +360,7 @@ class PropertyTest extends AnyFunSuite with TestHelper {
     assert(property.writeAccess == property.readAccess)
     assert(
       dummyIssues ==
-        "Error: line 1 at 53-56: Modifier '@TestVisible' is used more than once\n"
+        "Error: line 1 at 20-32: Duplicate modifier: TestVisible\n"
     )
   }
 }

--- a/jvm/src/test/scala/com/nawforce/pkgforce/modifiers/ClassModifierTest.scala
+++ b/jvm/src/test/scala/com/nawforce/pkgforce/modifiers/ClassModifierTest.scala
@@ -25,6 +25,17 @@ import scala.collection.compat.immutable.ArraySeq
 
 class ClassModifierTest extends AnyFunSuite {
 
+  private def classIssues(source: String): ArraySeq[Issue] = {
+    val path   = Path("Dummy.cls")
+    val parser = CodeParser(path, SourceData(source))
+    val result = parser.parseClass()
+    if (result.issues.nonEmpty) {
+      result.issues
+    } else {
+      ApexNode(parser, result.value).get.parseIssues
+    }
+  }
+
   def legalClassAccess(use: ArraySeq[Modifier], expected: ArraySeq[Modifier]): Boolean = {
     val modifiers = use.map(_.name).mkString(" ")
     val path      = Path("Dummy.cls")
@@ -109,6 +120,33 @@ class ClassModifierTest extends AnyFunSuite {
 
   test("isTest modifier") {
     assert(legalClassAccess(ArraySeq(ISTEST_ANNOTATION)))
+  }
+
+  test("Duplicate SuppressWarnings annotation with identical arguments") {
+    val issues =
+      classIssues("@SuppressWarnings('PMD') @SuppressWarnings('PMD') public class Dummy {}")
+    assert(issues.map(_.diagnostic.message) == Seq("Duplicate modifier: SuppressWarnings"))
+    assert(issues.forall(_.diagnostic.category == ERROR_CATEGORY))
+  }
+
+  test("Duplicate SuppressWarnings annotation with different arguments") {
+    val issues =
+      classIssues("@SuppressWarnings('PMD') @SuppressWarnings('Unused') public class Dummy {}")
+    assert(issues.map(_.diagnostic.message) == Seq("Duplicate modifier: SuppressWarnings"))
+    assert(issues.forall(_.diagnostic.category == ERROR_CATEGORY))
+  }
+
+  test("Duplicate SuppressWarnings annotation with unrecognized arguments") {
+    val issues =
+      classIssues("@SuppressWarnings('Foo') @SuppressWarnings('Bar') public class Dummy {}")
+    assert(issues.map(_.diagnostic.message) == Seq("Duplicate modifier: SuppressWarnings"))
+    assert(issues.forall(_.diagnostic.category == ERROR_CATEGORY))
+  }
+
+  test("Duplicate TestVisible annotation") {
+    val issues = classIssues("@TestVisible @TestVisible public class Dummy {}")
+    assert(issues.map(_.diagnostic.message) == Seq("Duplicate modifier: TestVisible"))
+    assert(issues.forall(_.diagnostic.category == ERROR_CATEGORY))
   }
 
   test("isTest and IntegrationTest annotations") {


### PR DESCRIPTION
Closes #287

## Summary

- detect duplicate annotations by their case-insensitive annotation name before argument expansion
- apply validation through the shared conversion funnels used by types, methods, fields, properties, constructors, and parameters in both parser-backed and outline-parser-backed declarations
- preserve existing duplicate handling and wording for plain modifiers
- avoid emitting the former second duplicate-modifier diagnostic after the annotation-level error
- add regression coverage for identical, different, and unrecognized `@SuppressWarnings` arguments plus duplicate `@TestVisible`

The new focused cases are exercised on class declarations in `ClassModifierTest`. Other declaration kinds are covered structurally because their modifier entry points all pass through the same updated `toModifiers` implementation; the existing duplicate-property assertion also exercises the property path.

## Diagnostic wording

This uses Salesforce-style `Duplicate modifier: <AnnotationName>` wording. It distinguishes the new annotation-name validation from apex-ls's existing `Modifier '<x>' is used more than once` diagnostic, which remains unchanged for plain modifiers.

The diagnostic now points at the annotation that established the duplicated name. For the existing duplicate-property test this changes the reported span from the property identifier (`53-56`) to the first `@TestVisible` annotation (`20-32`).

## Validation

- `sbt scalafmtAll`
- `sbt 'apexlsJVM/testOnly com.nawforce.pkgforce.modifiers.ClassModifierTest'`
- `sbt apexlsJVM/test` (2,504 tests passed)

All commands ran on JDK 17.
