### PR TITLE
Warn when static methods implement instance contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Warn when a static method is used to implement an interface or inherited abstract method.
+- Warn when implementing an interface or inherited abstract method with a static method could be
+  confusing.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Warn when a static method is used to implement an interface or inherited abstract method.
+
 ### Added
 
 - Documentation and clarified diagnostics for the deliberate difference between apex-ls package-directory handling and Salesforce's merged deployment behaviour (#339)

--- a/js/npm/snapshots/system/SampleCheckSys.ts.snap
+++ b/js/npm/snapshots/system/SampleCheckSys.ts.snap
@@ -3479,6 +3479,8 @@ exports[`Check samples Sample: Cumulus 1`] = `
       "Cumulus/force-app/main/default/classes/OPP_OpportunityNaming.cls",
       "Unused: line 177 at 20-85: Unused local variable 'allFields'",
       "Unused: line 314 at 25-36: Unused public static method 'System.String getConQuery(System.Set<System.String>)'; remove, make private @TestVisible, or add @SuppressWarnings('Unused') with a comment if this is an external entry point",
+      "Warning: line 111 at 36-58: Static method 'System.List<Schema.Opportunity> getOppNamesAfterInsert(System.List<Schema.Opportunity>)' cannot implement method from interface 'npsp.OPP_INaming'; make it an instance method",
+      "Warning: line 65 at 23-38: Static method 'void refreshOppNames(System.List<Schema.Opportunity>)' cannot implement method from interface 'npsp.OPP_INaming'; make it an instance method",
     ],
     [
       "Cumulus/force-app/main/default/classes/OPP_OpportunityNaming_BATCH_TEST.cls",
@@ -4102,6 +4104,7 @@ exports[`Check samples Sample: Cumulus 1`] = `
     [
       "Cumulus/force-app/main/default/classes/UTIL_MasterSchedulable.cls",
       "Unused: line 52 at 12-46: Unused local variable 'instance'",
+      "Warning: line 46 at 23-30: Static method 'void execute(System.SchedulableContext)' cannot implement method from interface 'System.Schedulable'; make it an instance method",
     ],
     [
       "Cumulus/force-app/main/default/classes/UTIL_Namespace.cls",
@@ -4336,6 +4339,7 @@ exports[`Check samples Sample: Cumulus 1`] = `
     [
       "Cumulus/force-app/tdtm/classes/TDTM_ObjectDataGateway.cls",
       "Unused: line 90 at 23-56: Unused public static method 'void ClearCachedTriggerHandlersForTest()'; only referenced by test code, remove, make private @TestVisible, or add @SuppressWarnings('Unused') with a comment if this is an external entry point",
+      "Warning: line 67 at 32-57: Static method 'System.List<System.SObject> getClassesToCallForObject(System.String, npsp.TDTM_Runnable.Action)' cannot implement method from interface 'npsp.TDTM_iTableDataGateway'; make it an instance method",
     ],
     [
       "Cumulus/force-app/tdtm/classes/TDTM_TriggerHandler.cls",
@@ -11883,6 +11887,7 @@ exports[`Check samples Sample: EDA 1`] = `
       "force-app/main/default/classes/EDAHealthCheckGroupAPIService.cls",
       "Unused: line 97 at 36-88: Unused local variable 'hlthChkItemsList'",
       "Unused: line 98 at 21-53: Unused local variable 'rowKeysList'",
+      "Warning: line 52 at 54-65: Static method 'hed.HealthCheckGroupAPIServiceInterface getInstance()' cannot implement method from interface 'hed.HealthCheckGroupAPIServiceInterface'; make it an instance method",
     ],
     [
       "force-app/main/default/classes/ERR_AsyncErrors.cls",
@@ -12332,6 +12337,10 @@ exports[`Check samples Sample: EnhancedLightningGrid 1`] = `
 {
   "logs": [
     [
+      "EnhancedLightningGrid/classes/CustomDataProviderExample.cls",
+      "Warning: line 9 at 28-35: Static method 'SDGResult getData(SDG, SDGRequest)' cannot implement method from interface 'sdgDataProvider'; make it an instance method",
+    ],
+    [
       "EnhancedLightningGrid/classes/SDGField.cls",
       "Unused: line 28 at 105-112: Unused local variable 'canSort'",
       "Unused: line 28 at 137-144: Unused local variable 'options'",
@@ -12352,10 +12361,22 @@ exports[`Check samples Sample: EnhancedLightningGrid 1`] = `
       "EnhancedLightningGrid/classes/sdgDataProviderApexExample.cls",
       "Unused: line 17 at 16-62: Unused local variable 'dataoffset'",
       "Unused: line 18 at 16-44: Unused local variable 'datalimit'",
+      "Warning: line 13 at 28-35: Static method 'SDGResult getData(SDG, SDGRequest)' cannot implement method from interface 'sdgIDataProvider'; make it an instance method",
+      "Warning: line 8 at 30-46: Static method 'System.Boolean isUserSelectable()' cannot implement method from interface 'sdgIDataProvider'; make it an instance method",
     ],
     [
       "EnhancedLightningGrid/classes/sdgDataProviderFactory.cls",
       "Unused: line 12 at 26-37: Unused public static method 'System.Boolean isNameValid(System.String)'; only referenced by test code, remove, make private @TestVisible, or add @SuppressWarnings('Unused') with a comment if this is an external entry point",
+    ],
+    [
+      "EnhancedLightningGrid/classes/sdgDataProviderMetadata.cls",
+      "Warning: line 13 at 28-35: Static method 'SDGResult getData(SDG, SDGRequest)' cannot implement method from interface 'sdgIDataProvider'; make it an instance method",
+      "Warning: line 8 at 26-42: Static method 'System.Boolean isUserSelectable()' cannot implement method from interface 'sdgIDataProvider'; make it an instance method",
+    ],
+    [
+      "EnhancedLightningGrid/classes/sdgDataProviderNative.cls",
+      "Warning: line 12 at 28-35: Static method 'SDGResult getData(SDG, SDGRequest)' cannot implement method from interface 'sdgIDataProvider'; make it an instance method",
+      "Warning: line 8 at 26-42: Static method 'System.Boolean isUserSelectable()' cannot implement method from interface 'sdgIDataProvider'; make it an instance method",
     ],
     [
       "EnhancedLightningGrid/classes/sdgDataProviderNativeTest.cls",
@@ -12364,6 +12385,8 @@ exports[`Check samples Sample: EnhancedLightningGrid 1`] = `
     [
       "EnhancedLightningGrid/classes/sdgDataProviderRelationship.cls",
       "Unused: line 102 at 17-24: Unused local variable 'idfield'",
+      "Warning: line 12 at 28-35: Static method 'SDGResult getData(SDG, SDGRequest)' cannot implement method from interface 'sdgIDataProvider'; make it an instance method",
+      "Warning: line 8 at 26-42: Static method 'System.Boolean isUserSelectable()' cannot implement method from interface 'sdgIDataProvider'; make it an instance method",
     ],
     [
       "EnhancedLightningGrid/classes/sdgImportExport.cls",
@@ -12372,6 +12395,14 @@ exports[`Check samples Sample: EnhancedLightningGrid 1`] = `
     [
       "EnhancedLightningGrid/classes/sdgLabels.cls",
       "Unused: line 7 at 26-35: Unused class 'sdgLabels', only referenced by test code, consider using @isTest or @SuppressWarnings('Unused') if needed",
+    ],
+    [
+      "EnhancedLightningGrid/classes/sdgMetadataDataProvider.cls",
+      "Warning: line 8 at 28-35: Static method 'SDGResult getData(SDG, SDGRequest)' cannot implement method from interface 'sdgDataProvider'; make it an instance method",
+    ],
+    [
+      "EnhancedLightningGrid/classes/sdgNativeDataProvider.cls",
+      "Warning: line 9 at 32-39: Static method 'SDGResult getData(SDG, SDGRequest)' cannot implement method from interface 'sdgDataProvider'; make it an instance method",
     ],
     [
       "EnhancedLightningGrid/classes/sdgObjectEventHandlerTest.cls",
@@ -12418,6 +12449,10 @@ exports[`Check samples Sample: EnhancedLightningGrid 1`] = `
       "Unused: line 86 at 15-76: Unused local variable 'booleanfield'",
       "Unused: line 90 at 16-33: Unused local variable 'errorThrown'",
       "Unused: line 91 at 15-28: Unused local variable 'errorMsg'",
+    ],
+    [
+      "EnhancedLightningGrid/classes/sdgRelationshipDataProvider.cls",
+      "Warning: line 9 at 28-35: Static method 'SDGResult getData(SDG, SDGRequest)' cannot implement method from interface 'sdgDataProvider'; make it an instance method",
     ],
     [
       "EnhancedLightningGrid/classes/sdgSecurity.cls",
@@ -13951,6 +13986,7 @@ exports[`Check samples Sample: HEDAP 1`] = `
       "force-app/main/default/classes/EDAHealthCheckGroupAPIService.cls",
       "Unused: line 97 at 36-88: Unused local variable 'hlthChkItemsList'",
       "Unused: line 98 at 21-53: Unused local variable 'rowKeysList'",
+      "Warning: line 52 at 54-65: Static method 'hed.HealthCheckGroupAPIServiceInterface getInstance()' cannot implement method from interface 'hed.HealthCheckGroupAPIServiceInterface'; make it an instance method",
     ],
     [
       "force-app/main/default/classes/ERR_AsyncErrors.cls",
@@ -16615,6 +16651,8 @@ exports[`Check samples Sample: NPSP 1`] = `
       "NPSP/force-app/main/default/classes/OPP_OpportunityNaming.cls",
       "Unused: line 177 at 20-85: Unused local variable 'allFields'",
       "Unused: line 314 at 25-36: Unused public static method 'System.String getConQuery(System.Set<System.String>)'; remove, make private @TestVisible, or add @SuppressWarnings('Unused') with a comment if this is an external entry point",
+      "Warning: line 111 at 36-58: Static method 'System.List<Schema.Opportunity> getOppNamesAfterInsert(System.List<Schema.Opportunity>)' cannot implement method from interface 'npsp.OPP_INaming'; make it an instance method",
+      "Warning: line 65 at 23-38: Static method 'void refreshOppNames(System.List<Schema.Opportunity>)' cannot implement method from interface 'npsp.OPP_INaming'; make it an instance method",
     ],
     [
       "NPSP/force-app/main/default/classes/OPP_OpportunityNaming_BATCH_TEST.cls",
@@ -17238,6 +17276,7 @@ exports[`Check samples Sample: NPSP 1`] = `
     [
       "NPSP/force-app/main/default/classes/UTIL_MasterSchedulable.cls",
       "Unused: line 52 at 12-46: Unused local variable 'instance'",
+      "Warning: line 46 at 23-30: Static method 'void execute(System.SchedulableContext)' cannot implement method from interface 'System.Schedulable'; make it an instance method",
     ],
     [
       "NPSP/force-app/main/default/classes/UTIL_Namespace.cls",
@@ -17472,6 +17511,7 @@ exports[`Check samples Sample: NPSP 1`] = `
     [
       "NPSP/force-app/tdtm/classes/TDTM_ObjectDataGateway.cls",
       "Unused: line 90 at 23-56: Unused public static method 'void ClearCachedTriggerHandlersForTest()'; only referenced by test code, remove, make private @TestVisible, or add @SuppressWarnings('Unused') with a comment if this is an external entry point",
+      "Warning: line 67 at 32-57: Static method 'System.List<System.SObject> getClassesToCallForObject(System.String, npsp.TDTM_Runnable.Action)' cannot implement method from interface 'npsp.TDTM_iTableDataGateway'; make it an instance method",
     ],
     [
       "NPSP/force-app/tdtm/classes/TDTM_TriggerHandler.cls",
@@ -28476,8 +28516,17 @@ exports[`Check samples Sample: apex-recipes 1`] = `
       "Unused: line 51 at 23-58: Unused public static method 'void atFutureMethodWithCalloutPrivileges(System.String)'; only referenced by test code, remove, make private @TestVisible, or add @SuppressWarnings('Unused') with a comment if this is an external entry point",
     ],
     [
+      "force-app/main/default/classes/Async Apex Recipes/QueueableChainingRecipes.cls",
+      "Warning: line 26 at 23-30: Static method 'void execute(System.QueueableContext)' cannot implement method from interface 'System.Queueable'; make it an instance method",
+    ],
+    [
+      "force-app/main/default/classes/Async Apex Recipes/QueueableRecipes.cls",
+      "Warning: line 27 at 23-30: Static method 'void execute(System.QueueableContext)' cannot implement method from interface 'System.Queueable'; make it an instance method",
+    ],
+    [
       "force-app/main/default/classes/Async Apex Recipes/QueueableWithCalloutRecipes.cls",
       "Unused: line 22 at 17-53: Unused class 'QueueableWithCalloutRecipes.QueueableWithCalloutRecipesException'",
+      "Warning: line 36 at 23-30: Static method 'void execute(System.QueueableContext)' cannot implement method from interface 'System.Queueable'; make it an instance method",
     ],
     [
       "force-app/main/default/classes/Collection Recipes/CollectionUtils.cls",

--- a/js/npm/snapshots/system/SampleCheckSys.ts.snap
+++ b/js/npm/snapshots/system/SampleCheckSys.ts.snap
@@ -3479,8 +3479,8 @@ exports[`Check samples Sample: Cumulus 1`] = `
       "Cumulus/force-app/main/default/classes/OPP_OpportunityNaming.cls",
       "Unused: line 177 at 20-85: Unused local variable 'allFields'",
       "Unused: line 314 at 25-36: Unused public static method 'System.String getConQuery(System.Set<System.String>)'; remove, make private @TestVisible, or add @SuppressWarnings('Unused') with a comment if this is an external entry point",
-      "Warning: line 111 at 36-58: Static method 'System.List<Schema.Opportunity> getOppNamesAfterInsert(System.List<Schema.Opportunity>)' cannot implement method from interface 'npsp.OPP_INaming'; make it an instance method",
-      "Warning: line 65 at 23-38: Static method 'void refreshOppNames(System.List<Schema.Opportunity>)' cannot implement method from interface 'npsp.OPP_INaming'; make it an instance method",
+      "Warning: line 111 at 36-58: Implementing 'System.List<Schema.Opportunity> getOppNamesAfterInsert(System.List<Schema.Opportunity>)' from interface 'npsp.OPP_INaming' with a static method can be confusing, change to an instance method",
+      "Warning: line 65 at 23-38: Implementing 'void refreshOppNames(System.List<Schema.Opportunity>)' from interface 'npsp.OPP_INaming' with a static method can be confusing, change to an instance method",
     ],
     [
       "Cumulus/force-app/main/default/classes/OPP_OpportunityNaming_BATCH_TEST.cls",
@@ -4104,7 +4104,7 @@ exports[`Check samples Sample: Cumulus 1`] = `
     [
       "Cumulus/force-app/main/default/classes/UTIL_MasterSchedulable.cls",
       "Unused: line 52 at 12-46: Unused local variable 'instance'",
-      "Warning: line 46 at 23-30: Static method 'void execute(System.SchedulableContext)' cannot implement method from interface 'System.Schedulable'; make it an instance method",
+      "Warning: line 46 at 23-30: Implementing 'void execute(System.SchedulableContext)' from interface 'System.Schedulable' with a static method can be confusing, change to an instance method",
     ],
     [
       "Cumulus/force-app/main/default/classes/UTIL_Namespace.cls",
@@ -4339,7 +4339,7 @@ exports[`Check samples Sample: Cumulus 1`] = `
     [
       "Cumulus/force-app/tdtm/classes/TDTM_ObjectDataGateway.cls",
       "Unused: line 90 at 23-56: Unused public static method 'void ClearCachedTriggerHandlersForTest()'; only referenced by test code, remove, make private @TestVisible, or add @SuppressWarnings('Unused') with a comment if this is an external entry point",
-      "Warning: line 67 at 32-57: Static method 'System.List<System.SObject> getClassesToCallForObject(System.String, npsp.TDTM_Runnable.Action)' cannot implement method from interface 'npsp.TDTM_iTableDataGateway'; make it an instance method",
+      "Warning: line 67 at 32-57: Implementing 'System.List<System.SObject> getClassesToCallForObject(System.String, npsp.TDTM_Runnable.Action)' from interface 'npsp.TDTM_iTableDataGateway' with a static method can be confusing, change to an instance method",
     ],
     [
       "Cumulus/force-app/tdtm/classes/TDTM_TriggerHandler.cls",
@@ -11887,7 +11887,7 @@ exports[`Check samples Sample: EDA 1`] = `
       "force-app/main/default/classes/EDAHealthCheckGroupAPIService.cls",
       "Unused: line 97 at 36-88: Unused local variable 'hlthChkItemsList'",
       "Unused: line 98 at 21-53: Unused local variable 'rowKeysList'",
-      "Warning: line 52 at 54-65: Static method 'hed.HealthCheckGroupAPIServiceInterface getInstance()' cannot implement method from interface 'hed.HealthCheckGroupAPIServiceInterface'; make it an instance method",
+      "Warning: line 52 at 54-65: Implementing 'hed.HealthCheckGroupAPIServiceInterface getInstance()' from interface 'hed.HealthCheckGroupAPIServiceInterface' with a static method can be confusing, change to an instance method",
     ],
     [
       "force-app/main/default/classes/ERR_AsyncErrors.cls",
@@ -12338,7 +12338,7 @@ exports[`Check samples Sample: EnhancedLightningGrid 1`] = `
   "logs": [
     [
       "EnhancedLightningGrid/classes/CustomDataProviderExample.cls",
-      "Warning: line 9 at 28-35: Static method 'SDGResult getData(SDG, SDGRequest)' cannot implement method from interface 'sdgDataProvider'; make it an instance method",
+      "Warning: line 9 at 28-35: Implementing 'SDGResult getData(SDG, SDGRequest)' from interface 'sdgDataProvider' with a static method can be confusing, change to an instance method",
     ],
     [
       "EnhancedLightningGrid/classes/SDGField.cls",
@@ -12361,8 +12361,8 @@ exports[`Check samples Sample: EnhancedLightningGrid 1`] = `
       "EnhancedLightningGrid/classes/sdgDataProviderApexExample.cls",
       "Unused: line 17 at 16-62: Unused local variable 'dataoffset'",
       "Unused: line 18 at 16-44: Unused local variable 'datalimit'",
-      "Warning: line 13 at 28-35: Static method 'SDGResult getData(SDG, SDGRequest)' cannot implement method from interface 'sdgIDataProvider'; make it an instance method",
-      "Warning: line 8 at 30-46: Static method 'System.Boolean isUserSelectable()' cannot implement method from interface 'sdgIDataProvider'; make it an instance method",
+      "Warning: line 13 at 28-35: Implementing 'SDGResult getData(SDG, SDGRequest)' from interface 'sdgIDataProvider' with a static method can be confusing, change to an instance method",
+      "Warning: line 8 at 30-46: Implementing 'System.Boolean isUserSelectable()' from interface 'sdgIDataProvider' with a static method can be confusing, change to an instance method",
     ],
     [
       "EnhancedLightningGrid/classes/sdgDataProviderFactory.cls",
@@ -12370,13 +12370,13 @@ exports[`Check samples Sample: EnhancedLightningGrid 1`] = `
     ],
     [
       "EnhancedLightningGrid/classes/sdgDataProviderMetadata.cls",
-      "Warning: line 13 at 28-35: Static method 'SDGResult getData(SDG, SDGRequest)' cannot implement method from interface 'sdgIDataProvider'; make it an instance method",
-      "Warning: line 8 at 26-42: Static method 'System.Boolean isUserSelectable()' cannot implement method from interface 'sdgIDataProvider'; make it an instance method",
+      "Warning: line 13 at 28-35: Implementing 'SDGResult getData(SDG, SDGRequest)' from interface 'sdgIDataProvider' with a static method can be confusing, change to an instance method",
+      "Warning: line 8 at 26-42: Implementing 'System.Boolean isUserSelectable()' from interface 'sdgIDataProvider' with a static method can be confusing, change to an instance method",
     ],
     [
       "EnhancedLightningGrid/classes/sdgDataProviderNative.cls",
-      "Warning: line 12 at 28-35: Static method 'SDGResult getData(SDG, SDGRequest)' cannot implement method from interface 'sdgIDataProvider'; make it an instance method",
-      "Warning: line 8 at 26-42: Static method 'System.Boolean isUserSelectable()' cannot implement method from interface 'sdgIDataProvider'; make it an instance method",
+      "Warning: line 12 at 28-35: Implementing 'SDGResult getData(SDG, SDGRequest)' from interface 'sdgIDataProvider' with a static method can be confusing, change to an instance method",
+      "Warning: line 8 at 26-42: Implementing 'System.Boolean isUserSelectable()' from interface 'sdgIDataProvider' with a static method can be confusing, change to an instance method",
     ],
     [
       "EnhancedLightningGrid/classes/sdgDataProviderNativeTest.cls",
@@ -12385,8 +12385,8 @@ exports[`Check samples Sample: EnhancedLightningGrid 1`] = `
     [
       "EnhancedLightningGrid/classes/sdgDataProviderRelationship.cls",
       "Unused: line 102 at 17-24: Unused local variable 'idfield'",
-      "Warning: line 12 at 28-35: Static method 'SDGResult getData(SDG, SDGRequest)' cannot implement method from interface 'sdgIDataProvider'; make it an instance method",
-      "Warning: line 8 at 26-42: Static method 'System.Boolean isUserSelectable()' cannot implement method from interface 'sdgIDataProvider'; make it an instance method",
+      "Warning: line 12 at 28-35: Implementing 'SDGResult getData(SDG, SDGRequest)' from interface 'sdgIDataProvider' with a static method can be confusing, change to an instance method",
+      "Warning: line 8 at 26-42: Implementing 'System.Boolean isUserSelectable()' from interface 'sdgIDataProvider' with a static method can be confusing, change to an instance method",
     ],
     [
       "EnhancedLightningGrid/classes/sdgImportExport.cls",
@@ -12398,11 +12398,11 @@ exports[`Check samples Sample: EnhancedLightningGrid 1`] = `
     ],
     [
       "EnhancedLightningGrid/classes/sdgMetadataDataProvider.cls",
-      "Warning: line 8 at 28-35: Static method 'SDGResult getData(SDG, SDGRequest)' cannot implement method from interface 'sdgDataProvider'; make it an instance method",
+      "Warning: line 8 at 28-35: Implementing 'SDGResult getData(SDG, SDGRequest)' from interface 'sdgDataProvider' with a static method can be confusing, change to an instance method",
     ],
     [
       "EnhancedLightningGrid/classes/sdgNativeDataProvider.cls",
-      "Warning: line 9 at 32-39: Static method 'SDGResult getData(SDG, SDGRequest)' cannot implement method from interface 'sdgDataProvider'; make it an instance method",
+      "Warning: line 9 at 32-39: Implementing 'SDGResult getData(SDG, SDGRequest)' from interface 'sdgDataProvider' with a static method can be confusing, change to an instance method",
     ],
     [
       "EnhancedLightningGrid/classes/sdgObjectEventHandlerTest.cls",
@@ -12452,7 +12452,7 @@ exports[`Check samples Sample: EnhancedLightningGrid 1`] = `
     ],
     [
       "EnhancedLightningGrid/classes/sdgRelationshipDataProvider.cls",
-      "Warning: line 9 at 28-35: Static method 'SDGResult getData(SDG, SDGRequest)' cannot implement method from interface 'sdgDataProvider'; make it an instance method",
+      "Warning: line 9 at 28-35: Implementing 'SDGResult getData(SDG, SDGRequest)' from interface 'sdgDataProvider' with a static method can be confusing, change to an instance method",
     ],
     [
       "EnhancedLightningGrid/classes/sdgSecurity.cls",
@@ -13986,7 +13986,7 @@ exports[`Check samples Sample: HEDAP 1`] = `
       "force-app/main/default/classes/EDAHealthCheckGroupAPIService.cls",
       "Unused: line 97 at 36-88: Unused local variable 'hlthChkItemsList'",
       "Unused: line 98 at 21-53: Unused local variable 'rowKeysList'",
-      "Warning: line 52 at 54-65: Static method 'hed.HealthCheckGroupAPIServiceInterface getInstance()' cannot implement method from interface 'hed.HealthCheckGroupAPIServiceInterface'; make it an instance method",
+      "Warning: line 52 at 54-65: Implementing 'hed.HealthCheckGroupAPIServiceInterface getInstance()' from interface 'hed.HealthCheckGroupAPIServiceInterface' with a static method can be confusing, change to an instance method",
     ],
     [
       "force-app/main/default/classes/ERR_AsyncErrors.cls",
@@ -16651,8 +16651,8 @@ exports[`Check samples Sample: NPSP 1`] = `
       "NPSP/force-app/main/default/classes/OPP_OpportunityNaming.cls",
       "Unused: line 177 at 20-85: Unused local variable 'allFields'",
       "Unused: line 314 at 25-36: Unused public static method 'System.String getConQuery(System.Set<System.String>)'; remove, make private @TestVisible, or add @SuppressWarnings('Unused') with a comment if this is an external entry point",
-      "Warning: line 111 at 36-58: Static method 'System.List<Schema.Opportunity> getOppNamesAfterInsert(System.List<Schema.Opportunity>)' cannot implement method from interface 'npsp.OPP_INaming'; make it an instance method",
-      "Warning: line 65 at 23-38: Static method 'void refreshOppNames(System.List<Schema.Opportunity>)' cannot implement method from interface 'npsp.OPP_INaming'; make it an instance method",
+      "Warning: line 111 at 36-58: Implementing 'System.List<Schema.Opportunity> getOppNamesAfterInsert(System.List<Schema.Opportunity>)' from interface 'npsp.OPP_INaming' with a static method can be confusing, change to an instance method",
+      "Warning: line 65 at 23-38: Implementing 'void refreshOppNames(System.List<Schema.Opportunity>)' from interface 'npsp.OPP_INaming' with a static method can be confusing, change to an instance method",
     ],
     [
       "NPSP/force-app/main/default/classes/OPP_OpportunityNaming_BATCH_TEST.cls",
@@ -17276,7 +17276,7 @@ exports[`Check samples Sample: NPSP 1`] = `
     [
       "NPSP/force-app/main/default/classes/UTIL_MasterSchedulable.cls",
       "Unused: line 52 at 12-46: Unused local variable 'instance'",
-      "Warning: line 46 at 23-30: Static method 'void execute(System.SchedulableContext)' cannot implement method from interface 'System.Schedulable'; make it an instance method",
+      "Warning: line 46 at 23-30: Implementing 'void execute(System.SchedulableContext)' from interface 'System.Schedulable' with a static method can be confusing, change to an instance method",
     ],
     [
       "NPSP/force-app/main/default/classes/UTIL_Namespace.cls",
@@ -17511,7 +17511,7 @@ exports[`Check samples Sample: NPSP 1`] = `
     [
       "NPSP/force-app/tdtm/classes/TDTM_ObjectDataGateway.cls",
       "Unused: line 90 at 23-56: Unused public static method 'void ClearCachedTriggerHandlersForTest()'; only referenced by test code, remove, make private @TestVisible, or add @SuppressWarnings('Unused') with a comment if this is an external entry point",
-      "Warning: line 67 at 32-57: Static method 'System.List<System.SObject> getClassesToCallForObject(System.String, npsp.TDTM_Runnable.Action)' cannot implement method from interface 'npsp.TDTM_iTableDataGateway'; make it an instance method",
+      "Warning: line 67 at 32-57: Implementing 'System.List<System.SObject> getClassesToCallForObject(System.String, npsp.TDTM_Runnable.Action)' from interface 'npsp.TDTM_iTableDataGateway' with a static method can be confusing, change to an instance method",
     ],
     [
       "NPSP/force-app/tdtm/classes/TDTM_TriggerHandler.cls",
@@ -28517,16 +28517,16 @@ exports[`Check samples Sample: apex-recipes 1`] = `
     ],
     [
       "force-app/main/default/classes/Async Apex Recipes/QueueableChainingRecipes.cls",
-      "Warning: line 26 at 23-30: Static method 'void execute(System.QueueableContext)' cannot implement method from interface 'System.Queueable'; make it an instance method",
+      "Warning: line 26 at 23-30: Implementing 'void execute(System.QueueableContext)' from interface 'System.Queueable' with a static method can be confusing, change to an instance method",
     ],
     [
       "force-app/main/default/classes/Async Apex Recipes/QueueableRecipes.cls",
-      "Warning: line 27 at 23-30: Static method 'void execute(System.QueueableContext)' cannot implement method from interface 'System.Queueable'; make it an instance method",
+      "Warning: line 27 at 23-30: Implementing 'void execute(System.QueueableContext)' from interface 'System.Queueable' with a static method can be confusing, change to an instance method",
     ],
     [
       "force-app/main/default/classes/Async Apex Recipes/QueueableWithCalloutRecipes.cls",
       "Unused: line 22 at 17-53: Unused class 'QueueableWithCalloutRecipes.QueueableWithCalloutRecipesException'",
-      "Warning: line 36 at 23-30: Static method 'void execute(System.QueueableContext)' cannot implement method from interface 'System.Queueable'; make it an instance method",
+      "Warning: line 36 at 23-30: Implementing 'void execute(System.QueueableContext)' from interface 'System.Queueable' with a static method can be confusing, change to an instance method",
     ],
     [
       "force-app/main/default/classes/Collection Recipes/CollectionUtils.cls",

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/MethodMap.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/MethodMap.scala
@@ -558,7 +558,7 @@ object MethodMap {
             if (matched.isStatic) {
               setMethodError(
                 matched,
-                s"Static method '${matched.signature}' cannot implement method from interface '${interface.typeName}'; make it an instance method",
+                s"Implementing '${matched.signature}' from interface '${interface.typeName}' with a static method can be confusing, change to an instance method",
                 errors,
                 isWarning = true
               )
@@ -613,7 +613,7 @@ object MethodMap {
         }
         setMethodError(
           method,
-          s"Static method '${method.signature}' cannot implement abstract method from class '$declaringType'; make it an instance method",
+          s"Implementing '${method.signature}' from abstract class '$declaringType' with a static method can be confusing, change to an instance method",
           errors,
           isWarning = true
         )

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/MethodMap.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/MethodMap.scala
@@ -359,7 +359,7 @@ object MethodMap {
     }
     staticLocals
       .filterNot(ignorableStatics.contains)
-      .foreach(method => applyStaticMethod(workingMap, method))
+      .foreach(method => applyStaticMethod(workingMap, method, errors))
 
     val ad = td match {
       case ad: ApexClassDeclaration => Some(ad)
@@ -555,6 +555,14 @@ object MethodMap {
                 )
               )
             }
+            if (matched.isStatic) {
+              setMethodError(
+                matched,
+                s"Static method '${matched.signature}' cannot implement method from interface '${interface.typeName}'; make it an instance method",
+                errors,
+                isWarning = true
+              )
+            }
             matched.addShadow(method)
           case Some(_) => ()
           case None =>
@@ -583,14 +591,34 @@ object MethodMap {
       })
   }
 
-  private def applyStaticMethod(workingMap: WorkingMap, method: MethodDeclaration): Unit = {
+  private def applyStaticMethod(
+    workingMap: WorkingMap,
+    method: MethodDeclaration,
+    errors: mutable.Buffer[Issue]
+  ): Unit = {
     val key     = (method.name, method.parameters.length)
     val methods = workingMap.getOrElse(key, Nil)
     val matched = methods.find(mapMethod => areSameMethodsIgnoringReturn(mapMethod, method))
-    if (matched.isEmpty)
-      workingMap.put(key, method :: methods)
-    else if (matched.get.isStatic)
-      workingMap.put(key, method :: methods.filterNot(_ eq matched.get))
+    matched match {
+      case None =>
+        workingMap.put(key, method :: methods)
+      case Some(matched) if matched.isStatic =>
+        workingMap.put(key, method :: methods.filterNot(_ eq matched))
+      case Some(matched) if matched.isAbstract =>
+        val declaringType = matched match {
+          case apexMethod: ApexMethodLike => apexMethod.thisTypeId.typeName
+          case platformMethod: PlatformMethod =>
+            platformMethod.typeDeclaration.typeName
+          case _ => TypeNames.InternalObject
+        }
+        setMethodError(
+          method,
+          s"Static method '${method.signature}' cannot implement abstract method from class '$declaringType'; make it an instance method",
+          errors,
+          isWarning = true
+        )
+      case _ => ()
+    }
   }
 
   /** Add an instance method into the working map.

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/ImplementsTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/ImplementsTest.scala
@@ -64,6 +64,83 @@ class ImplementsTest extends AnyFunSuite with TestHelper {
     assert(dummyIssues.isEmpty)
   }
 
+  test("Static implementation of interface method") {
+    typeDeclarations(
+      Map(
+        "Dummy.cls" -> "public class Dummy implements A {public static void func() {}}",
+        "A.cls"     -> "public interface A {void func();}"
+      )
+    )
+    assert(
+      dummyIssues ==
+        "Warning: line 1 at 52-56: Static method 'void func()' cannot implement method from interface 'A'; make it an instance method\n"
+    )
+  }
+
+  test("Unrelated static method on interface implementation") {
+    typeDeclarations(
+      Map(
+        "Dummy.cls" -> "public class Dummy implements A {public void func() {} public static void helper() {}}",
+        "A.cls" -> "public interface A {void func();}"
+      )
+    )
+    assert(dummyIssues.isEmpty)
+  }
+
+  test("Static implementation of Schedulable method") {
+    typeDeclarations(
+      Map(
+        "Dummy.cls" ->
+          "public class Dummy implements Schedulable {public static void execute(SchedulableContext context) {}}"
+      )
+    )
+    assert(
+      dummyIssues ==
+        "Warning: line 1 at 62-69: Static method 'void execute(System.SchedulableContext)' cannot implement method from interface 'System.Schedulable'; make it an instance method\n"
+    )
+  }
+
+  test("Instance implementation of Schedulable method") {
+    typeDeclarations(
+      Map(
+        "Dummy.cls" ->
+          "public class Dummy implements Schedulable {public void execute(SchedulableContext context) {}}"
+      )
+    )
+    assert(dummyIssues.isEmpty)
+  }
+
+  test("Static implementation of Queueable method") {
+    typeDeclarations(
+      Map(
+        "Dummy.cls" ->
+          "public class Dummy implements Queueable {public static void execute(QueueableContext context) {}}"
+      )
+    )
+    assert(
+      dummyIssues ==
+        "Warning: line 1 at 60-67: Static method 'void execute(System.QueueableContext)' cannot implement method from interface 'System.Queueable'; make it an instance method\n"
+    )
+  }
+
+  test("Instance implementation of Queueable method") {
+    typeDeclarations(
+      Map(
+        "Dummy.cls" ->
+          "public class Dummy implements Queueable {public void execute(QueueableContext context) {}}"
+      )
+    )
+    assert(dummyIssues.isEmpty)
+  }
+
+  test("Missing implementation of Schedulable method") {
+    typeDeclarations(Map("Dummy.cls" -> "public class Dummy implements Schedulable {}"))
+    assert(
+      dummyIssues ==
+        "Missing: line 1 at 13-18: Non-abstract class must implement method 'void execute(System.SchedulableContext)' from interface 'System.Schedulable'\n"
+    )
+  }
+
   test("Protected implementation of interface method") {
     typeDeclarations(
       Map(

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/ImplementsTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/ImplementsTest.scala
@@ -73,7 +73,7 @@ class ImplementsTest extends AnyFunSuite with TestHelper {
     )
     assert(
       dummyIssues ==
-        "Warning: line 1 at 52-56: Static method 'void func()' cannot implement method from interface 'A'; make it an instance method\n"
+        "Warning: line 1 at 52-56: Implementing 'void func()' from interface 'A' with a static method can be confusing, change to an instance method\n"
     )
   }
 
@@ -96,7 +96,7 @@ class ImplementsTest extends AnyFunSuite with TestHelper {
     )
     assert(
       dummyIssues ==
-        "Warning: line 1 at 62-69: Static method 'void execute(System.SchedulableContext)' cannot implement method from interface 'System.Schedulable'; make it an instance method\n"
+        "Warning: line 1 at 62-69: Implementing 'void execute(System.SchedulableContext)' from interface 'System.Schedulable' with a static method can be confusing, change to an instance method\n"
     )
   }
 
@@ -119,7 +119,7 @@ class ImplementsTest extends AnyFunSuite with TestHelper {
     )
     assert(
       dummyIssues ==
-        "Warning: line 1 at 60-67: Static method 'void execute(System.QueueableContext)' cannot implement method from interface 'System.Queueable'; make it an instance method\n"
+        "Warning: line 1 at 60-67: Implementing 'void execute(System.QueueableContext)' from interface 'System.Queueable' with a static method can be confusing, change to an instance method\n"
     )
   }
 

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodShadowTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodShadowTest.scala
@@ -40,7 +40,7 @@ class MethodShadowTest extends AnyFunSuite with TestHelper {
         "Dummy.cls" -> "public class Dummy extends SuperClass { public static void func() {} }",
         "SuperClass.cls" -> "public abstract class SuperClass { public abstract void func(); }"
       ),
-      "Warning: line 1 at 59-63: Static method 'void func()' cannot implement abstract method from class 'SuperClass'; make it an instance method\n"
+      "Warning: line 1 at 59-63: Implementing 'void func()' from abstract class 'SuperClass' with a static method can be confusing, change to an instance method\n"
     )
   }
 

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodShadowTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/MethodShadowTest.scala
@@ -34,6 +34,26 @@ class MethodShadowTest extends AnyFunSuite with TestHelper {
     )
   }
 
+  test("Static implementation of inherited abstract method") {
+    testMethods(
+      Map(
+        "Dummy.cls" -> "public class Dummy extends SuperClass { public static void func() {} }",
+        "SuperClass.cls" -> "public abstract class SuperClass { public abstract void func(); }"
+      ),
+      "Warning: line 1 at 59-63: Static method 'void func()' cannot implement abstract method from class 'SuperClass'; make it an instance method\n"
+    )
+  }
+
+  test("Instance implementation of inherited abstract method") {
+    testMethods(
+      Map(
+        "Dummy.cls" -> "public class Dummy extends SuperClass { public override void func() {} }",
+        "SuperClass.cls" -> "public abstract class SuperClass { public abstract void func(); }"
+      ),
+      ""
+    )
+  }
+
   test("Override of public virtual without override") {
     testMethods(
       Map(


### PR DESCRIPTION
## Summary

- warn at the declaration site when an interface method is implemented with a static method
- apply the equivalent warning when a static method matches an inherited abstract method
- preserve correct instance implementations, missing-method errors, and unrelated static helpers

Salesforce compiles, deploys, and runs this construct. The warning is advisory because expressing an instance contract with a static method can be confusing. The interface case flows through `MethodMap.checkInterface`. The abstract-class variant does not share that path: inherited abstract methods are matched while local static methods are merged in `MethodMap.applyStaticMethod`, so the equivalent warning is emitted there. No call-site tracking was added.

Closes #351

## System-test snapshot delta

The regenerated apex-samples snapshot adds **25 warnings across 6 sample projects**, with no removed diagnostics and no removed `Unused:` diagnostics:

- Cumulus: 4
- EDA: 1
- EnhancedLightningGrid: 12
- HEDAP: 1
- NPSP: 4
- apex-recipes: 3

Spot checks against the sample `.cls` sources confirmed the additions are static methods matching interface methods, including `Schedulable` and `Queueable`.

## Tests

- `sbt -batch scalafmtAll`
- `sbt -batch apexlsJVM/test` (2,520 tests passed)
- `sbt -batch apexlsJVM/build`
- `SAMPLES=../apex-samples npm run test-snapshot -- --runInBand` (100 sample tests passed)