### PR TITLE
Fix final assignment diagnostics and initializer handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Static final assignments from instance initializer blocks now receive targeted advisory guidance
+  matching Apex legality, and final-assignment warnings distinguish enforced fields from
+  deliberately stricter guidance for locals and parameters (#124)
 - Duplicate annotations on declarations are now reported as errors, including annotations with different or unrecognized arguments (#287)
 - Abstract and override methods with omitted or private visibility now report an error, matching the latest Apex compiler behaviour (#386)
 - Set assignments and List/Set constructor initializers now enforce the platform's collection element-type compatibility rules (#318)

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
@@ -907,7 +907,8 @@ final case class BinaryExpression(lhs: Expression, rhs: Expression, op: String) 
         s"Expecting instance for operation, not type '${rightInter.typeName}'"
       )
 
-    // TODO Remove temporary warning, add getReadOnlyError calls back to each operation verify
+    // Keep these as warnings: Apex permits assignment to final locals and parameters, and a
+    // stricter apex-ls warning is far less disruptive than a false error.
     operation match {
       case AssignmentOperation | BitwiseAssignmentOperation |
           ArithmeticAddSubtractAssignmentOperation | ArithmeticMultiplyDivideAssignmentOperation =>

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Operations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Operations.scala
@@ -106,18 +106,25 @@ abstract class Operation {
   ): Option[String] = {
     exprContext.locatable match {
       case Some(variable: VariableDeclarator) if variable.isReadOnly =>
-        Some(s"Variable '${variable.id.name.value}' can not be assigned to, it is final")
+        Some(s"Variable '${variable.id.name.value}' should not be assigned to, it is final")
+      case Some(field: ApexFieldDeclaration)
+          if field.isReadOnly &&
+            isFinalStaticFieldAssignedFromInstanceInitializer(field, verifyContext) =>
+        Some(
+          s"Final static field '${field.name.value}' is assigned in an instance initializer, it will be reassigned on each construction, use a static initializer"
+        )
       case Some(field: ApexFieldDeclaration)
           if field.isReadOnly && !isFieldFinalInitialisationContext(field, verifyContext) =>
-        // Final fields can be set in ctor & init blocks
-        Some(s"Field '${field.name.value}' can not be assigned to, it is final")
+        Some(
+          s"Field '${field.name.value}' can not be assigned to here, final fields can only be assigned in their declaration, an init block, or a constructor"
+        )
       case Some(id: Id) if verifyContext.isVar(id.name).exists(_.isReadOnly) =>
         // For params the locatable only gives Id currently, so we need extra verification
         verifyContext
           .isVar(id.name)
           .flatMap(varDetails =>
             if (varDetails.isReadOnly && varDetails.definition.contains(id))
-              Some(s"Parameter '${id.name.value}' can not be assigned to, it is final")
+              Some(s"Parameter '${id.name.value}' should not be assigned to, it is final")
             else None
           )
       case _ => None
@@ -132,6 +139,20 @@ abstract class Operation {
       case bodyContext: BodyDeclarationVerifyContext =>
         bodyContext.isFieldFinalInitialisationContext(field)
       case _ => context.parent().exists(parent => isFieldFinalInitialisationContext(field, parent))
+    }
+  }
+
+  private def isFinalStaticFieldAssignedFromInstanceInitializer(
+    field: ApexFieldDeclaration,
+    context: VerifyContext
+  ): Boolean = {
+    context match {
+      case bodyContext: BodyDeclarationVerifyContext =>
+        bodyContext.isFinalStaticFieldAssignedFromInstanceInitializer(field)
+      case _ =>
+        context
+          .parent()
+          .exists(parent => isFinalStaticFieldAssignedFromInstanceInitializer(field, parent))
     }
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/VerifyContext.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/VerifyContext.scala
@@ -310,9 +310,17 @@ final class BodyDeclarationVerifyContext(
         (thisType.typeName == field.thisType.typeName ||
           thisType.extendsOrImplements(field.thisType.typeName))
       case block: ApexInitializerBlock =>
-        field.isStatic == block.isStatic && block.thisType.typeId == field.thisTypeId
+        (!block.isStatic || field.isStatic) && block.thisType.typeId == field.thisTypeId
       case property: ApexPropertyDeclaration =>
         property == field
+      case _ => false
+    }
+  }
+
+  def isFinalStaticFieldAssignedFromInstanceInitializer(field: ApexFieldDeclaration): Boolean = {
+    classBodyDeclaration match {
+      case block: ApexInitializerBlock =>
+        field.isStatic && !block.isStatic && block.thisType.typeId == field.thisTypeId
       case _ => false
     }
   }

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/FinalTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/FinalTest.scala
@@ -9,15 +9,16 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class FinalTest extends AnyFunSuite with TestHelper {
 
-  // Apex does not always enforce 'final', we are trying to do better ;-)
-  // There are likely additional cases where we should enforce read-only, here we only have known cases to date
+  // Apex permits reassignment of final locals and parameters, but restricts final fields by
+  // context. It also permits static final fields in instance initializers; apex-ls warns about
+  // that likely accidental pattern and the stricter local and parameter guidance.
 
   test("Initialised local") {
     typeDeclaration("public class Dummy {{final String a=''; a = 'a';}}")
 
     assert(
       dummyIssues ==
-        "Warning: line 1 at 40-47: Variable 'a' can not be assigned to, it is final\n"
+        "Warning: line 1 at 40-47: Variable 'a' should not be assigned to, it is final\n"
     )
   }
 
@@ -25,7 +26,7 @@ class FinalTest extends AnyFunSuite with TestHelper {
     typeDeclaration("public class Dummy {{final String a; a = 'a';}}")
     assert(
       dummyIssues ==
-        "Warning: line 1 at 37-44: Variable 'a' can not be assigned to, it is final\n"
+        "Warning: line 1 at 37-44: Variable 'a' should not be assigned to, it is final\n"
     )
   }
 
@@ -33,7 +34,7 @@ class FinalTest extends AnyFunSuite with TestHelper {
     typeDeclaration("public class Dummy {final String a=''; void func(){a += 'a';}}")
     assert(
       dummyIssues ==
-        "Warning: line 1 at 51-59: Field 'a' can not be assigned to, it is final\n"
+        "Warning: line 1 at 51-59: Field 'a' can not be assigned to here, final fields can only be assigned in their declaration, an init block, or a constructor\n"
     )
   }
 
@@ -41,7 +42,7 @@ class FinalTest extends AnyFunSuite with TestHelper {
     typeDeclaration("public class Dummy {final String a; void func(){a += 'a';}}")
     assert(
       dummyIssues ==
-        "Warning: line 1 at 48-56: Field 'a' can not be assigned to, it is final\n"
+        "Warning: line 1 at 48-56: Field 'a' can not be assigned to here, final fields can only be assigned in their declaration, an init block, or a constructor\n"
     )
   }
 
@@ -49,7 +50,7 @@ class FinalTest extends AnyFunSuite with TestHelper {
     typeDeclaration("public class Dummy {final static String a=''; void func(){a += 'a';}}")
     assert(
       dummyIssues ==
-        "Warning: line 1 at 58-66: Field 'a' can not be assigned to, it is final\n"
+        "Warning: line 1 at 58-66: Field 'a' can not be assigned to here, final fields can only be assigned in their declaration, an init block, or a constructor\n"
     )
   }
 
@@ -57,7 +58,7 @@ class FinalTest extends AnyFunSuite with TestHelper {
     typeDeclaration("public class Dummy {final static String a; void func(){a += 'a';}}")
     assert(
       dummyIssues ==
-        "Warning: line 1 at 55-63: Field 'a' can not be assigned to, it is final\n"
+        "Warning: line 1 at 55-63: Field 'a' can not be assigned to here, final fields can only be assigned in their declaration, an init block, or a constructor\n"
     )
   }
 
@@ -71,11 +72,21 @@ class FinalTest extends AnyFunSuite with TestHelper {
     assert(dummyIssues.isEmpty)
   }
 
-  test("Static field assignment not allowed in instance init") {
+  test("Static final field assignment in instance init warns") {
     typeDeclaration("public class Dummy {final static String a; {a += 'a';}}")
     assert(
       dummyIssues ==
-        "Warning: line 1 at 44-52: Field 'a' can not be assigned to, it is final\n"
+        "Warning: line 1 at 44-52: Final static field 'a' is assigned in an instance initializer, it will be reassigned on each construction, use a static initializer\n"
+    )
+  }
+
+  test("Instance field assignment not allowed in static init") {
+    typeDeclaration("public class Dummy {final String a; static {Dummy d; d.a = ''; d.a += 'a';}}")
+    assert(
+      dummyIssues ==
+        """Warning: line 1 at 53-61: Field 'a' can not be assigned to here, final fields can only be assigned in their declaration, an init block, or a constructor
+          |Warning: line 1 at 63-73: Field 'a' can not be assigned to here, final fields can only be assigned in their declaration, an init block, or a constructor
+          |""".stripMargin
     )
   }
 
@@ -97,15 +108,50 @@ class FinalTest extends AnyFunSuite with TestHelper {
     typeDeclaration("public class Dummy {final static String a; Dummy(){a += 'a';}}")
     assert(
       dummyIssues ==
-        "Warning: line 1 at 51-59: Field 'a' can not be assigned to, it is final\n"
+        "Warning: line 1 at 51-59: Field 'a' can not be assigned to here, final fields can only be assigned in their declaration, an init block, or a constructor\n"
     )
+  }
+
+  test("Apex final field initialisation contexts with plain assignment") {
+    typeDeclaration("""public class Dummy {
+        |  static final String staticValue;
+        |  final String instanceValue;
+        |  { staticValue = 'a'; instanceValue = 'a'; }
+        |  static { staticValue = 'a'; }
+        |  Dummy() { instanceValue = 'a'; }
+        |}
+        |""".stripMargin)
+    assert(
+      dummyIssues ==
+        "Warning: line 4 at 4-21: Final static field 'staticValue' is assigned in an instance initializer, it will be reassigned on each construction, use a static initializer\n"
+    )
+  }
+
+  test("Apex final field initialisation contexts with compound assignment") {
+    typeDeclaration("""public class Dummy {
+        |  static final String staticValue;
+        |  final String instanceValue;
+        |  { staticValue += 'a'; instanceValue += 'a'; }
+        |  static { staticValue += 'a'; }
+        |  Dummy() { instanceValue += 'a'; }
+        |}
+        |""".stripMargin)
+    assert(
+      dummyIssues ==
+        "Warning: line 4 at 4-22: Final static field 'staticValue' is assigned in an instance initializer, it will be reassigned on each construction, use a static initializer\n"
+    )
+  }
+
+  test("Non-final static field assignment in instance init is allowed") {
+    typeDeclaration("public class Dummy {static String a; {a = ''; a += 'a';}}")
+    assert(dummyIssues.isEmpty)
   }
 
   test("Parameter not assignable in instance method") {
     typeDeclaration("public class Dummy {void func(final Integer a) {a &= 1;}}")
     assert(
       dummyIssues ==
-        "Warning: line 1 at 48-54: Parameter 'a' can not be assigned to, it is final\n"
+        "Warning: line 1 at 48-54: Parameter 'a' should not be assigned to, it is final\n"
     )
   }
 
@@ -113,7 +159,7 @@ class FinalTest extends AnyFunSuite with TestHelper {
     typeDeclaration("public class Dummy {static void func(final Integer a) {a &= 1;}}")
     assert(
       dummyIssues ==
-        "Warning: line 1 at 55-61: Parameter 'a' can not be assigned to, it is final\n"
+        "Warning: line 1 at 55-61: Parameter 'a' should not be assigned to, it is final\n"
     )
   }
 
@@ -121,7 +167,7 @@ class FinalTest extends AnyFunSuite with TestHelper {
     typeDeclaration("public class Dummy {enum MyEnum {A} void func(){MyEnum.A = null;} }")
     assert(
       dummyIssues ==
-        "Warning: line 1 at 48-63: Field 'A' can not be assigned to, it is final\n"
+        "Warning: line 1 at 48-63: Field 'A' can not be assigned to here, final fields can only be assigned in their declaration, an init block, or a constructor\n"
     )
   }
 


### PR DESCRIPTION
Closes #124

## Summary

- use advisory wording for deliberately stricter final-local and final-parameter warnings
- make field diagnostics describe the Apex-legal initialization contexts
- keep final-assignment diagnostics as warnings and document why
- model Apex's asymmetric initializer rule: instance initializers may assign static final fields, while static initializers may not assign instance final fields
- warn specifically when a static final is assigned from an instance initializer because it is reassigned on every construction

## Apex API 67.0 org checks

Validated with `sf project deploy start --dry-run -o pre-release` in a temporary local SFDX project. Dry runs persisted no metadata or other org state.

- Static final field assigned in a constructor:
  - plain `=`: rejected with `Final members can only be assigned in their declaration, init blocks, or constructors: value`
  - compound `+=`: rejected with the same message
  - this matches the existing apex-ls constructor expectation, which remains unchanged
- Protected final superclass field assigned in a subclass constructor:
  - accepted; the dry run succeeded with no compiler diagnostic
  - this matches the existing apex-ls expectation
- Enum constant assignment (`Example.A = null`):
  - rejected with `Final members can only be assigned in their declaration, init blocks, or constructors: A`
  - this matches the existing apex-ls expectation
- Static final field assigned in an instance initializer:
  - both plain `=` and compound `+=` were accepted with no compiler diagnostic
  - this contradicted the former `FinalTest.scala` expectation. The behavior now models Apex legality but emits the approved advisory: `Final static field 'a' is assigned in an instance initializer, it will be reassigned on each construction, use a static initializer`.

Plain and compound assignment did not differ in any checked context. `getReadOnlyError` continues to cover both through the same warning path.

## Snapshot delta

After initializing the pinned `apex-samples` submodules and regenerating the system snapshots, there was no tracked snapshot delta. None of the pinned samples currently exercises these final-assignment diagnostics, so there were no warning additions, removals, or rewordings in the snapshot file.

## Tests

- `sbt -batch scalafmtAll`
- `sbt -batch 'apexlsJVM/testOnly com.nawforce.apexlink.cst.FinalTest'`
- `sbt -batch apexlsJVM/test` — 2,528 tests passed
- `sbt -batch apexlsJVM/build`
- `npm run test-snapshot -- --runInBand` — 100 samples passed; snapshots unchanged