### PR TITLE
chore: release 6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Fix completion omitting `@TestVisible` members in test classes.
-
-- Warn when implementing an interface or inherited abstract method with a static method could be
-  confusing.
+## [6.2.0] - 2026-07-29
 
 ### Added
 
+- Warnings when a static method implements an interface method or inherited abstract method, since
+  static implementations of instance contracts can be confusing (#351)
 - Documentation and clarified diagnostics for the deliberate difference between apex-ls package-directory handling and Salesforce's merged deployment behaviour (#339)
 - `dependencyCountAliases` `sfdx-project.json` option to define named (and optionally nested) presets for `// MaxDependencyCount(...)`, so `// MaxDependencyCount(med)` or `// MaxDependencyCount(group.name)` can be used instead of repeating raw numbers across files (#324)
 
 ### Fixed
 
+- Completions from test classes now include accessible `@TestVisible` members (#522)
 - Static final assignments from instance initializer blocks now receive targeted advisory guidance
   matching Apex legality, and final-assignment warnings distinguish enforced fields from
   deliberately stricter guidance for locals and parameters (#124)


### PR DESCRIPTION
## Summary

- move the accumulated changelog entries into a dated `6.2.0` section and restore an empty `Unreleased` section
- normalize the static-contract warning under `Added` and the `@TestVisible` completion fix under `Fixed`
- keep project versioning tag-derived; no literal source version is added

The notes were cross-checked against all 14 closed issues in milestone 6.2.0 and all 15 merged PRs plus commits since `v6.1.0`.

## Validation

- `git diff --check`
- changelog heading, date, issue-reference uniqueness, and release-range checks
- `sbt -batch scalafmtCheckAll` — blocked during project loading by the linked-worktree sbt-git/JGit `NoWorkTreeException`; no Scala sources changed

## Release step

After merge, publish the `v6.2.0` GitHub Release/tag on the release commit to trigger the Maven publish workflow. npm remains deprecated and is not published automatically.