### PR TITLE
test: cover private access from test classes

### DIFF
--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/FieldTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/FieldTest.scala
@@ -101,6 +101,18 @@ class FieldTest extends AnyFunSuite with TestHelper {
     assert(getMessages(root.join("Dummy.cls")).contains("Field is not visible"))
   }
 
+  test("IsTest class can not read private field without TestVisible") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {private static String f;}",
+        "Dummy.cls" -> "@IsTest public class Dummy {static testMethod void t() {String s = Target.f;}}"
+      )
+    )
+    assert(
+      getMessages(root.join("Dummy.cls")) == "Error: line 1 at 67-75: Field is not visible: f\n"
+    )
+  }
+
   test("Unrelated class can not access protected instance field") {
     typeDeclarations(
       Map(

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodTest.scala
@@ -84,6 +84,44 @@ class MethodTest extends AnyFunSuite with TestHelper {
     assert(getMessages(root.join("Dummy.cls")).contains("Method is not visible"))
   }
 
+  test("IsTest class can not call private instance method without TestVisible") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {private void helper(){}}",
+        "Dummy.cls" -> "@IsTest public class Dummy {static testMethod void t() {Target x = new Target(); x.helper();}}"
+      )
+    )
+    assert(
+      getMessages(
+        root.join("Dummy.cls")
+      ) == "Error: line 1 at 81-91: Method is not visible: helper()\n"
+    )
+  }
+
+  test("IsTest class can not call private static method without TestVisible") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {private static void helper(){}}",
+        "Dummy.cls"  -> "@IsTest public class Dummy {static testMethod void t() {Target.helper();}}"
+      )
+    )
+    assert(
+      getMessages(
+        root.join("Dummy.cls")
+      ) == "Error: line 1 at 56-71: Method is not visible: helper()\n"
+    )
+  }
+
+  test("IsTest class can call private static method with TestVisible") {
+    typeDeclarations(
+      Map(
+        "Target.cls" -> "public class Target {@TestVisible private static void helper(){}}",
+        "Dummy.cls"  -> "@IsTest public class Dummy {static testMethod void t() {Target.helper();}}"
+      )
+    )
+    assert(getMessages(root.join("Dummy.cls")).isEmpty)
+  }
+
   test("Unrelated class can not call protected instance method") {
     typeDeclarations(
       Map(


### PR DESCRIPTION
Closes #332

## Summary
- cover private instance method access from an `@IsTest` class without `@TestVisible`
- cover private static method access with and without `@TestVisible`
- cover private field reads from an `@IsTest` class without `@TestVisible`

## Tests
- `sbt -batch scalafmtCheckAll`
- `sbt -batch "apexlsJVM/testOnly com.nawforce.apexlink.cst.MethodTest com.nawforce.apexlink.cst.FieldTest"`
- `sbt -batch apexlsJVM/test` (2,508 tests passed)

No changelog entry is needed because this PR adds regression coverage only and does not change user-facing behavior.