### PR TITLE
Fix @TestVisible members missing from test completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix completion omitting `@TestVisible` members in test classes.
+
 - Warn when implementing an interface or inherited abstract method with a static method could be
   confusing.
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/TestVisibleAccess.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/TestVisibleAccess.scala
@@ -26,19 +26,29 @@ import com.nawforce.pkgforce.modifiers.{
   Modifier,
   PRIVATE_MODIFIER,
   PROTECTED_MODIFIER,
-  PUBLIC_MODIFIER
+  PUBLIC_MODIFIER,
+  TEST_VISIBLE_ANNOTATION
 }
 import com.nawforce.pkgforce.names.TypeName
 
 object TestVisibleAccess {
+  sealed trait AccessResult {
+    def isAccessible: Boolean
+    def errorMessage: Option[String]
+  }
+
+  case object Accessible extends AccessResult {
+    override val isAccessible: Boolean         = true
+    override val errorMessage: Option[String] = None
+  }
+
+  case class Inaccessible(message: String) extends AccessResult {
+    override val isAccessible: Boolean         = false
+    override val errorMessage: Option[String] = Some(message)
+  }
+
   def fieldAccessError(field: FieldDeclaration, calledFrom: TypeDeclaration): Option[String] = {
-    if (isInvalidPrivateFieldAccess(field, calledFrom)) {
-      Some("Private @TestVisible fields can only be accessed from @IsTest classes")
-    } else if (!isFieldAccessible(field, calledFrom)) {
-      Some(s"Field is not visible: ${field.name}")
-    } else {
-      None
-    }
+    field.visibility.flatMap(_ => access(field, Some(calledFrom)).errorMessage)
   }
 
   def methodAccessError(method: MethodDeclaration, calledFrom: TypeDeclaration): Option[String] = {
@@ -49,59 +59,86 @@ object TestVisibleAccess {
       case wrapped: AnyReturnMethodDeclaration => wrapped.method
       case other                               => other
     }
-    if (isInvalidPrivateMethodAccess(resolved, calledFrom)) {
-      Some("Private @TestVisible methods can only be accessed from @IsTest classes")
-    } else if (!isMethodAccessible(resolved, calledFrom)) {
-      Some(s"Method is not visible: ${resolved.nameAndParameterTypes}")
+    resolved.visibility.flatMap(_ => access(resolved, Some(calledFrom)).errorMessage)
+  }
+
+  def access(
+    field: FieldDeclaration,
+    calledFrom: Option[TypeDeclaration]
+  ): AccessResult = {
+    if (calledFrom.exists(isInvalidPrivateFieldAccess(field, _))) {
+      Inaccessible("Private @TestVisible fields can only be accessed from @IsTest classes")
+    } else if (!isAccessible(
+                 field.visibility.getOrElse(PRIVATE_MODIFIER),
+                 field.thisTypeIdOpt.map(_.typeName),
+                 isSameApexFile(field, calledFrom),
+                 field.isTestVisible,
+                 calledFrom
+               )) {
+      Inaccessible(s"Field is not visible: ${field.name}")
     } else {
-      None
+      Accessible
     }
   }
 
-  def isInvalidPrivateFieldAccess(field: FieldDeclaration, calledFrom: TypeDeclaration): Boolean = {
+  def access(
+    method: MethodDeclaration,
+    calledFrom: Option[TypeDeclaration]
+  ): AccessResult = {
+    val resolved = method match {
+      case wrapped: AnyReturnMethodDeclaration => wrapped.method
+      case other                               => other
+    }
+    if (calledFrom.exists(isInvalidPrivateMethodAccess(resolved, _))) {
+      Inaccessible("Private @TestVisible methods can only be accessed from @IsTest classes")
+    } else if (!isAccessible(
+                 resolved.visibility.getOrElse(PRIVATE_MODIFIER),
+                 resolved.thisTypeIdOpt.map(_.typeName),
+                 isSameApexFile(resolved, calledFrom),
+                 resolved.isTestVisible,
+                 calledFrom
+               )) {
+      Inaccessible(s"Method is not visible: ${resolved.nameAndParameterTypes}")
+    } else {
+      Accessible
+    }
+  }
+
+  def access(
+    declaration: TypeDeclaration,
+    calledFrom: Option[TypeDeclaration]
+  ): AccessResult = {
+    if (!isAccessible(
+          declaration.visibility.getOrElse(PRIVATE_MODIFIER),
+          declaration.outerTypeName,
+          isSameApexFile(declaration, calledFrom),
+          declaration.modifiers.contains(TEST_VISIBLE_ANNOTATION),
+          calledFrom
+        )) {
+      Inaccessible(s"Type is not visible: ${declaration.typeName}")
+    } else {
+      Accessible
+    }
+  }
+
+  private def isInvalidPrivateFieldAccess(
+    field: FieldDeclaration,
+    calledFrom: TypeDeclaration
+  ): Boolean = {
     field.isTestVisible &&
     field.visibility.contains(PRIVATE_MODIFIER) &&
-    !isSameApexFile(field, calledFrom) &&
+    !isSameApexFile(field, Some(calledFrom)) &&
     !calledFrom.isUnitTestContext
   }
 
-  def isInvalidPrivateMethodAccess(
+  private def isInvalidPrivateMethodAccess(
     method: MethodDeclaration,
     calledFrom: TypeDeclaration
   ): Boolean = {
     method.isTestVisible &&
     method.visibility.contains(PRIVATE_MODIFIER) &&
-    !isSameApexFile(method, calledFrom) &&
+    !isSameApexFile(method, Some(calledFrom)) &&
     !calledFrom.isUnitTestContext
-  }
-
-  private def isFieldAccessible(field: FieldDeclaration, calledFrom: TypeDeclaration): Boolean = {
-    field.visibility
-      .forall(visibility =>
-        isAccessible(
-          visibility,
-          field.thisTypeIdOpt.map(_.typeName),
-          isSameApexFile(field, calledFrom),
-          field.isTestVisible,
-          calledFrom
-        )
-      )
-  }
-
-  private def isMethodAccessible(
-    method: MethodDeclaration,
-    calledFrom: TypeDeclaration
-  ): Boolean = {
-    method.visibility
-      .forall(visibility =>
-        isAccessible(
-          visibility,
-          method.thisTypeIdOpt.map(_.typeName),
-          isSameApexFile(method, calledFrom),
-          method.isTestVisible,
-          calledFrom
-        )
-      )
   }
 
   private def isAccessible(
@@ -109,13 +146,13 @@ object TestVisibleAccess {
     ownerTypeName: Option[TypeName],
     isSameApexFile: Boolean,
     isTestVisible: Boolean,
-    calledFrom: TypeDeclaration
+    calledFrom: Option[TypeDeclaration]
   ): Boolean = {
     lazy val isSameTypeOrSubtype =
-      ownerTypeName.exists(owner =>
-        calledFrom.typeName == owner || calledFrom.extendsOrImplements(owner)
+      calledFrom.exists(from =>
+        ownerTypeName.exists(owner => from.typeName == owner || from.extendsOrImplements(owner))
       )
-    lazy val isUnitTestVisible = isTestVisible && calledFrom.isUnitTestContext
+    lazy val isUnitTestVisible = isTestVisible && calledFrom.exists(_.isUnitTestContext)
 
     visibility match {
       case PUBLIC_MODIFIER | GLOBAL_MODIFIER => true
@@ -125,17 +162,34 @@ object TestVisibleAccess {
     }
   }
 
-  private def isSameApexFile(field: FieldDeclaration, calledFrom: TypeDeclaration): Boolean = {
-    (field, calledFrom) match {
+  private def isSameApexFile(
+    field: FieldDeclaration,
+    calledFrom: Option[TypeDeclaration]
+  ): Boolean = {
+    (field, calledFrom.orNull) match {
       case (af: ApexFieldLike, ad: ApexDeclaration) => af.location.path == ad.location.path
       case _                                        => false
     }
   }
 
-  private def isSameApexFile(method: MethodDeclaration, calledFrom: TypeDeclaration): Boolean = {
-    (method, calledFrom) match {
+  private def isSameApexFile(
+    method: MethodDeclaration,
+    calledFrom: Option[TypeDeclaration]
+  ): Boolean = {
+    (method, calledFrom.orNull) match {
       case (am: ApexMethodLike, ad: ApexDeclaration) => am.location.path == ad.location.path
       case _                                         => false
+    }
+  }
+
+  private def isSameApexFile(
+    declaration: TypeDeclaration,
+    calledFrom: Option[TypeDeclaration]
+  ): Boolean = {
+    (declaration, calledFrom.orNull) match {
+      case (target: ApexDeclaration, from: ApexDeclaration) =>
+        target.location.path == from.location.path
+      case _ => false
     }
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/TestVisibleAccess.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/TestVisibleAccess.scala
@@ -38,12 +38,12 @@ object TestVisibleAccess {
   }
 
   case object Accessible extends AccessResult {
-    override val isAccessible: Boolean         = true
+    override val isAccessible: Boolean        = true
     override val errorMessage: Option[String] = None
   }
 
   case class Inaccessible(message: String) extends AccessResult {
-    override val isAccessible: Boolean         = false
+    override val isAccessible: Boolean        = false
     override val errorMessage: Option[String] = Some(message)
   }
 
@@ -62,59 +62,56 @@ object TestVisibleAccess {
     resolved.visibility.flatMap(_ => access(resolved, Some(calledFrom)).errorMessage)
   }
 
-  def access(
-    field: FieldDeclaration,
-    calledFrom: Option[TypeDeclaration]
-  ): AccessResult = {
+  def access(field: FieldDeclaration, calledFrom: Option[TypeDeclaration]): AccessResult = {
     if (calledFrom.exists(isInvalidPrivateFieldAccess(field, _))) {
       Inaccessible("Private @TestVisible fields can only be accessed from @IsTest classes")
-    } else if (!isAccessible(
-                 field.visibility.getOrElse(PRIVATE_MODIFIER),
-                 field.thisTypeIdOpt.map(_.typeName),
-                 isSameApexFile(field, calledFrom),
-                 field.isTestVisible,
-                 calledFrom
-               )) {
+    } else if (
+      !isAccessible(
+        field.visibility.getOrElse(PRIVATE_MODIFIER),
+        field.thisTypeIdOpt.map(_.typeName),
+        isSameApexFile(field, calledFrom),
+        field.isTestVisible,
+        calledFrom
+      )
+    ) {
       Inaccessible(s"Field is not visible: ${field.name}")
     } else {
       Accessible
     }
   }
 
-  def access(
-    method: MethodDeclaration,
-    calledFrom: Option[TypeDeclaration]
-  ): AccessResult = {
+  def access(method: MethodDeclaration, calledFrom: Option[TypeDeclaration]): AccessResult = {
     val resolved = method match {
       case wrapped: AnyReturnMethodDeclaration => wrapped.method
       case other                               => other
     }
     if (calledFrom.exists(isInvalidPrivateMethodAccess(resolved, _))) {
       Inaccessible("Private @TestVisible methods can only be accessed from @IsTest classes")
-    } else if (!isAccessible(
-                 resolved.visibility.getOrElse(PRIVATE_MODIFIER),
-                 resolved.thisTypeIdOpt.map(_.typeName),
-                 isSameApexFile(resolved, calledFrom),
-                 resolved.isTestVisible,
-                 calledFrom
-               )) {
+    } else if (
+      !isAccessible(
+        resolved.visibility.getOrElse(PRIVATE_MODIFIER),
+        resolved.thisTypeIdOpt.map(_.typeName),
+        isSameApexFile(resolved, calledFrom),
+        resolved.isTestVisible,
+        calledFrom
+      )
+    ) {
       Inaccessible(s"Method is not visible: ${resolved.nameAndParameterTypes}")
     } else {
       Accessible
     }
   }
 
-  def access(
-    declaration: TypeDeclaration,
-    calledFrom: Option[TypeDeclaration]
-  ): AccessResult = {
-    if (!isAccessible(
-          declaration.visibility.getOrElse(PRIVATE_MODIFIER),
-          declaration.outerTypeName,
-          isSameApexFile(declaration, calledFrom),
-          declaration.modifiers.contains(TEST_VISIBLE_ANNOTATION),
-          calledFrom
-        )) {
+  def access(declaration: TypeDeclaration, calledFrom: Option[TypeDeclaration]): AccessResult = {
+    if (
+      !isAccessible(
+        declaration.visibility.getOrElse(PRIVATE_MODIFIER),
+        declaration.outerTypeName,
+        isSameApexFile(declaration, calledFrom),
+        declaration.modifiers.contains(TEST_VISIBLE_ANNOTATION),
+        calledFrom
+      )
+    ) {
       Inaccessible(s"Type is not visible: ${declaration.typeName}")
     } else {
       Accessible

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/CompletionProvider.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/CompletionProvider.scala
@@ -21,7 +21,6 @@ import com.nawforce.apexlink.rpc.CompletionItemLink
 import com.nawforce.apexlink.types.apex.{ApexClassDeclaration, ApexFullDeclaration}
 import com.nawforce.apexlink.types.core._
 import com.nawforce.pkgforce.documents.{ApexClassDocument, ApexTriggerDocument, MetadataDocument}
-import com.nawforce.pkgforce.modifiers.{PRIVATE_MODIFIER, PROTECTED_MODIFIER, PUBLIC_MODIFIER}
 import com.nawforce.pkgforce.names.TypeName
 import com.nawforce.pkgforce.path.PathLike
 import com.vmware.antlr4c3.CodeCompletionCore
@@ -304,26 +303,19 @@ trait CompletionProvider {
   ): Array[CompletionItemLink] = {
     var items = Array[CompletionItemLink]()
 
-    val minimumVisibility =
-      if (fromDeclaration.contains(targetDeclaration))
-        PRIVATE_MODIFIER.order
-      else if (fromDeclaration.exists(_.extendsOrImplements(targetDeclaration.typeName)))
-        PROTECTED_MODIFIER.order
-      else PUBLIC_MODIFIER.order
-
     items = items ++ targetDeclaration.methods
       .filter(isStatic.isEmpty || _.isStatic == isStatic.get)
-      .filter(_.visibility.map(_.order).getOrElse(0) >= minimumVisibility)
+      .filter(TestVisibleAccess.access(_, fromDeclaration).isAccessible)
       .map(method => CompletionItemLink(method))
 
     items = items ++ targetDeclaration.fields
       .filter(isStatic.isEmpty || _.isStatic == isStatic.get)
-      .filter(_.visibility.map(_.order).getOrElse(0) >= minimumVisibility)
+      .filter(TestVisibleAccess.access(_, fromDeclaration).isAccessible)
       .map(field => CompletionItemLink(field))
 
     if (isStatic.isEmpty || isStatic.contains(true)) {
       items = items ++ targetDeclaration.nestedTypes
-        .filter(_.visibility.map(_.order).getOrElse(0) >= minimumVisibility)
+        .filter(TestVisibleAccess.access(_, fromDeclaration).isAccessible)
         .flatMap(nested => CompletionItemLink(nested))
     }
     if (isStatic.isEmpty) {

--- a/jvm/src/test/scala/com/nawforce/apexlink/pkg/CompletionProviderTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/pkg/CompletionProviderTest.scala
@@ -56,6 +56,93 @@ class CompletionProviderTest extends AnyFunSuite with TestHelper {
                            |$bodyContent
                            |}""".stripMargin.replaceAll("\r\n", "\n")
 
+  private val testVisibleContent =
+    """public virtual class VisibilityTarget {
+      |  public static String publicField;
+      |  protected static String protectedField;
+      |  private static String privateField;
+      |  @TestVisible private static String testVisibleField;
+      |
+      |  public static void publicMethod() {}
+      |  protected static void protectedMethod() {}
+      |  private static void privateMethod() {}
+      |  @TestVisible private static void testVisibleMethod() {}
+      |
+      |  public class PublicType {}
+      |  private class PrivateType {}
+      |  @TestVisible private class TestVisibleType {}
+      |}""".stripMargin
+
+  private def staticCompletionLabels(
+    root: PathLike,
+    declaration: String
+  ): Set[String] = {
+    val org     = createOrg(root)
+    val path    = root.join("Completion.cls")
+    val content = s"$declaration { static void complete() { VisibilityTarget."
+    org
+      .getCompletionItemsInternal(path, line = 1, offset = content.length, content)
+      .map(_.label)
+      .toSet
+  }
+
+  test("@TestVisible static completions respect caller accessibility") {
+    FileSystemHelper.run(Map("VisibilityTarget.cls" -> testVisibleContent)) { root: PathLike =>
+      val testLabels = staticCompletionLabels(root, "@IsTest private class Completion")
+      assert(
+        Set(
+          "publicField",
+          "publicMethod()",
+          "PublicType",
+          "testVisibleField",
+          "testVisibleMethod()",
+          "TestVisibleType"
+        ).subsetOf(testLabels)
+      )
+      assert(!Set("privateField", "privateMethod()", "PrivateType").exists(testLabels))
+
+      val normalLabels = staticCompletionLabels(root, "public class Completion")
+      assert(Set("publicField", "publicMethod()", "PublicType").subsetOf(normalLabels))
+      assert(
+        !Set(
+          "privateField",
+          "privateMethod()",
+          "PrivateType",
+          "testVisibleField",
+          "testVisibleMethod()",
+          "TestVisibleType"
+        ).exists(normalLabels)
+      )
+
+      val subtypeLabels =
+        staticCompletionLabels(root, "public class Completion extends VisibilityTarget")
+      assert(
+        Set("protectedField", "protectedMethod()").subsetOf(subtypeLabels)
+      )
+    }
+  }
+
+  test("Static completions without a caller remain public") {
+    FileSystemHelper.run(Map("VisibilityTarget.cls" -> testVisibleContent)) { root: PathLike =>
+      val org          = createOrg(root)
+      val content      = "VisibilityTarget."
+      val completions  =
+        org.getCompletionItemsInternal(root.join("Completion.cls"), 1, content.length, content)
+      val labels       = completions.map(_.label).toSet
+      val nonPublicSet = Set(
+        "protectedField",
+        "protectedMethod()",
+        "privateField",
+        "privateMethod()",
+        "PrivateType",
+        "testVisibleField",
+        "testVisibleMethod()",
+        "TestVisibleType"
+      )
+      assert(!nonPublicSet.exists(labels))
+    }
+  }
+
   test("Internal Completion") {
     FileSystemHelper.run(Map()) { root: PathLike =>
       val org  = createOrg(root)


### PR DESCRIPTION
Closes #522

## Summary

- extract shared candidate accessibility results in `TestVisibleAccess`, including a message-bearing inaccessible result that validation/type-reference callers can attach to their source location
- use the shared access decision for completion fields, methods, and nested types
- offer `@TestVisible` members in unit-test contexts while preserving normal, subtype, and same-type visibility behavior
- keep absent `fromDeclaration` conservative: public/global candidates remain accessible, while protected/private candidates are omitted
- preserve the existing validation wrappers and messages, including their implicit-visibility behavior

## Tests

- `sbt -batch scalafmtAll`
- `sbt -batch "apexlsJVM/testOnly com.nawforce.apexlink.pkg.CompletionProviderTest"` (64 passed)
- `sbt -batch "apexlsJVM/test"` (2,526 passed)
- `sbt -batch "apexlsJVM/build"`
- `npm run test-samples -- --runInBand` (100/100 tests and 100/100 snapshots passed; no snapshot changes)