### PR TITLE
Add versioned JVM batch dispatcher and JSON protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- A versioned JVM batch dispatcher with centralized workspace, cache, and parser options, stable
-  JSON result/error envelopes, and machine-clean stdout for one-shot analysis integrations (#527)
+- A versioned JVM batch dispatcher with centralized workspace and cache options, stable JSON
+  result/error envelopes, and machine-clean stdout for one-shot analysis integrations (#527)
 
 ## [6.2.0] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A versioned JVM batch dispatcher with centralized workspace, cache, and parser options, stable
+  JSON result/error envelopes, and machine-clean stdout for one-shot analysis integrations (#527)
+
 ## [6.2.0] - 2026-07-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,10 +46,9 @@ JVM batch integrations should use the versioned dispatcher instead:
   ```
 
 The dispatcher writes exactly one UTF-8 JSON response to stdout. Its shared options are
-`--workspace <path>`, `--cache-dir <path>`, `--no-cache`, and
-`--parser <ANTLR|OutlineSingle|OutlineMulti>`. The initial `ping` command provides a lightweight
-way to verify the distribution and protocol. Exit status `0` indicates success, `1` indicates an
-invalid command, argument, or request scope, and `3` indicates a workspace, analysis,
+`--workspace <path>`, `--cache-dir <path>`, and `--no-cache`. The initial `ping` command provides a
+lightweight way to verify the distribution and protocol. Exit status `0` indicates success, `1`
+indicates an invalid command, argument, or request scope, and `3` indicates a workspace, analysis,
 serialization, or unexpected internal failure. Logs and exception details are written to stderr.
 Stable error codes are `INVALID_ARGUMENT`, `UNKNOWN_COMMAND`, `INVALID_SCOPE`,
 `WORKSPACE_LOAD_FAILED`, `ANALYSIS_FAILED`, `SERIALIZATION_FAILED`, and `INTERNAL_ERROR`.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,33 @@ The jar is also executable without a client via the commands, `CheckForIssues` a
   java -cp "apex-ls*.jar" io.github.apexdevtools.apexls.<CommandName> [args]
   ```
 
+JVM batch integrations should use the versioned dispatcher instead:
+
+  ```sh
+  java -cp "<apex-ls distribution>/*" io.github.apexdevtools.apexls.Batch <command> [options]
+  ```
+
+The dispatcher writes exactly one UTF-8 JSON response to stdout. Its shared options are
+`--workspace <path>`, `--cache-dir <path>`, `--no-cache`, and
+`--parser <ANTLR|OutlineSingle|OutlineMulti>`. The initial `ping` command provides a lightweight
+way to verify the distribution and protocol. Exit status `0` indicates success, `1` indicates an
+invalid command, argument, or request scope, and `3` indicates a workspace, analysis,
+serialization, or unexpected internal failure. Logs and exception details are written to stderr.
+Stable error codes are `INVALID_ARGUMENT`, `UNKNOWN_COMMAND`, `INVALID_SCOPE`,
+`WORKSPACE_LOAD_FAILED`, `ANALYSIS_FAILED`, `SERIALIZATION_FAILED`, and `INTERNAL_ERROR`.
+
+Every response uses protocol version 1 and has the same envelope:
+
+  ```json
+  {
+    "protocolVersion": 1,
+    "command": "ping",
+    "ok": true,
+    "result": {},
+    "error": null
+  }
+  ```
+
 The following arguments are available:
 
 | Argument             | Description                                                                                        | Supported Commands |

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ ThisBuild / resolvers += Resolver.sonatypeCentralSnapshots
 lazy val build      = taskKey[File]("Build artifacts")
 lazy val pack       = inputKey[Unit]("Publish specific local version")
 lazy val npmInstall = taskKey[Unit]("Install Node modules for Scala.js tasks")
+lazy val batchDistributionTest = taskKey[Unit]("Test the packaged JVM batch dispatcher")
 lazy val Dev        = config("dev") extend Compile
 
 // Don't publish root
@@ -54,7 +55,12 @@ lazy val apexls = crossProject(JSPlatform, JVMPlatform)
   .jvmSettings(
     javacOptions ++= Seq("--release", "8"),
     scalacOptions ++= Seq("-release", "8"),
-    build       := buildJVM.value,
+    build := buildJVM.value,
+    batchDistributionTest := testBatchDistribution(
+      build.value,
+      crossTarget.value,
+      streams.value.log
+    ),
     Test / fork := true,
     Test / javaOptions ++= enableNativeAccessForJdk24Plus.value,
     libraryDependencies ++= Seq(
@@ -117,6 +123,37 @@ def buildJs(jsTask: TaskKey[Attributed[Report]]): Def.Initialize[Task[File]] = D
   syncNodeModules.value
 
   targetFile
+}
+
+def testBatchDistribution(targetJar: File, targetDir: File, log: Logger): Unit = {
+  val javaName = if (scala.util.Properties.isWin) "java.exe" else "java"
+  val javaExecutable = file(sys.props("java.home")) / "bin" / javaName
+  IO.withTemporaryDirectory { temporaryDirectory =>
+    val workspace = temporaryDirectory / "workspace with spaces"
+    IO.createDirectory(workspace)
+    val stdout = new StringBuilder
+    val stderr = new StringBuilder
+    val command = Seq(
+      javaExecutable.getAbsolutePath,
+      "-cp",
+      (targetDir / "*").getAbsolutePath,
+      "io.github.apexdevtools.apexls.Batch",
+      "ping",
+      "--workspace",
+      workspace.getAbsolutePath
+    )
+    val logger = ProcessLogger(stdout append _ append '\n', stderr append _ append '\n')
+    val status = Process(command) ! logger
+    val expected =
+      """{"protocolVersion":1,"command":"ping","ok":true,"result":{},"error":null}"""
+    if (status != 0 || stdout.toString.trim != expected) {
+      sys.error(
+        s"Packaged batch dispatcher failed (status $status, jar $targetJar): " +
+          s"stdout=${stdout.toString.trim}, stderr=${stderr.toString.trim}"
+      )
+    }
+  }
+  log.info("Packaged JVM batch dispatcher passed wildcard-classpath execution")
 }
 
 def syncNodeModules: Def.Initialize[Task[Unit]] = Def.task {

--- a/jvm/src/main/scala/io/github/apexdevtools/apexls/Batch.scala
+++ b/jvm/src/main/scala/io/github/apexdevtools/apexls/Batch.scala
@@ -1,0 +1,359 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package io.github.apexdevtools.apexls
+
+import com.nawforce.apexlink.api.Org
+import com.nawforce.apexlink.rpc.OpenOptions
+import com.nawforce.runtime.platform.Path
+
+import java.io.{OutputStream, PrintStream}
+import java.nio.charset.StandardCharsets
+import scala.collection.mutable
+import scala.util.control.NonFatal
+
+/** Versioned, machine-readable entry point for one-shot JVM analysis commands. */
+object Batch {
+  private final val StatusOk       = 0
+  private final val StatusArgument = 1
+  private final val StatusInternal = 3
+
+  private val commands: Seq[BatchCommand] = Seq(PingCommand)
+
+  def main(args: Array[String]): Unit = {
+    System.exit(run(args, System.out, System.err))
+  }
+
+  /** Run a batch invocation, writing exactly one UTF-8 JSON document and newline to stdout. */
+  def run(args: Array[String], stdout: OutputStream, stderr: OutputStream): Int = {
+    run(args, stdout, stderr, commands, DefaultBatchWorkspaceLoader, BatchProtocol.write)
+  }
+
+  private[apexls] def run(
+    args: Array[String],
+    stdout: OutputStream,
+    stderr: OutputStream,
+    availableCommands: Seq[BatchCommand],
+    workspaceLoader: BatchWorkspaceLoader,
+    encoder: BatchEnvelope => String
+  ): Int = synchronized {
+    val diagnosticStream = stderr match {
+      case stream: PrintStream => stream
+      case _                   => new PrintStream(stderr, true, StandardCharsets.UTF_8.name())
+    }
+    val originalStdout = System.out
+    val originalStderr = System.err
+
+    System.setOut(diagnosticStream)
+    System.setErr(diagnosticStream)
+    val (envelope, status) =
+      try {
+        Console.withOut(diagnosticStream) {
+          Console.withErr(diagnosticStream) {
+            dispatch(args.toIndexedSeq, availableCommands, workspaceLoader)
+          }
+        }
+      } catch {
+        case NonFatal(exception) =>
+          exception.printStackTrace(diagnosticStream)
+          failure("", "INTERNAL_ERROR", message(exception), StatusInternal)
+      }
+
+    val (json, finalStatus) =
+      try {
+        (encoder(envelope), status)
+      } catch {
+        case NonFatal(exception) =>
+          exception.printStackTrace(diagnosticStream)
+          val serializationFailure = BatchProtocol.failure(
+            envelope.command,
+            BatchError("SERIALIZATION_FAILED", message(exception))
+          )
+          (BatchProtocol.write(serializationFailure), StatusInternal)
+      } finally {
+        System.setOut(originalStdout)
+        System.setErr(originalStderr)
+      }
+
+    stdout.write(json.getBytes(StandardCharsets.UTF_8))
+    stdout.write('\n')
+    stdout.flush()
+    finalStatus
+  }
+
+  private def dispatch(
+    args: IndexedSeq[String],
+    availableCommands: Seq[BatchCommand],
+    workspaceLoader: BatchWorkspaceLoader
+  ): (BatchEnvelope, Int) = {
+    val commandName = args.headOption.getOrElse("")
+    if (commandName.isEmpty) {
+      return failure("", "INVALID_ARGUMENT", "A command is required", StatusArgument)
+    }
+
+    val commandByName = availableCommands.map(command => command.name -> command).toMap
+    commandByName.get(commandName) match {
+      case None =>
+        failure(commandName, "UNKNOWN_COMMAND", s"Unknown command '$commandName'", StatusArgument)
+      case Some(command) =>
+        BatchOptions.parse(args.tail) match {
+          case Left(error) => (BatchProtocol.failure(commandName, error), StatusArgument)
+          case Right((options, commandArguments)) =>
+            command.validate(commandArguments) match {
+              case Left(error) => (BatchProtocol.failure(commandName, error), StatusArgument)
+              case Right(_) =>
+                loadContext(command, options, workspaceLoader) match {
+                  case Left(dispatchFailure) =>
+                    (
+                      BatchProtocol.failure(commandName, dispatchFailure.error),
+                      dispatchFailure.status
+                    )
+                  case Right(context) =>
+                    try {
+                      command.execute(context, commandArguments) match {
+                        case Left(error) =>
+                          (BatchProtocol.failure(commandName, error), StatusArgument)
+                        case Right(result) => (BatchProtocol.success(commandName, result), StatusOk)
+                      }
+                    } catch {
+                      case NonFatal(exception) =>
+                        exception.printStackTrace(System.err)
+                        failure(commandName, "ANALYSIS_FAILED", message(exception), StatusInternal)
+                    }
+                }
+            }
+        }
+    }
+  }
+
+  private def loadContext(
+    command: BatchCommand,
+    options: BatchOptions,
+    workspaceLoader: BatchWorkspaceLoader
+  ): Either[BatchDispatchFailure, BatchContext] = {
+    if (!command.requiresWorkspace) {
+      Right(BatchContext(options, None))
+    } else {
+      try {
+        workspaceLoader.load(options).map(org => BatchContext(options, Some(org)))
+      } catch {
+        case NonFatal(exception) =>
+          exception.printStackTrace(System.err)
+          Left(
+            BatchDispatchFailure(
+              BatchError("WORKSPACE_LOAD_FAILED", message(exception)),
+              StatusInternal
+            )
+          )
+      }
+    }
+  }
+
+  private def failure(
+    command: String,
+    code: String,
+    errorMessage: String,
+    status: Int
+  ): (BatchEnvelope, Int) = {
+    (BatchProtocol.failure(command, BatchError(code, errorMessage)), status)
+  }
+
+  private def message(exception: Throwable): String = {
+    Option(exception.getMessage).filter(_.nonEmpty).getOrElse(exception.getClass.getSimpleName)
+  }
+
+  private object PingCommand extends BatchCommand {
+    override val name: String               = "ping"
+    override val requiresWorkspace: Boolean = false
+    override def execute(
+      context: BatchContext,
+      args: Seq[String]
+    ): Either[BatchError, BatchResult] =
+      Right(BatchPingResult())
+  }
+}
+
+private[apexls] final case class BatchOptions(
+  workspace: String,
+  cacheDirectory: Option[String],
+  cacheEnabled: Boolean,
+  parser: String
+)
+
+private[apexls] object BatchOptions {
+  private final val DefaultParser = "OutlineSingle"
+
+  def parse(args: IndexedSeq[String]): Either[BatchError, (BatchOptions, Seq[String])] = {
+    var workspace      = Option(System.getProperty("user.dir")).getOrElse(".")
+    var cacheDirectory = Option.empty[String]
+    var cacheEnabled   = true
+    var parser         = DefaultParser
+    var index          = 0
+    val commandArgs    = mutable.ArrayBuffer[String]()
+    val seen           = mutable.Set[String]()
+
+    def duplicate(option: String): Left[BatchError, Nothing] = {
+      Left(BatchError("INVALID_ARGUMENT", s"Option '$option' may only be provided once"))
+    }
+
+    def value(option: String, inline: Option[String]): Either[BatchError, String] = {
+      inline match {
+        case Some(candidate) if candidate.nonEmpty => Right(candidate)
+        case Some(_) => Left(BatchError("INVALID_ARGUMENT", s"Option '$option' requires a value"))
+        case None if index + 1 >= args.length =>
+          Left(BatchError("INVALID_ARGUMENT", s"Option '$option' requires a value"))
+        case None =>
+          index += 1
+          Right(args(index))
+      }
+    }
+
+    while (index < args.length) {
+      val token                 = args(index)
+      val (option, inlineValue) = splitOption(token)
+      option match {
+        case "--workspace" =>
+          if (!seen.add(option)) return duplicate(option)
+          value(option, inlineValue) match {
+            case Left(error)      => return Left(error)
+            case Right(candidate) => workspace = candidate
+          }
+        case "--cache-dir" =>
+          if (!seen.add(option)) return duplicate(option)
+          value(option, inlineValue) match {
+            case Left(error)      => return Left(error)
+            case Right(candidate) => cacheDirectory = Some(candidate)
+          }
+        case "--parser" =>
+          if (!seen.add(option)) return duplicate(option)
+          value(option, inlineValue).flatMap(normalizeParser) match {
+            case Left(error)      => return Left(error)
+            case Right(candidate) => parser = candidate
+          }
+        case "--no-cache" =>
+          if (inlineValue.nonEmpty) {
+            return Left(BatchError("INVALID_ARGUMENT", "Option '--no-cache' does not take a value"))
+          }
+          if (!seen.add(option)) return duplicate(option)
+          cacheEnabled = false
+        case _ => commandArgs += token
+      }
+      index += 1
+    }
+
+    Right((BatchOptions(workspace, cacheDirectory, cacheEnabled, parser), commandArgs.toSeq))
+  }
+
+  private def splitOption(token: String): (String, Option[String]) = {
+    val index = token.indexOf('=')
+    if (index < 0) (token, None) else (token.substring(0, index), Some(token.substring(index + 1)))
+  }
+
+  private def normalizeParser(parser: String): Either[BatchError, String] = {
+    parser.toLowerCase match {
+      case "antlr"         => Right("ANTLR")
+      case "outlinesingle" => Right("OutlineSingle")
+      case "outlinemulti"  => Right("OutlineMulti")
+      case _ =>
+        Left(
+          BatchError(
+            "INVALID_ARGUMENT",
+            s"Unknown parser '$parser', expected 'ANTLR', 'OutlineSingle' or 'OutlineMulti'"
+          )
+        )
+    }
+  }
+}
+
+private[apexls] final case class BatchContext(options: BatchOptions, org: Option[Org])
+
+private[apexls] trait BatchCommand {
+  def name: String
+  def requiresWorkspace: Boolean
+  def validate(args: Seq[String]): Either[BatchError, Unit] = {
+    if (args.isEmpty) Right(())
+    else Left(BatchError("INVALID_ARGUMENT", s"Unexpected argument '${args.head}'"))
+  }
+  def execute(context: BatchContext, args: Seq[String]): Either[BatchError, BatchResult]
+}
+
+private[apexls] final case class BatchDispatchFailure(error: BatchError, status: Int)
+
+private[apexls] trait BatchWorkspaceLoader {
+  def load(options: BatchOptions): Either[BatchDispatchFailure, Org]
+}
+
+private[apexls] object DefaultBatchWorkspaceLoader extends BatchWorkspaceLoader {
+  private final val StatusArgument = 1
+  private final val StatusInternal = 3
+
+  override def load(options: BatchOptions): Either[BatchDispatchFailure, Org] = {
+    val workspace = Path(options.workspace)
+    if (!workspace.exists || !workspace.isDirectory) {
+      return Left(
+        BatchDispatchFailure(
+          BatchError("INVALID_SCOPE", s"Workspace '${options.workspace}' is not a directory"),
+          StatusArgument
+        )
+      )
+    }
+    if (!workspace.join("sfdx-project.json").isFile) {
+      return Left(
+        BatchDispatchFailure(
+          BatchError(
+            "INVALID_SCOPE",
+            s"Workspace '${options.workspace}' does not contain sfdx-project.json"
+          ),
+          StatusArgument
+        )
+      )
+    }
+
+    try {
+      val openOptions = OpenOptions
+        .default()
+        .withParser(options.parser)
+        .withLoggingLevel("none")
+        .withAutoFlush(enabled = false)
+        .withCache(options.cacheEnabled)
+        .withCacheDirectory(options.cacheDirectory.getOrElse(""))
+      val org = Org.newOrg(workspace, openOptions)
+      if (org.getProjectConfig().isEmpty) {
+        return Left(
+          BatchDispatchFailure(
+            BatchError("WORKSPACE_LOAD_FAILED", s"Unable to load workspace '${options.workspace}'"),
+            StatusInternal
+          )
+        )
+      }
+      if (options.cacheEnabled) {
+        org.flush()
+      }
+      Right(org)
+    } catch {
+      case NonFatal(exception) =>
+        Left(
+          BatchDispatchFailure(
+            BatchError(
+              "WORKSPACE_LOAD_FAILED",
+              Option(exception.getMessage)
+                .filter(_.nonEmpty)
+                .getOrElse(exception.getClass.getSimpleName)
+            ),
+            StatusInternal
+          )
+        )
+    }
+  }
+}

--- a/jvm/src/main/scala/io/github/apexdevtools/apexls/Batch.scala
+++ b/jvm/src/main/scala/io/github/apexdevtools/apexls/Batch.scala
@@ -133,7 +133,22 @@ object Batch {
                       command.execute(context, commandArguments) match {
                         case Left(error) =>
                           (BatchProtocol.failure(commandName, error), StatusArgument)
-                        case Right(result) => (BatchProtocol.success(commandName, result), StatusOk)
+                        case Right(result) =>
+                          try {
+                            (
+                              BatchProtocol.success(commandName, command.writeResult(result)),
+                              StatusOk
+                            )
+                          } catch {
+                            case NonFatal(exception) =>
+                              exception.printStackTrace(System.err)
+                              failure(
+                                commandName,
+                                "SERIALIZATION_FAILED",
+                                message(exception),
+                                StatusInternal
+                              )
+                          }
                       }
                     } catch {
                       case NonFatal(exception) =>
@@ -183,13 +198,14 @@ object Batch {
   }
 
   private object PingCommand extends BatchCommand {
+    override type Result = Unit
+
     override val name: String               = "ping"
     override val requiresWorkspace: Boolean = false
-    override def execute(
-      context: BatchContext,
-      args: Seq[String]
-    ): Either[BatchError, BatchResult] =
-      Right(BatchPingResult())
+    override def execute(context: BatchContext, args: Seq[String]): Either[BatchError, Unit] =
+      Right(())
+
+    override def writeResult(result: Unit): ujson.Value = ujson.Obj()
   }
 }
 
@@ -263,13 +279,16 @@ private[apexls] object BatchOptions {
 private[apexls] final case class BatchContext(options: BatchOptions, org: Option[Org])
 
 private[apexls] trait BatchCommand {
+  type Result
+
   def name: String
   def requiresWorkspace: Boolean
   def validate(args: Seq[String]): Either[BatchError, Unit] = {
     if (args.isEmpty) Right(())
     else Left(BatchError("INVALID_ARGUMENT", s"Unexpected argument '${args.head}'"))
   }
-  def execute(context: BatchContext, args: Seq[String]): Either[BatchError, BatchResult]
+  def execute(context: BatchContext, args: Seq[String]): Either[BatchError, Result]
+  def writeResult(result: Result): ujson.Value
 }
 
 private[apexls] final case class BatchDispatchFailure(error: BatchError, status: Int)

--- a/jvm/src/main/scala/io/github/apexdevtools/apexls/Batch.scala
+++ b/jvm/src/main/scala/io/github/apexdevtools/apexls/Batch.scala
@@ -196,18 +196,14 @@ object Batch {
 private[apexls] final case class BatchOptions(
   workspace: String,
   cacheDirectory: Option[String],
-  cacheEnabled: Boolean,
-  parser: String
+  cacheEnabled: Boolean
 )
 
 private[apexls] object BatchOptions {
-  private final val DefaultParser = "OutlineSingle"
-
   def parse(args: IndexedSeq[String]): Either[BatchError, (BatchOptions, Seq[String])] = {
     var workspace      = Option(System.getProperty("user.dir")).getOrElse(".")
     var cacheDirectory = Option.empty[String]
     var cacheEnabled   = true
-    var parser         = DefaultParser
     var index          = 0
     val commandArgs    = mutable.ArrayBuffer[String]()
     val seen           = mutable.Set[String]()
@@ -244,12 +240,6 @@ private[apexls] object BatchOptions {
             case Left(error)      => return Left(error)
             case Right(candidate) => cacheDirectory = Some(candidate)
           }
-        case "--parser" =>
-          if (!seen.add(option)) return duplicate(option)
-          value(option, inlineValue).flatMap(normalizeParser) match {
-            case Left(error)      => return Left(error)
-            case Right(candidate) => parser = candidate
-          }
         case "--no-cache" =>
           if (inlineValue.nonEmpty) {
             return Left(BatchError("INVALID_ARGUMENT", "Option '--no-cache' does not take a value"))
@@ -261,27 +251,12 @@ private[apexls] object BatchOptions {
       index += 1
     }
 
-    Right((BatchOptions(workspace, cacheDirectory, cacheEnabled, parser), commandArgs.toSeq))
+    Right((BatchOptions(workspace, cacheDirectory, cacheEnabled), commandArgs.toSeq))
   }
 
   private def splitOption(token: String): (String, Option[String]) = {
     val index = token.indexOf('=')
     if (index < 0) (token, None) else (token.substring(0, index), Some(token.substring(index + 1)))
-  }
-
-  private def normalizeParser(parser: String): Either[BatchError, String] = {
-    parser.toLowerCase match {
-      case "antlr"         => Right("ANTLR")
-      case "outlinesingle" => Right("OutlineSingle")
-      case "outlinemulti"  => Right("OutlineMulti")
-      case _ =>
-        Left(
-          BatchError(
-            "INVALID_ARGUMENT",
-            s"Unknown parser '$parser', expected 'ANTLR', 'OutlineSingle' or 'OutlineMulti'"
-          )
-        )
-    }
   }
 }
 
@@ -332,7 +307,6 @@ private[apexls] object DefaultBatchWorkspaceLoader extends BatchWorkspaceLoader 
     try {
       val openOptions = OpenOptions
         .default()
-        .withParser(options.parser)
         .withLoggingLevel("none")
         .withAutoFlush(enabled = false)
         .withCache(options.cacheEnabled)

--- a/jvm/src/main/scala/io/github/apexdevtools/apexls/Batch.scala
+++ b/jvm/src/main/scala/io/github/apexdevtools/apexls/Batch.scala
@@ -14,9 +14,10 @@
 
 package io.github.apexdevtools.apexls
 
-import com.nawforce.apexlink.api.Org
+import com.nawforce.apexlink.api.{Org, ServerOps}
 import com.nawforce.apexlink.rpc.OpenOptions
-import com.nawforce.runtime.platform.Path
+import com.nawforce.pkgforce.diagnostics.LoggerOps
+import com.nawforce.runtime.platform.{Environment, Path}
 
 import java.io.{OutputStream, PrintStream}
 import java.nio.charset.StandardCharsets
@@ -52,8 +53,12 @@ object Batch {
       case stream: PrintStream => stream
       case _                   => new PrintStream(stderr, true, StandardCharsets.UTF_8.name())
     }
-    val originalStdout = System.out
-    val originalStderr = System.err
+    val originalStdout         = System.out
+    val originalStderr         = System.err
+    val originalCacheDirectory = Environment.getCacheDirOverride
+    val originalAutoFlush      = ServerOps.isAutoFlushEnabled
+    val originalParser         = ServerOps.getCurrentParser
+    val originalLoggingLevel   = LoggerOps.getLoggingLevel
 
     System.setOut(diagnosticStream)
     System.setErr(diagnosticStream)
@@ -82,6 +87,10 @@ object Batch {
           )
           (BatchProtocol.write(serializationFailure), StatusInternal)
       } finally {
+        Environment.setCacheDirOverride(originalCacheDirectory)
+        ServerOps.setAutoFlush(originalAutoFlush)
+        ServerOps.setCurrentParser(originalParser)
+        LoggerOps.setLoggingLevel(originalLoggingLevel)
         System.setOut(originalStdout)
         System.setErr(originalStderr)
       }

--- a/jvm/src/main/scala/io/github/apexdevtools/apexls/BatchProtocol.scala
+++ b/jvm/src/main/scala/io/github/apexdevtools/apexls/BatchProtocol.scala
@@ -1,0 +1,73 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package io.github.apexdevtools.apexls
+
+import upickle.default.{macroRW, ReadWriter}
+
+/** A stable, machine-readable error returned by the JVM batch protocol. */
+final case class BatchError(code: String, message: String)
+
+/** A result returned by a JVM batch command. */
+trait BatchResult
+
+/** Empty result used by the protocol health-check command. */
+final case class BatchPingResult() extends BatchResult
+
+/** Versioned response envelope shared by all JVM batch commands. */
+final case class BatchEnvelope(
+  protocolVersion: Int,
+  command: String,
+  ok: Boolean,
+  result: Option[BatchResult],
+  error: Option[BatchError]
+)
+
+private[apexls] object BatchProtocol {
+  final val Version: Int = 1
+
+  implicit private val errorWriter: ReadWriter[BatchError]           = macroRW
+  implicit private val pingResultWriter: ReadWriter[BatchPingResult] = macroRW
+
+  def success(command: String, result: BatchResult): BatchEnvelope = {
+    BatchEnvelope(Version, command, ok = true, Some(result), None)
+  }
+
+  def failure(command: String, error: BatchError): BatchEnvelope = {
+    BatchEnvelope(Version, command, ok = false, None, Some(error))
+  }
+
+  def write(envelope: BatchEnvelope): String = {
+    val result = envelope.result match {
+      case Some(value: BatchPingResult) => upickle.default.writeJs(value)
+      case Some(value) =>
+        throw new IllegalArgumentException(s"Unsupported batch result '${value.getClass.getName}'")
+      case None => ujson.Null
+    }
+    val error = envelope.error match {
+      case Some(value) => upickle.default.writeJs(value)
+      case None        => ujson.Null
+    }
+
+    ujson.write(
+      ujson.Obj(
+        "protocolVersion" -> envelope.protocolVersion,
+        "command"         -> envelope.command,
+        "ok"              -> envelope.ok,
+        "result"          -> result,
+        "error"           -> error
+      )
+    )
+  }
+}

--- a/jvm/src/main/scala/io/github/apexdevtools/apexls/BatchProtocol.scala
+++ b/jvm/src/main/scala/io/github/apexdevtools/apexls/BatchProtocol.scala
@@ -19,28 +19,21 @@ import upickle.default.{macroRW, ReadWriter}
 /** A stable, machine-readable error returned by the JVM batch protocol. */
 final case class BatchError(code: String, message: String)
 
-/** A result returned by a JVM batch command. */
-trait BatchResult
-
-/** Empty result used by the protocol health-check command. */
-final case class BatchPingResult() extends BatchResult
-
 /** Versioned response envelope shared by all JVM batch commands. */
 final case class BatchEnvelope(
   protocolVersion: Int,
   command: String,
   ok: Boolean,
-  result: Option[BatchResult],
+  result: Option[ujson.Value],
   error: Option[BatchError]
 )
 
 private[apexls] object BatchProtocol {
   final val Version: Int = 1
 
-  implicit private val errorWriter: ReadWriter[BatchError]           = macroRW
-  implicit private val pingResultWriter: ReadWriter[BatchPingResult] = macroRW
+  implicit private val errorWriter: ReadWriter[BatchError] = macroRW
 
-  def success(command: String, result: BatchResult): BatchEnvelope = {
+  def success(command: String, result: ujson.Value): BatchEnvelope = {
     BatchEnvelope(Version, command, ok = true, Some(result), None)
   }
 
@@ -50,10 +43,8 @@ private[apexls] object BatchProtocol {
 
   def write(envelope: BatchEnvelope): String = {
     val result = envelope.result match {
-      case Some(value: BatchPingResult) => upickle.default.writeJs(value)
-      case Some(value) =>
-        throw new IllegalArgumentException(s"Unsupported batch result '${value.getClass.getName}'")
-      case None => ujson.Null
+      case Some(value) => value
+      case None        => ujson.Null
     }
     val error = envelope.error match {
       case Some(value) => upickle.default.writeJs(value)

--- a/jvm/src/test/scala/io/github/apexdevtools/apexls/BatchTest.scala
+++ b/jvm/src/test/scala/io/github/apexdevtools/apexls/BatchTest.scala
@@ -38,13 +38,13 @@ class BatchTest extends AnyFunSuite {
     assert(invocation.stdout.count(_ == '\n') == 1)
   }
 
-  test("a command may return a successful result") {
-    val command    = new TestCommand("success", requiresWorkspace = false)
-    val invocation = invoke(Array("success"), commands = Seq(command))
+  test("commands own serialization of their result shape") {
+    val invocation = invoke(Array("details"), commands = Seq(DetailsCommand))
 
     assert(invocation.status == 0)
     assert(invocation.json("ok").bool)
-    assert(invocation.json("result").obj.isEmpty)
+    assert(invocation.json("result")("count").num == 2)
+    assert(invocation.json("result")("label").str == "details")
   }
 
   test("missing and unknown commands are argument failures") {
@@ -192,6 +192,19 @@ class BatchTest extends AnyFunSuite {
     assert(invocation.stderr.contains("serialization broke"))
   }
 
+  test("command result encoding failures return serialization failures") {
+    val command = new TestCommand(
+      "serialize-result",
+      requiresWorkspace = false,
+      writer = _ => throw new IllegalStateException("result encoding broke")
+    )
+    val invocation = invoke(Array("serialize-result"), commands = Seq(command))
+
+    assert(invocation.status == 3)
+    assert(invocation.json("error")("code").str == "SERIALIZATION_FAILED")
+    assert(invocation.stderr.contains("result encoding broke"))
+  }
+
   private def invoke(
     args: Array[String],
     commands: Seq[BatchCommand] = Seq.empty,
@@ -227,21 +240,42 @@ class BatchTest extends AnyFunSuite {
   private class TestCommand(
     override val name: String,
     override val requiresWorkspace: Boolean,
-    action: BatchContext => BatchResult = _ => BatchPingResult()
+    action: BatchContext => Unit = _ => (),
+    writer: Unit => ujson.Value = _ => ujson.Obj()
   ) extends BatchCommand {
-    override def execute(
-      context: BatchContext,
-      args: Seq[String]
-    ): Either[BatchError, BatchResult] = Right(action(context))
+    override type Result = Unit
+
+    override def execute(context: BatchContext, args: Seq[String]): Either[BatchError, Unit] =
+      Right(action(context))
+
+    override def writeResult(result: Unit): ujson.Value = writer(result)
   }
 
   private object PingCommand extends BatchCommand {
+    override type Result = Unit
+
     override val name: String               = "ping"
     override val requiresWorkspace: Boolean = false
-    override def execute(
-      context: BatchContext,
-      args: Seq[String]
-    ): Either[BatchError, BatchResult] = Right(BatchPingResult())
+    override def execute(context: BatchContext, args: Seq[String]): Either[BatchError, Unit] =
+      Right(())
+
+    override def writeResult(result: Unit): ujson.Value = ujson.Obj()
+  }
+
+  private final class Details(val count: Int, val label: String)
+
+  private object DetailsCommand extends BatchCommand {
+    override type Result = Details
+
+    override val name: String               = "details"
+    override val requiresWorkspace: Boolean = false
+
+    override def execute(context: BatchContext, args: Seq[String]): Either[BatchError, Details] =
+      Right(new Details(2, "details"))
+
+    override def writeResult(result: Details): ujson.Value = {
+      ujson.Obj("count" -> result.count, "label" -> result.label)
+    }
   }
 
   private object NoWorkspaceLoader extends BatchWorkspaceLoader {

--- a/jvm/src/test/scala/io/github/apexdevtools/apexls/BatchTest.scala
+++ b/jvm/src/test/scala/io/github/apexdevtools/apexls/BatchTest.scala
@@ -60,10 +60,6 @@ class BatchTest extends AnyFunSuite {
   }
 
   test("invalid common and command options are argument failures") {
-    val invalidParser = invoke(Array("ping", "--parser", "not-a-parser"))
-    assert(invalidParser.status == 1)
-    assert(invalidParser.json("error")("code").str == "INVALID_ARGUMENT")
-
     val invalidOption = invoke(Array("ping", "--invalid"))
     assert(invalidOption.status == 1)
     assert(invalidOption.json("error")("code").str == "INVALID_ARGUMENT")
@@ -71,6 +67,13 @@ class BatchTest extends AnyFunSuite {
     val missingValue = invoke(Array("ping", "--workspace"))
     assert(missingValue.status == 1)
     assert(missingValue.json("error")("code").str == "INVALID_ARGUMENT")
+  }
+
+  test("parser selection is not a supported option") {
+    val invocation = invoke(Array("ping", "--parser", "OutlineSingle"))
+
+    assert(invocation.status == 1)
+    assert(invocation.json("error")("code").str == "INVALID_ARGUMENT")
   }
 
   test("invalid workspace scope is an argument failure") {
@@ -127,7 +130,7 @@ class BatchTest extends AnyFunSuite {
     }
   }
 
-  test("workspace, cache, and parser options are passed to workspace commands") {
+  test("workspace and cache options are passed to workspace commands") {
     val command  = new TestCommand("workspace", requiresWorkspace = true)
     val captures = collection.mutable.ArrayBuffer[BatchOptions]()
     val loader = new BatchWorkspaceLoader {
@@ -138,14 +141,7 @@ class BatchTest extends AnyFunSuite {
     }
 
     val cacheEnabled = invoke(
-      Array(
-        "workspace",
-        "--workspace",
-        "/workspace with spaces",
-        "--cache-dir=/cache with spaces",
-        "--parser",
-        "OutlineMulti"
-      ),
+      Array("workspace", "--workspace", "/workspace with spaces", "--cache-dir=/cache with spaces"),
       commands = Seq(command),
       loader = loader
     )
@@ -160,10 +156,8 @@ class BatchTest extends AnyFunSuite {
     assert(captures.head.workspace == "/workspace with spaces")
     assert(captures.head.cacheDirectory.contains("/cache with spaces"))
     assert(captures.head.cacheEnabled)
-    assert(captures.head.parser == "OutlineMulti")
     assert(captures(1).workspace == "/workspace with spaces")
     assert(!captures(1).cacheEnabled)
-    assert(captures(1).parser == "OutlineSingle")
   }
 
   test("thrown command exceptions return analysis failures and keep stdout clean") {

--- a/jvm/src/test/scala/io/github/apexdevtools/apexls/BatchTest.scala
+++ b/jvm/src/test/scala/io/github/apexdevtools/apexls/BatchTest.scala
@@ -1,0 +1,248 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package io.github.apexdevtools.apexls
+
+import com.nawforce.apexlink.api.Org
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+class BatchTest extends AnyFunSuite {
+
+  test("ping returns an empty successful result") {
+    val invocation = invoke(Array("ping"))
+
+    assert(invocation.status == 0)
+    assert(invocation.json("protocolVersion").num == 1)
+    assert(invocation.json("command").str == "ping")
+    assert(invocation.json("ok").bool)
+    assert(invocation.json("result").obj.isEmpty)
+    assert(invocation.json("error") == ujson.Null)
+    assert(invocation.stdout.endsWith("\n"))
+    assert(invocation.stdout.count(_ == '\n') == 1)
+  }
+
+  test("a command may return a successful result") {
+    val command    = new TestCommand("success", requiresWorkspace = false)
+    val invocation = invoke(Array("success"), commands = Seq(command))
+
+    assert(invocation.status == 0)
+    assert(invocation.json("ok").bool)
+    assert(invocation.json("result").obj.isEmpty)
+  }
+
+  test("missing and unknown commands are argument failures") {
+    val missing = invoke(Array.empty)
+    assert(missing.status == 1)
+    assert(missing.json("command").str.isEmpty)
+    assert(missing.json("error")("code").str == "INVALID_ARGUMENT")
+
+    val unknown = invoke(Array("not-a-command"))
+    assert(unknown.status == 1)
+    assert(unknown.json("command").str == "not-a-command")
+    assert(unknown.json("error")("code").str == "UNKNOWN_COMMAND")
+  }
+
+  test("invalid common and command options are argument failures") {
+    val invalidParser = invoke(Array("ping", "--parser", "not-a-parser"))
+    assert(invalidParser.status == 1)
+    assert(invalidParser.json("error")("code").str == "INVALID_ARGUMENT")
+
+    val invalidOption = invoke(Array("ping", "--invalid"))
+    assert(invalidOption.status == 1)
+    assert(invalidOption.json("error")("code").str == "INVALID_ARGUMENT")
+
+    val missingValue = invoke(Array("ping", "--workspace"))
+    assert(missingValue.status == 1)
+    assert(missingValue.json("error")("code").str == "INVALID_ARGUMENT")
+  }
+
+  test("invalid workspace scope is an argument failure") {
+    val command = new TestCommand("workspace", requiresWorkspace = true)
+    val invocation = invoke(
+      Array("workspace", "--workspace", "/path/that/does/not/exist"),
+      commands = Seq(command),
+      loader = DefaultBatchWorkspaceLoader
+    )
+
+    assert(invocation.status == 1)
+    assert(invocation.json("error")("code").str == "INVALID_SCOPE")
+  }
+
+  test("workspace loading failure is an execution failure") {
+    val command = new TestCommand("workspace", requiresWorkspace = true)
+    val loader = new BatchWorkspaceLoader {
+      override def load(options: BatchOptions): Either[BatchDispatchFailure, Org] = {
+        Left(BatchDispatchFailure(BatchError("WORKSPACE_LOAD_FAILED", "could not load"), 3))
+      }
+    }
+    val invocation = invoke(Array("workspace"), commands = Seq(command), loader = loader)
+
+    assert(invocation.status == 3)
+    assert(invocation.json("ok").bool == false)
+    assert(invocation.json("error")("code").str == "WORKSPACE_LOAD_FAILED")
+  }
+
+  test("malformed workspace configuration is a workspace loading failure") {
+    val workspace = Files.createTempDirectory("batch-workspace")
+    val project   = workspace.resolve("sfdx-project.json")
+    try {
+      Files.write(project, "{".getBytes(StandardCharsets.UTF_8))
+      val command = new TestCommand("workspace", requiresWorkspace = true)
+      val invocation = invoke(
+        Array("workspace", "--workspace", workspace.toString, "--no-cache"),
+        commands = Seq(command),
+        loader = DefaultBatchWorkspaceLoader
+      )
+
+      assert(invocation.status == 3)
+      assert(invocation.json("error")("code").str == "WORKSPACE_LOAD_FAILED")
+    } finally {
+      Files.deleteIfExists(project)
+      Files.deleteIfExists(workspace)
+    }
+  }
+
+  test("workspace, cache, and parser options are passed to workspace commands") {
+    val command  = new TestCommand("workspace", requiresWorkspace = true)
+    val captures = collection.mutable.ArrayBuffer[BatchOptions]()
+    val loader = new BatchWorkspaceLoader {
+      override def load(options: BatchOptions): Either[BatchDispatchFailure, Org] = {
+        captures += options
+        Right(null.asInstanceOf[Org])
+      }
+    }
+
+    val cacheEnabled = invoke(
+      Array(
+        "workspace",
+        "--workspace",
+        "/workspace with spaces",
+        "--cache-dir=/cache with spaces",
+        "--parser",
+        "OutlineMulti"
+      ),
+      commands = Seq(command),
+      loader = loader
+    )
+    val cacheDisabled = invoke(
+      Array("workspace", "--workspace=/workspace with spaces", "--no-cache"),
+      commands = Seq(command),
+      loader = loader
+    )
+
+    assert(cacheEnabled.status == 0)
+    assert(cacheDisabled.status == 0)
+    assert(captures.head.workspace == "/workspace with spaces")
+    assert(captures.head.cacheDirectory.contains("/cache with spaces"))
+    assert(captures.head.cacheEnabled)
+    assert(captures.head.parser == "OutlineMulti")
+    assert(captures(1).workspace == "/workspace with spaces")
+    assert(!captures(1).cacheEnabled)
+    assert(captures(1).parser == "OutlineSingle")
+  }
+
+  test("thrown command exceptions return analysis failures and keep stdout clean") {
+    val command = new TestCommand(
+      "throws",
+      requiresWorkspace = false,
+      action = _ => {
+        println("command noise")
+        throw new IllegalStateException("analysis broke")
+      }
+    )
+    val invocation = invoke(Array("throws"), commands = Seq(command))
+
+    assert(invocation.status == 3)
+    assert(invocation.json("error")("code").str == "ANALYSIS_FAILED")
+    assert(!invocation.stdout.contains("command noise"))
+    assert(invocation.stderr.contains("command noise"))
+    assert(invocation.stderr.contains("analysis broke"))
+  }
+
+  test("serialization failures return a valid fallback envelope") {
+    val command = new TestCommand("serialize", requiresWorkspace = false)
+    val invocation = invoke(
+      Array("serialize"),
+      commands = Seq(command),
+      encoder = _ => throw new IllegalStateException("serialization broke")
+    )
+
+    assert(invocation.status == 3)
+    assert(invocation.json("error")("code").str == "SERIALIZATION_FAILED")
+    assert(invocation.stdout.count(_ == '\n') == 1)
+    assert(invocation.stderr.contains("serialization broke"))
+  }
+
+  private def invoke(
+    args: Array[String],
+    commands: Seq[BatchCommand] = Seq.empty,
+    loader: BatchWorkspaceLoader = NoWorkspaceLoader,
+    encoder: BatchEnvelope => String = BatchProtocol.write
+  ): Invocation = {
+    val stdout           = new ByteArrayOutputStream()
+    val stderr           = new ByteArrayOutputStream()
+    val selectedCommands = if (commands.nonEmpty) commands else Seq(PingCommand)
+    val status           = Batch.run(args, stdout, stderr, selectedCommands, loader, encoder)
+    val stdoutText       = new String(stdout.toByteArray, StandardCharsets.UTF_8)
+    Invocation(
+      status,
+      stdoutText,
+      new String(stderr.toByteArray, StandardCharsets.UTF_8),
+      ujson.read(stdoutText)
+    )
+  }
+
+  private final class Invocation(
+    val status: Int,
+    val stdout: String,
+    val stderr: String,
+    val json: ujson.Value
+  )
+
+  private object Invocation {
+    def apply(status: Int, stdout: String, stderr: String, json: ujson.Value): Invocation = {
+      new Invocation(status, stdout, stderr, json)
+    }
+  }
+
+  private class TestCommand(
+    override val name: String,
+    override val requiresWorkspace: Boolean,
+    action: BatchContext => BatchResult = _ => BatchPingResult()
+  ) extends BatchCommand {
+    override def execute(
+      context: BatchContext,
+      args: Seq[String]
+    ): Either[BatchError, BatchResult] = Right(action(context))
+  }
+
+  private object PingCommand extends BatchCommand {
+    override val name: String               = "ping"
+    override val requiresWorkspace: Boolean = false
+    override def execute(
+      context: BatchContext,
+      args: Seq[String]
+    ): Either[BatchError, BatchResult] = Right(BatchPingResult())
+  }
+
+  private object NoWorkspaceLoader extends BatchWorkspaceLoader {
+    override def load(options: BatchOptions): Either[BatchDispatchFailure, Org] = {
+      fail("Workspace loader should not have been called")
+    }
+  }
+}

--- a/jvm/src/test/scala/io/github/apexdevtools/apexls/BatchTest.scala
+++ b/jvm/src/test/scala/io/github/apexdevtools/apexls/BatchTest.scala
@@ -14,7 +14,9 @@
 
 package io.github.apexdevtools.apexls
 
-import com.nawforce.apexlink.api.Org
+import com.nawforce.apexlink.api.{Org, ServerOps}
+import com.nawforce.pkgforce.diagnostics.LoggerOps
+import com.nawforce.runtime.platform.Environment
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.io.ByteArrayOutputStream
@@ -98,8 +100,12 @@ class BatchTest extends AnyFunSuite {
   }
 
   test("malformed workspace configuration is a workspace loading failure") {
-    val workspace = Files.createTempDirectory("batch-workspace")
-    val project   = workspace.resolve("sfdx-project.json")
+    val workspace              = Files.createTempDirectory("batch-workspace")
+    val project                = workspace.resolve("sfdx-project.json")
+    val originalCacheDirectory = Environment.getCacheDirOverride
+    val originalAutoFlush      = ServerOps.isAutoFlushEnabled
+    val originalParser         = ServerOps.getCurrentParser
+    val originalLoggingLevel   = LoggerOps.getLoggingLevel
     try {
       Files.write(project, "{".getBytes(StandardCharsets.UTF_8))
       val command = new TestCommand("workspace", requiresWorkspace = true)
@@ -111,6 +117,10 @@ class BatchTest extends AnyFunSuite {
 
       assert(invocation.status == 3)
       assert(invocation.json("error")("code").str == "WORKSPACE_LOAD_FAILED")
+      assert(Environment.getCacheDirOverride == originalCacheDirectory)
+      assert(ServerOps.isAutoFlushEnabled == originalAutoFlush)
+      assert(ServerOps.getCurrentParser == originalParser)
+      assert(LoggerOps.getLoggingLevel == originalLoggingLevel)
     } finally {
       Files.deleteIfExists(project)
       Files.deleteIfExists(workspace)


### PR DESCRIPTION
## Summary

- Add a versioned JVM `Batch` dispatcher.
- Add shared, stable JSON success/error envelopes and documented exit codes.
- Keep `BatchProtocol` generic while each typed `BatchCommand` owns its result encoding.
- Centralize workspace and cache option handling while using the normal internal parser behavior.
- Keep stdout machine-clean, with diagnostics and failures separated appropriately.
- Preserve the existing `CheckForIssues` and `DependencyReport` entry points and schemas unchanged.
- Include only a minimal `ping` command to validate dispatch; the #528 and #529 feature commands remain out of scope.
- Add comprehensive protocol tests and a packaged wildcard-classpath validation task.

## Validation

- `sbt scalafmtAll`
- Focused `BatchTest` and `CheckForIssuesTest`: 17 tests
- `sbt apexlsJVM/batchDistributionTest`
- `sbt apexlsJVM/test`: 2543 tests

Closes #527
