### PR TITLE
fix: resolve Formula API exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Static final assignments from instance initializer blocks now receive targeted advisory guidance
   matching Apex legality, and final-assignment warnings distinguish enforced fields from
   deliberately stricter guidance for locals and parameters (#124)
+- `System.FormulaValidationException` and `System.FormulaEvaluationException` now resolve in valid
+  catch clauses (#514)
 - Duplicate annotations on declarations are now reported as errors, including annotations with different or unrecognized arguments (#287)
 - Abstract and override methods with omitted or private visibility now report an error, matching the latest Apex compiler behaviour (#386)
 - Set assignments and List/Set constructor initializers now enforce the platform's collection element-type compatibility rules (#318)

--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ lazy val apexls = crossProject(JSPlatform, JVMPlatform)
       "io.github.apex-dev-tools" % "apex-parser"                    % "5.1.0",
       "io.github.apex-dev-tools" % "vf-parser"                      % "2.0.0",
       "io.github.apex-dev-tools" % "sobject-types"                  % "67.0.0",
-      "io.github.apex-dev-tools" % "standard-types"                 % "67.0.0",
+      "io.github.apex-dev-tools" % "standard-types"                 % "67.0.1",
       "io.methvin"              %% "directory-watcher-better-files" % "0.18.0",
       "com.github.nawforce"      % "uber-apex-jorje"                % "1.0.0" % Test,
       "com.google.jimfs"         % "jimfs"                          % "1.1"   % Test

--- a/js/npm/snapshots/system/SampleCheckSys.ts.snap
+++ b/js/npm/snapshots/system/SampleCheckSys.ts.snap
@@ -34379,10 +34379,6 @@ exports[`Check samples Sample: apex-trigger-actions-framework 1`] = `
       "Unused: line 34 at 46-55: Unused field 'OPERATION'",
     ],
     [
-      "trigger-actions-framework/main/default/classes/FormulaFilter.cls",
-      "Missing: line 163 at 11-44: No type declaration found for 'System.FormulaValidationException'",
-    ],
-    [
       "trigger-actions-framework/main/default/classes/FormulaFilterTest.cls",
       "Unused: line 332 at 17-23: Unused property 'record'",
       "Unused: line 337 at 17-28: Unused property 'recordPrior'",

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/CatchTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/CatchTest.scala
@@ -12,6 +12,13 @@ class CatchTest extends AnyFunSuite with TestHelper {
     happyTypeDeclaration("public class Dummy {{ try {} catch (AssertException a) {} }}")
   }
 
+  test("Catch formula exceptions") {
+    happyTypeDeclaration("""public class Dummy {{
+        |  try {} catch (System.FormulaValidationException validationException) {}
+        |  try {} catch (System.FormulaEvaluationException evaluationException) {}
+        |}}""".stripMargin)
+  }
+
   test("Catch custom exception") {
     typeDeclarations(
       Map(

--- a/jvm/src/test/scala/com/nawforce/apexlink/pkg/CompletionProviderTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/pkg/CompletionProviderTest.scala
@@ -73,10 +73,7 @@ class CompletionProviderTest extends AnyFunSuite with TestHelper {
       |  @TestVisible private class TestVisibleType {}
       |}""".stripMargin
 
-  private def staticCompletionLabels(
-    root: PathLike,
-    declaration: String
-  ): Set[String] = {
+  private def staticCompletionLabels(root: PathLike, declaration: String): Set[String] = {
     val org     = createOrg(root)
     val path    = root.join("Completion.cls")
     val content = s"$declaration { static void complete() { VisibilityTarget."
@@ -116,19 +113,17 @@ class CompletionProviderTest extends AnyFunSuite with TestHelper {
 
       val subtypeLabels =
         staticCompletionLabels(root, "public class Completion extends VisibilityTarget")
-      assert(
-        Set("protectedField", "protectedMethod()").subsetOf(subtypeLabels)
-      )
+      assert(Set("protectedField", "protectedMethod()").subsetOf(subtypeLabels))
     }
   }
 
   test("Static completions without a caller remain public") {
     FileSystemHelper.run(Map("VisibilityTarget.cls" -> testVisibleContent)) { root: PathLike =>
-      val org          = createOrg(root)
-      val content      = "VisibilityTarget."
-      val completions  =
+      val org     = createOrg(root)
+      val content = "VisibilityTarget."
+      val completions =
         org.getCompletionItemsInternal(root.join("Completion.cls"), 1, content.length, content)
-      val labels       = completions.map(_.label).toSet
+      val labels = completions.map(_.label).toSet
       val nonPublicSet = Set(
         "protectedField",
         "protectedMethod()",

--- a/jvm/src/test/scala/com/nawforce/apexlink/types/PlatformTypesValidationTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/types/PlatformTypesValidationTest.scala
@@ -42,7 +42,7 @@ class PlatformTypesValidationTest extends AnyFunSuite with TestHelper {
   )
 
   test("Right number of types (should exclude inners)") {
-    assert(PlatformTypeDeclaration.classNames.size == 6510)
+    assert(PlatformTypeDeclaration.classNames.size == 6512)
   }
 
   test("SObject type is visible") {


### PR DESCRIPTION
## Summary

- bump `io.github.apex-dev-tools:standard-types` from 67.0.0 to 67.0.1
- add focused catch-clause coverage for `System.FormulaValidationException` and `System.FormulaEvaluationException`
- update the platform-type count and remove the obsolete sample diagnostic
- leave `sobject-types` at 67.0.0 because sbt resolves the direct standard-types 67.0.1 dependency correctly

This restores validation for valid Apex catch clauses using the documented Formula API exceptions.

Closes #514

## Validation

- Maven Central POM and JAR URLs for standard-types 67.0.1 returned HTTP 200
- resolved JVM classpath contains `standard-types-67.0.1.jar` and `sobject-types-67.0.0.jar`
- `sbt scalafmtCheckAll`
- `sbt "apexlsJVM/testOnly com.nawforce.apexlink.cst.CatchTest"` - 5 tests passed
- `sbt apexlsJVM/test` - 2,525 tests passed across 116 suites

The sample-project suite was not run locally because the sibling apex-samples checkout has
uninitialized submodules; the obsolete expected snapshot diagnostic was updated directly.
