### PR TITLE
Add test class batch discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   result/error envelopes, and machine-clean stdout for one-shot analysis integrations (#527)
 - JVM batch commands for deterministic dependency reports, scoped dependency counts, and dependency
   bomb rankings (#528)
+- Public impacted and declared test-class discovery APIs, plus a deterministic `test-classes` JVM
+  batch command with dependency explanations and namespace-qualified names (#529)
 
 ## [6.2.0] - 2026-07-29
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,12 @@ JVM batch integrations should use the versioned dispatcher instead:
 
 The dispatcher writes exactly one UTF-8 JSON response to stdout. Its shared options are
 `--workspace <path>`, `--cache-dir <path>`, and `--no-cache`. Available commands are `ping`,
-`dependency-report`, `dependency-counts`, and `dependency-bombs`. `dependency-counts` additionally
+`dependency-report`, `dependency-counts`, `dependency-bombs`, and `test-classes`.
+`dependency-counts` additionally
 accepts `--scope <directory>` (workspace-relative or absolute within the workspace) and
 `--exclude-tests`; `dependency-bombs` accepts a non-negative `--count <n>` that defaults to 20.
+`test-classes` accepts `--mode impacted` with one or more repeatable `--path <path>` arguments, or
+`--mode all` with optional repeatable paths. Paths may be absolute or workspace-relative.
 Exit status `0` indicates success, `1` indicates an invalid command, argument, or request scope, and
 `3` indicates a workspace, analysis, serialization, or unexpected internal failure. Logs and
 exception details are written to stderr. Stable error codes are `INVALID_ARGUMENT`,

--- a/build.sbt
+++ b/build.sbt
@@ -139,7 +139,8 @@ def testBatchDistribution(targetJar: File, targetDir: File, log: Logger): Unit =
       "ping"              -> "{}",
       "dependency-report" -> "{\"nodes\":[]}",
       "dependency-counts" -> "{\"counts\":[]}",
-      "dependency-bombs"  -> "{\"bombs\":[]}"
+      "dependency-bombs"  -> "{\"bombs\":[]}",
+      "test-classes"      -> "{\"testClasses\":[]}"
     )
     commands.foreach { case (batchCommand, result) =>
       val stdout = new StringBuilder
@@ -153,7 +154,7 @@ def testBatchDistribution(targetJar: File, targetDir: File, log: Logger): Unit =
         "--workspace",
         workspace.getAbsolutePath,
         "--no-cache"
-      )
+      ) ++ (if (batchCommand == "test-classes") Seq("--mode", "all") else Seq.empty)
       val logger = ProcessLogger(stdout append _ append '\n', stderr append _ append '\n')
       val status = Process(command) ! logger
       val expected =

--- a/jvm/src/main/scala/com/nawforce/apexlink/api/Org.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/api/Org.scala
@@ -217,6 +217,26 @@ trait Org {
     */
   def getDependencyCounts(paths: Array[String], excludeTestClasses: Boolean): Array[DependencyCount]
 
+  /** Find test classes impacted by the passed set of Apex class paths.
+    *
+    * Results include direct and transitive references and references through supertypes,
+    * interfaces, and nested types. Each result contains a dependency explanation from the test
+    * class to a supplied type. Missing, deleted, and unrecognised paths are ignored.
+    *
+    * Class namespaces are included and results are ordered by name.
+    */
+  def getImpactedTestClasses(paths: Array[String]): Array[TestClass]
+
+  /** Find top-level test classes declared in the workspace or at the supplied Apex class paths.
+    *
+    * Pass an empty array to retrieve all declared test classes. Missing, unreadable, syntactically
+    * invalid, and non-test paths are ignored. Explanations are empty because this operation
+    * classifies declarations rather than dependencies.
+    *
+    * Class namespaces are included and results are ordered by name.
+    */
+  def getDeclaredTestClasses(paths: Array[String]): Array[TestClass]
+
   /** Find test class names that can be used to test the passed set of files.
     *
     * This calculates a set of tests that should be run when the passed files have been changed. The

--- a/jvm/src/main/scala/com/nawforce/apexlink/api/TestClass.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/api/TestClass.scala
@@ -1,0 +1,23 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.apexlink.api
+
+/** A discovered Apex test class.
+  *
+  * Names are namespace-qualified when the declaring package has a namespace. For impacted test
+  * discovery, explanation contains the dependency path from the test class to a supplied type. It
+  * is empty for declared test discovery.
+  */
+final case class TestClass(name: String, explanation: Array[String])

--- a/jvm/src/main/scala/com/nawforce/apexlink/org/OrgTestClasses.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/org/OrgTestClasses.scala
@@ -13,7 +13,7 @@
  */
 package com.nawforce.apexlink.org
 
-import com.nawforce.apexlink.api.TypeSummary
+import com.nawforce.apexlink.api.{TestClass, TypeSummary}
 import com.nawforce.apexlink.deps.ReferencingCollector
 import com.nawforce.apexlink.deps.ReferencingCollector.NodeInfo
 import com.nawforce.apexlink.finding.TypeResolver
@@ -21,6 +21,7 @@ import com.nawforce.apexlink.rpc.{ClassTestItem, MethodTestItem, TargetLocation}
 import com.nawforce.apexlink.types.apex.{ApexDeclaration, ApexMethodLike}
 import com.nawforce.apexlink.types.core.{TypeDeclaration, TypeId}
 import com.nawforce.pkgforce.modifiers.{
+  ApexModifiers,
   INTEGRATION_TEST_ANNOTATION,
   ISTEST_ANNOTATION,
   Modifier,
@@ -37,8 +38,27 @@ import scala.collection.mutable
 trait OrgTestClasses {
   self: OPM.OrgImpl =>
 
+  def getImpactedTestClasses(paths: Array[String]): Array[TestClass] = {
+    findTestClassReferences(paths.map(p => Path(p)))
+      .map(info =>
+        TestClass(info.testClass.typeName.toString, info.explain.map(_.typeName.toString).toArray)
+      )
+      .toArray
+      .sortBy(_.name)
+  }
+
+  def getDeclaredTestClasses(paths: Array[String]): Array[TestClass] = {
+    findTestClasses(paths)
+      .map(cls => TestClass(cls.typeName.toString, Array.empty))
+      .groupBy(_.name)
+      .values
+      .map(_.head)
+      .toArray
+      .sortBy(_.name)
+  }
+
   def getTestClassNames(paths: Array[String]): Array[String] = {
-    getTestClassNamesInternal(paths.map(p => Path(p))).map(_._1).toArray
+    getImpactedTestClasses(paths).map(_.name)
   }
 
   def getTestClassNamesInternal(paths: Array[PathLike]): Set[(String, Array[String])] = {
@@ -84,7 +104,12 @@ trait OrgTestClasses {
   }
 
   private def getAllTestClasses: Array[ApexDeclaration] = {
-    packages.view.flatMap(_.orderedModules.flatMap(_.testClasses.toSeq)).toArray
+    packages.view
+      .flatMap(
+        _.orderedModules.flatMap(module => module.testClasses.toSeq ++ module.nonTestClasses.toSeq)
+      )
+      .filter(isDeclaredTestClass)
+      .toArray
   }
 
   private def findTestClassesFromPaths(paths: Array[String]): Array[ApexDeclaration] = {
@@ -95,7 +120,7 @@ trait OrgTestClasses {
           typeId.module
             .findType(typeId.typeName)
             .toOption
-            .collect { case td: ApexDeclaration if td.inTest => td }
+            .collect { case td: ApexDeclaration if isDeclaredTestClass(td) => td }
             .filter(_.outerTypeName.isEmpty)
         })
       })
@@ -104,6 +129,12 @@ trait OrgTestClasses {
   private def hasTestModifier(modifiers: ArraySeq[Modifier]): Boolean = {
     modifiers.contains(TEST_METHOD_MODIFIER) || modifiers.contains(ISTEST_ANNOTATION) || modifiers
       .contains(INTEGRATION_TEST_ANNOTATION)
+  }
+
+  private def isDeclaredTestClass(cls: ApexDeclaration): Boolean = {
+    ApexModifiers.hasTestClassModifier(cls.modifiers) || cls.methods.exists(method =>
+      hasTestModifier(method.modifiers)
+    )
   }
 
   private def findTestClassReferences(

--- a/jvm/src/main/scala/com/nawforce/apexlink/rpc/OrgAPIImpl.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/rpc/OrgAPIImpl.scala
@@ -379,12 +379,13 @@ object GetDependencyBombs {
 case class GetTestClassNames(promise: Promise[GetTestClassNamesResult], paths: Array[String])
     extends APIRequest {
   override def process(queue: OrgQueue): Unit = {
-    val orgImpl = queue.org.asInstanceOf[OPM.OrgImpl]
-    OrgInfo.current.withValue(orgImpl) {
-      promise.success(
-        GetTestClassNamesResult(orgImpl.getTestClassNamesInternal(paths.map(p => Path(p))).toArray)
+    promise.success(
+      GetTestClassNamesResult(
+        queue.org
+          .getImpactedTestClasses(paths)
+          .map(testClass => (testClass.name, testClass.explanation))
       )
-    }
+    )
   }
 }
 

--- a/jvm/src/main/scala/io/github/apexdevtools/apexls/Batch.scala
+++ b/jvm/src/main/scala/io/github/apexdevtools/apexls/Batch.scala
@@ -29,7 +29,13 @@ object Batch {
   private final val StatusInternal = 3
 
   private val commands: Seq[BatchCommand] =
-    Seq(PingCommand, DependencyReportCommand, DependencyCountsCommand, DependencyBombsCommand)
+    Seq(
+      PingCommand,
+      DependencyReportCommand,
+      DependencyCountsCommand,
+      DependencyBombsCommand,
+      TestClassesCommand
+    )
 
   def main(args: Array[String]): Unit = {
     System.exit(run(args, System.out, System.err))

--- a/jvm/src/main/scala/io/github/apexdevtools/apexls/TestClassesCommand.scala
+++ b/jvm/src/main/scala/io/github/apexdevtools/apexls/TestClassesCommand.scala
@@ -1,0 +1,128 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package io.github.apexdevtools.apexls
+
+import com.nawforce.apexlink.api.TestClass
+import com.nawforce.runtime.platform.Path
+
+import java.nio.file.Paths
+import scala.collection.mutable
+
+private[apexls] final case class TestClassesResult(testClasses: Array[TestClass])
+
+private[apexls] object TestClassesCommand extends BatchCommand {
+  override type Result = TestClassesResult
+
+  override val name: String               = "test-classes"
+  override val requiresWorkspace: Boolean = true
+
+  override def validate(args: Seq[String]): Either[BatchError, Unit] = {
+    TestClassesArguments.parse(args).map(_ => ())
+  }
+
+  override def execute(
+    context: BatchContext,
+    args: Seq[String]
+  ): Either[BatchError, TestClassesResult] = {
+    TestClassesArguments.parse(args).map { arguments =>
+      val workspace = Path(context.options.workspace)
+      val paths = arguments.paths
+        .map(path => if (Paths.get(path).isAbsolute) Path(path) else workspace.join(path))
+        .map(_.toString)
+        .distinct
+        .toArray
+      val testClasses = arguments.mode match {
+        case ImpactedMode => context.org.get.getImpactedTestClasses(paths)
+        case AllMode      => context.org.get.getDeclaredTestClasses(paths)
+      }
+      TestClassesResult(testClasses.sortBy(_.name))
+    }
+  }
+
+  override def writeResult(result: TestClassesResult): ujson.Value = {
+    val testClasses = result.testClasses.map { testClass =>
+      ujson.Obj(
+        "name"        -> testClass.name,
+        "explanation" -> ujson.Arr(testClass.explanation.map(ujson.Str(_)).toIndexedSeq: _*)
+      )
+    }
+    ujson.Obj("testClasses" -> ujson.Arr(testClasses.toIndexedSeq: _*))
+  }
+
+  private sealed trait TestClassesMode
+  private case object ImpactedMode extends TestClassesMode
+  private case object AllMode      extends TestClassesMode
+
+  private final case class TestClassesArguments(mode: TestClassesMode, paths: Seq[String])
+
+  private object TestClassesArguments {
+    def parse(args: Seq[String]): Either[BatchError, TestClassesArguments] = {
+      var mode  = Option.empty[TestClassesMode]
+      val paths = mutable.ArrayBuffer[String]()
+      var index = 0
+
+      def value(option: String, token: String): Either[BatchError, String] = {
+        if (token == option) {
+          if (index + 1 >= args.length || args(index + 1).startsWith("--"))
+            Left(BatchError("INVALID_ARGUMENT", s"Option '$option' requires a value"))
+          else {
+            index += 1
+            Right(args(index))
+          }
+        } else {
+          val candidate = token.substring(option.length + 1)
+          if (candidate.isEmpty)
+            Left(BatchError("INVALID_ARGUMENT", s"Option '$option' requires a value"))
+          else Right(candidate)
+        }
+      }
+
+      while (index < args.length) {
+        val token = args(index)
+        if (token == "--mode" || token.startsWith("--mode=")) {
+          if (mode.nonEmpty)
+            return Left(BatchError("INVALID_ARGUMENT", "Option '--mode' may only be provided once"))
+          value("--mode", token) match {
+            case Left(error)       => return Left(error)
+            case Right("impacted") => mode = Some(ImpactedMode)
+            case Right("all")      => mode = Some(AllMode)
+            case Right(candidate) =>
+              return Left(
+                BatchError(
+                  "INVALID_ARGUMENT",
+                  s"Unsupported test class mode '$candidate'; expected 'impacted' or 'all'"
+                )
+              )
+          }
+        } else if (token == "--path" || token.startsWith("--path=")) {
+          value("--path", token) match {
+            case Left(error)      => return Left(error)
+            case Right(candidate) => paths += candidate
+          }
+        } else {
+          return Left(BatchError("INVALID_ARGUMENT", s"Unexpected argument '$token'"))
+        }
+        index += 1
+      }
+
+      mode match {
+        case None => Left(BatchError("INVALID_ARGUMENT", "Option '--mode' is required"))
+        case Some(ImpactedMode) if paths.isEmpty =>
+          Left(BatchError("INVALID_ARGUMENT", "Mode 'impacted' requires at least one '--path'"))
+        case Some(selectedMode) => Right(TestClassesArguments(selectedMode, paths.toSeq))
+      }
+    }
+  }
+}

--- a/jvm/src/test/scala/com/nawforce/apexlink/org/TestClassesTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/org/TestClassesTest.scala
@@ -22,7 +22,7 @@ class TestClassesTest extends AnyFunSuite with TestHelper {
 
   private def getTestClassNames(root: PathLike, paths: Array[String]): Set[String] = {
     withOrg(org => {
-      org.getTestClassNamesInternal(paths.map(p => root.join(p))).map(_._1)
+      org.getImpactedTestClasses(paths.map(p => root.join(p).toString)).map(_.name).toSet
     })
   }
 
@@ -111,6 +111,98 @@ class TestClassesTest extends AnyFunSuite with TestHelper {
     ) { (root: PathLike, ns: Option[String]) =>
       assert(getTestClassNames(root, Array("Dummy.cls")) == Set(withNamespace(ns, "DummyTest")))
       assert(getTestClassNames(root, Array("DummyTest.cls")) == Set(withNamespace(ns, "DummyTest")))
+    }
+  }
+
+  test("Impacted test classes expose namespace-qualified explanation chains") {
+    run(
+      Map(
+        "Service.cls"     -> "public class Service {}",
+        "ServiceImpl.cls" -> "public class ServiceImpl { Service service; }",
+        "ServiceTest.cls" -> "@isTest public class ServiceTest { ServiceImpl service; }"
+      )
+    ) { (root: PathLike, ns: Option[String]) =>
+      val results = withOrg(
+        _.getImpactedTestClasses(
+          Array(
+            root.join("Service.cls").toString,
+            root.join("missing.cls").toString,
+            root.join("Service.cls").toString
+          )
+        )
+      )
+
+      assert(results.map(_.name).toSeq == Seq(withNamespace(ns, "ServiceTest")))
+      assert(
+        results.head.explanation.toSeq == Seq(
+          withNamespace(ns, "ServiceTest"),
+          withNamespace(ns, "ServiceImpl"),
+          withNamespace(ns, "Service")
+        )
+      )
+
+      val deduplicated = withOrg(
+        _.getImpactedTestClasses(
+          Array(root.join("Service.cls").toString, root.join("ServiceImpl.cls").toString)
+        )
+      )
+      assert(deduplicated.map(_.name).toSeq == Seq(withNamespace(ns, "ServiceTest")))
+    }
+  }
+
+  test("Declared test classes support all and selected paths") {
+    run(
+      Map(
+        "Annotated.cls" -> "@IsTeSt private class Annotated {}",
+        "Legacy.cls"    -> "public class Legacy { testMethod static void verifiesBehavior() {} }",
+        "Ordinary.cls"  -> "public class Ordinary {}"
+      )
+    ) { (root: PathLike, ns: Option[String]) =>
+      val all = withOrg(_.getDeclaredTestClasses(Array.empty))
+      assert(
+        all.map(_.name).toSeq == Seq(withNamespace(ns, "Annotated"), withNamespace(ns, "Legacy"))
+      )
+      assert(all.forall(_.explanation.isEmpty))
+
+      val selected = withOrg(
+        _.getDeclaredTestClasses(
+          Array(
+            root.join("Legacy.cls").toString,
+            root.join("Annotated.cls").toString,
+            root.join("Legacy.cls").toString,
+            root.join("Ordinary.cls").toString,
+            root.join("Broken.cls").toString,
+            root.join("missing.cls").toString
+          )
+        )
+      )
+      assert(
+        selected.map(_.name).toSeq == Seq(
+          withNamespace(ns, "Annotated"),
+          withNamespace(ns, "Legacy")
+        )
+      )
+    }
+  }
+
+  test("Declared test classes ignore syntax and read failures") {
+    FileSystemHelper.run(
+      Map(
+        "Good.cls"   -> "@isTest private class Good {}",
+        "Broken.cls" -> "@isTest private class Broken {"
+      )
+    ) { root: PathLike =>
+      createOrg(root)
+      val results = withOrg(
+        _.getDeclaredTestClasses(
+          Array(
+            root.join("Good.cls").toString,
+            root.join("Broken.cls").toString,
+            root.join("missing.cls").toString
+          )
+        )
+      )
+      assert(results.map(_.name).toSeq == Seq("Good"))
     }
   }
 

--- a/jvm/src/test/scala/com/nawforce/apexlink/rpc/OrgAPITest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/rpc/OrgAPITest.scala
@@ -395,6 +395,7 @@ class OrgAPITest extends AsyncFunSuite with BeforeAndAfterEach with TestHelper {
       assert(result.error.isEmpty)
       assert(classes.testClassesWithPath.length == 1)
       assert(classes.testClassesWithPath(0)._1 == "HelloTest")
+      assert(classes.testClassesWithPath(0)._2.toSeq == Seq("HelloTest", "Hello"))
     }
   }
 

--- a/jvm/src/test/scala/io/github/apexdevtools/apexls/TestClassesCommandTest.scala
+++ b/jvm/src/test/scala/io/github/apexdevtools/apexls/TestClassesCommandTest.scala
@@ -1,0 +1,168 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package io.github.apexdevtools.apexls
+
+import com.nawforce.runtime.FileSystemHelper
+import org.scalatest.funsuite.AnyFunSuite
+
+class TestClassesCommandTest extends AnyFunSuite with BatchCommandTestSupport {
+  private val config =
+    """{
+      |  "packageDirectories": [
+      |    {"path": "force app", "default": true},
+      |    {"path": "second"}
+      |  ],
+      |  "namespace": "example"
+      |}""".stripMargin
+
+  private val files = Map(
+    "sfdx-project.json"                          -> config,
+    "force app/main/default/classes/Service.cls" -> "public class Service {}",
+    "force app/main/default/classes/ServiceImpl.cls" ->
+      "public class ServiceImpl { Service service; }",
+    "force app/main/default/classes/ServiceTest.cls" ->
+      "@isTest public class ServiceTest { ServiceImpl service; }",
+    "force app/main/default/classes/Annotated.cls" -> "@IsTeSt private class Annotated {}",
+    "force app/main/default/classes/Legacy.cls" ->
+      "public class Legacy { testMethod static void verifiesBehavior() {} }",
+    "force app/main/default/classes/Ordinary.cls" -> "public class Ordinary {}",
+    "force app/main/default/classes/Broken.cls"   -> "@isTest private class Broken {",
+    "second/classes/Second.cls"                   -> "public class Second {}",
+    "second/classes/SecondTest.cls" ->
+      "@isTest private class SecondTest { Second value; }"
+  )
+
+  test("impacted mode preserves explanations, namespaces, paths, cache modes, and ordering") {
+    FileSystemHelper.runTempDir(files) { workspace =>
+      Seq(false, true).foreach { cacheEnabled =>
+        val relative = "force app/main/default/classes/Service.cls"
+        val absolute = workspace.join(relative).toString
+        val invocation = invoke(
+          workspace,
+          "test-classes",
+          cacheEnabled,
+          "--mode",
+          "impacted",
+          "--path",
+          relative,
+          s"--path=$absolute",
+          "--path",
+          "second/classes/Second.cls",
+          "--path",
+          "force app/main/default/classes/missing.cls"
+        )
+
+        assert(invocation.status == 0)
+        assert(invocation.stderr.isEmpty)
+        val classes = invocation.json("result")("testClasses").arr
+        assert(classes.map(_("name").str) == Seq("example.SecondTest", "example.ServiceTest"))
+        assert(
+          classes.head("explanation").arr.map(_.str) == Seq("example.SecondTest", "example.Second")
+        )
+        assert(
+          classes(1)("explanation").arr
+            .map(_.str) == Seq("example.ServiceTest", "example.ServiceImpl", "example.Service")
+        )
+
+        val repeated = invoke(
+          workspace,
+          "test-classes",
+          cacheEnabled,
+          "--mode=impacted",
+          s"--path=$relative",
+          "--path=second/classes/Second.cls"
+        )
+        assert(repeated.stdout == invocation.stdout)
+      }
+    }
+  }
+
+  test("all mode discovers declared top-level tests for the workspace or selected paths") {
+    FileSystemHelper.runTempDir(files) { workspace =>
+      Seq(false, true).foreach { cacheEnabled =>
+        val all = invoke(workspace, "test-classes", cacheEnabled, "--mode", "all")
+        assert(all.status == 0)
+        assert(all.stderr.isEmpty)
+        assert(
+          all.json("result")("testClasses").arr.map(_("name").str) == Seq(
+            "example.Annotated",
+            "example.Legacy",
+            "example.SecondTest",
+            "example.ServiceTest"
+          )
+        )
+        assert(all.json("result")("testClasses").arr.forall(_("explanation").arr.isEmpty))
+
+        val selected = invoke(
+          workspace,
+          "test-classes",
+          cacheEnabled,
+          "--mode=all",
+          "--path",
+          "force app/main/default/classes/Legacy.cls",
+          "--path",
+          "force app/main/default/classes/Annotated.cls",
+          "--path",
+          "force app/main/default/classes/Legacy.cls",
+          "--path",
+          "force app/main/default/classes/Ordinary.cls",
+          "--path",
+          "force app/main/default/classes/Broken.cls",
+          "--path",
+          "force app/main/default/classes/missing.cls"
+        )
+        assert(selected.status == 0)
+        assert(
+          selected.json("result")("testClasses").arr.map(_("name").str) == Seq(
+            "example.Annotated",
+            "example.Legacy"
+          )
+        )
+      }
+    }
+  }
+
+  test("impacted mode returns an empty success for valid no-match paths") {
+    FileSystemHelper.runTempDir(files) { workspace =>
+      val invocation = invoke(
+        workspace,
+        "test-classes",
+        cacheEnabled = false,
+        "--mode",
+        "impacted",
+        "--path",
+        "force app/main/default/classes/Ordinary.cls"
+      )
+
+      assert(invocation.status == 0)
+      assert(invocation.json("result")("testClasses").arr.isEmpty)
+    }
+  }
+
+  test("test-classes validates mode and path arguments before loading a workspace") {
+    val invalid = Seq(
+      invokeRaw("test-classes"),
+      invokeRaw("test-classes", "--mode"),
+      invokeRaw("test-classes", "--mode", "unknown"),
+      invokeRaw("test-classes", "--mode", "all", "--mode", "all"),
+      invokeRaw("test-classes", "--mode", "impacted"),
+      invokeRaw("test-classes", "--mode", "all", "--path"),
+      invokeRaw("test-classes", "--mode", "all", "unexpected")
+    )
+
+    assert(invalid.forall(_.status == 1))
+    assert(invalid.forall(_.json("error")("code").str == "INVALID_ARGUMENT"))
+  }
+}


### PR DESCRIPTION
## Summary

- expose deterministic, synchronous impacted and declared test-class discovery through API-owned results
- preserve namespace-qualified impacted explanations while adapting the existing RPC endpoint to the public API
- add the `test-classes` batch command with distinct `impacted` and `all` modes, repeatable absolute or workspace-relative paths, and command-owned serialization
- cover cache modes, package directories, spaces, namespaces, missing and duplicate paths, legacy `testMethod`, parse failures, deterministic output, and packaged execution

## Validation

- `sbt scalafmtAll`
- `sbt 'apexlsJVM/testOnly io.github.apexdevtools.apexls.TestClassesCommandTest com.nawforce.apexlink.org.TestClassesTest com.nawforce.apexlink.rpc.OrgAPITest'` (81 tests)\n- `sbt apexlsJVM/test` (2,558 tests)\n- `sbt apexlsJVM/batchDistributionTest`\n\n## Risks\n\n- No known follow-ups. Git/path expansion and Salesforce test execution remain owned by play-cli and are intentionally out of scope.\n\nCloses #529