### PR TITLE
Add precise Location ranges for XML metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Explicit `Location.point`, `Location.wholeLine`, and half-open `Location.span` factories, plus
+  source extraction that clamps whole-line sentinels before line endings (#362)
 - Source-accurate, half-open lexical ranges for successfully parsed XML elements on JVM and
   Scala.js, exposed through `XMLElementLike.location` while retaining the existing `line` API
   (#535)
@@ -23,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bomb rankings (#528)
 - Public impacted and declared test-class discovery APIs, plus a deterministic `test-classes` JVM
   batch command with dependency explanations and namespace-qualified names (#529)
+
+### Changed
+
+- Labels, inline SObject components, and XML-derived metadata validation diagnostics now use exact
+  element ranges; standalone metadata components continue to use whole-file locations (#362)
 
 ## [6.2.0] - 2026-07-29
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Maven:
 The library can be consumed in JVM and ScalaJS projects, however the features available to each differ. See the JavaDoc for more details on the API. <!-- TODO link to hosted javadoc -->
 XML API consumers can also see [XML Element Locations](doc/XML_Element_Locations.md) for the
 source-range and coordinate contract.
+The [Location Ranges](doc/Location_Ranges.md) guide documents named point, whole-line, and span
+factories plus source extraction and sentinel clamping.
 
 The jar is also executable without a client via the commands, `CheckForIssues` and `DependencyReport`:
 

--- a/doc/Location_Ranges.md
+++ b/doc/Location_Ranges.md
@@ -1,0 +1,19 @@
+# Location Ranges
+
+`Location` retains its existing one-, two-, and four-argument `apply` overloads, `empty` and `all`
+sentinels, structural equality and hashing, and four-field serialized representation. Named
+factories make new call-site intent explicit:
+
+- `Location.point(line, column)` creates a zero-length point.
+- `Location.wholeLine(line)` creates a half-open range over a line's content. Its end column is
+  `Int.MaxValue`, an explicit sentinel in the same style as `Location.all`.
+- `Location.span(startLine, startColumn, endLine, endColumn)` creates a half-open range whose start
+  is inclusive and end is exclusive.
+
+Lines are one-based. Columns are zero-based Unicode code-point offsets, so JVM and Scala.js use the
+same coordinates for non-BMP text.
+
+`Location.extract(source, location)` slices source using this coordinate model. It clamps columns
+to the line's content before LF, CRLF, or CR terminators. A `wholeLine` range therefore returns the
+line content without consuming its following newline. Locations ending beyond the available lines,
+including `Location.all`, clamp to the end of the source.

--- a/doc/XML_Element_Locations.md
+++ b/doc/XML_Element_Locations.md
@@ -24,6 +24,10 @@ can be associated unambiguously with the complete parsed element tree. If that a
 no partial exact ranges are used and elements retain their previous point-location behavior.
 Malformed XML diagnostics also remain point based.
 
+Label declarations and inline SObject fields, field sets, and sharing reasons use these complete
+element ranges. XML-derived validation errors use the smallest offending element available, such
+as an invalid value child, while a missing child is reported against its parent. Standalone
+metadata component files remain whole-file locations.
+
 This API does not change `Location` constructors, equality, sentinels, or four-field serialization.
-It also does not migrate label generation, SObject generation, or XML validation diagnostics to
-consume the new ranges; those consumer changes remain separate work.
+See [Location Ranges](Location_Ranges.md) for the named factory and extraction contract.

--- a/js/npm/snapshots/system/SampleCheckSys.ts.snap
+++ b/js/npm/snapshots/system/SampleCheckSys.ts.snap
@@ -18743,7 +18743,7 @@ exports[`Check samples Sample: Volunteers-for-Salesforce 1`] = `
     ],
     [
       "src/objects/Campaign.object",
-      "Error: line 101: Related field 'Volunteer_Job__c.Number_of_Shifts__c' required by Schema.Campaign is not defined",
+      "Error: line 101:4 to 109:13: Related field 'Volunteer_Job__c.Number_of_Shifts__c' required by Schema.Campaign is not defined",
     ],
   ],
   "status": 4,

--- a/jvm/src/main/scala/com/nawforce/pkgforce/stream/LabelGenerator.scala
+++ b/jvm/src/main/scala/com/nawforce/pkgforce/stream/LabelGenerator.scala
@@ -57,11 +57,7 @@ object LabelGenerator {
                     val protect: Boolean =
                       c.getOptionalSingleChildAsBoolean("protected").getOrElse(true)
                     Some(
-                      LabelEvent(
-                        PathLocation(document.path, Location(c.line)),
-                        Name(fullName),
-                        protect
-                      )
+                      LabelEvent(PathLocation(document.path, c.location), Name(fullName), protect)
                     )
                   } catch {
                     case e: XMLException =>

--- a/jvm/src/main/scala/com/nawforce/pkgforce/stream/SObjectGenerator.scala
+++ b/jvm/src/main/scala/com/nawforce/pkgforce/stream/SObjectGenerator.scala
@@ -139,7 +139,7 @@ object SObjectGenerator {
             .getChildren("fields")
             .flatMap(field => {
               createField(
-                SourceInfo(PathLocation(controllingPath.get, Location(field.line)), sourceData.get),
+                SourceInfo(PathLocation(controllingPath.get, field.location), sourceData.get),
                 field,
                 controllingPath.get
               )
@@ -148,10 +148,7 @@ object SObjectGenerator {
               .getChildren("fieldSets")
               .flatMap(fieldSet => {
                 createFieldSet(
-                  SourceInfo(
-                    PathLocation(controllingPath.get, Location(fieldSet.line)),
-                    sourceData.get
-                  ),
+                  SourceInfo(PathLocation(controllingPath.get, fieldSet.location), sourceData.get),
                   fieldSet,
                   controllingPath.get
                 )
@@ -161,7 +158,7 @@ object SObjectGenerator {
               .flatMap(sharingReason => {
                 createSharingReason(
                   SourceInfo(
-                    PathLocation(controllingPath.get, Location(sharingReason.line)),
+                    PathLocation(controllingPath.get, sharingReason.location),
                     sourceData.get
                   ),
                   sharingReason,
@@ -196,20 +193,23 @@ object SObjectGenerator {
   private def extractCustomSettingsType(
     doc: XMLDocumentLike
   ): IssuesAnd[Option[CustomSettingType]] = {
-    doc.rootElement.getOptionalSingleChildAsString("customSettingsType") match {
-      case Some("List")      => IssuesAnd(Some(ListCustomSetting))
-      case Some("Hierarchy") => IssuesAnd(Some(HierarchyCustomSetting))
-      case Some(x) =>
-        IssuesAnd(
-          ArraySeq(
-            Issue(
-              ERROR_CATEGORY,
-              PathLocation(doc.path, Location(doc.rootElement.line)),
-              s"Unexpected customSettingsType value '$x', should be 'List' or 'Hierarchy'"
+    doc.rootElement.getOptionalSingleChild("customSettingsType") match {
+      case Some(element) =>
+        element.text match {
+          case "List"      => IssuesAnd(Some(ListCustomSetting))
+          case "Hierarchy" => IssuesAnd(Some(HierarchyCustomSetting))
+          case value =>
+            IssuesAnd(
+              ArraySeq(
+                Issue(
+                  ERROR_CATEGORY,
+                  PathLocation(doc.path, element.location),
+                  s"Unexpected customSettingsType value '$value', should be 'List' or 'Hierarchy'"
+                )
+              ),
+              None
             )
-          ),
-          None
-        )
+        }
       case None => IssuesAnd(None)
     }
   }
@@ -226,25 +226,24 @@ object SObjectGenerator {
   )
 
   private def extractSharingModel(doc: XMLDocumentLike): IssuesAnd[Option[SharingModel]] = {
-    val sharingModel = doc.rootElement.getOptionalSingleChildAsString("sharingModel")
-    if (sharingModel.nonEmpty) {
-      val matched = allSharingModels.find(_.value == sharingModel.get)
-      if (matched.nonEmpty) {
-        IssuesAnd(matched)
-      } else {
-        IssuesAnd(
-          ArraySeq(
-            Issue(
-              ERROR_CATEGORY,
-              PathLocation(doc.path, Location(doc.rootElement.line)),
-              s"Unexpected sharingModel value '${sharingModel.get}'"
-            )
-          ),
-          None
-        )
-      }
-    } else {
-      IssuesAnd(None)
+    doc.rootElement.getOptionalSingleChild("sharingModel") match {
+      case Some(element) =>
+        val matched = allSharingModels.find(_.value == element.text)
+        if (matched.nonEmpty) {
+          IssuesAnd(matched)
+        } else {
+          IssuesAnd(
+            ArraySeq(
+              Issue(
+                ERROR_CATEGORY,
+                PathLocation(doc.path, element.location),
+                s"Unexpected sharingModel value '${element.text}'"
+              )
+            ),
+            None
+          )
+        }
+      case None => IssuesAnd(None)
     }
   }
 
@@ -260,7 +259,8 @@ object SObjectGenerator {
       if (!name.toString.endsWith("__c"))
         return Iterator()
 
-      val rawType = elem.getSingleChildAsString("type").trim
+      val typeElement = elem.getOptionalSingleChild("type")
+      val rawType     = elem.getSingleChildAsString("type").trim
       if (!fieldTypes.contains(rawType)) {
         return IssuesEvent.iterator(
           ArraySeq(
@@ -268,7 +268,7 @@ object SObjectGenerator {
               path,
               Diagnostic(
                 ERROR_CATEGORY,
-                Location(elem.line),
+                typeElement.map(_.location).getOrElse(elem.location),
                 s"Unrecognised type '$rawType' on custom field '$name'"
               )
             )

--- a/jvm/src/test/scala/com/nawforce/apexlink/TestHelper.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/TestHelper.scala
@@ -334,19 +334,8 @@ trait TestHelper {
 }
 
 object TestHelper {
-  final val CURSOR = "$"
-  def locToString(source: String, loc: Location): String = {
-    val lines = source.linesWithSeparators.toArray
-    if (loc.startLine == loc.endLine) {
-      return lines(loc.startLine - 1).substring(loc.startCharOffset(), loc.endCharOffset())
-    }
-
-    // may be Location.all/Int.MaxValue
-    val endLine = if (loc.endLine > lines.length) lines.length else loc.endLine
-    lines(loc.startLine - 1).substring(loc.startPosition, lines(loc.startLine - 1).length) + lines(
-      endLine - 1
-    ).substring(0, loc.endPosition)
-  }
+  final val CURSOR                                       = "$"
+  def locToString(source: String, loc: Location): String = Location.extract(source, loc)
 }
 
 case class TargetLocationString(targetPath: String, target: String)

--- a/jvm/src/test/scala/com/nawforce/apexlink/pkg/DefinitionProviderTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/pkg/DefinitionProviderTest.scala
@@ -548,16 +548,22 @@ class DefinitionProviderTest extends AnyFunSuite with TestHelper {
   test("SObject variable typename") {
     val contentAndCursorPos =
       withCursor(s"public class Bar { { Foo${CURSOR}__c foo; } }")
+    val objectMetadata = customObject("Foo", Seq())
 
     FileSystemHelper.run(
       Map(
         "Bar.cls"                               -> contentAndCursorPos._1,
-        "objects/Foo__c/Foo__c.object-meta.xml" -> customObject("Foo", Seq())
+        "objects/Foo__c/Foo__c.object-meta.xml" -> objectMetadata
       )
     ) { root: PathLike =>
       val org = createHappyOrg(root)
-      val definition = org.unmanaged
+      val rawDefinition = org.unmanaged
         .getDefinition(root.join("Bar.cls"), line = 1, offset = contentAndCursorPos._2, None)
+      assert(rawDefinition.length == 1)
+      assert(rawDefinition.head.target == com.nawforce.pkgforce.path.Location.all)
+      assert(rawDefinition.head.targetSelection == com.nawforce.pkgforce.path.Location.all)
+
+      val definition = rawDefinition
         .map(LocationLinkString(root, contentAndCursorPos._1, _))
 
       assert(
@@ -566,8 +572,8 @@ class DefinitionProviderTest extends AnyFunSuite with TestHelper {
             LocationLinkString(
               "Foo__c",
               path"/objects/Foo__c/Foo__c.object-meta.xml",
-              "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
-              "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+              objectMetadata,
+              objectMetadata
             )
           )
       )

--- a/jvm/src/test/scala/com/nawforce/apexlink/pkg/RefreshSObjectTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/pkg/RefreshSObjectTest.scala
@@ -411,7 +411,7 @@ class RefreshSObjectTest extends AnyFunSuite with TestHelper {
 
         assert(
           getMessages() ==
-            path"/objects/Foo__c.object: Missing: line 10: Lookup object Schema.Bar__c does not exist for field 'Lookup__r'" + "\n"
+            path"/objects/Foo__c.object: Missing: line 10:4 to 15:13: Lookup object Schema.Bar__c does not exist for field 'Lookup__r'" + "\n"
         )
 
         assert(unmanagedSObject("Foo__c").get.findField(Name("Lookup__c"), Some(false)).nonEmpty)
@@ -495,7 +495,7 @@ class RefreshSObjectTest extends AnyFunSuite with TestHelper {
         val org = createOrg(root)
         assert(
           getMessages() ==
-            path"/objects/Foo__c/Foo__c.object-meta.xml: Missing: line 10: Lookup object Schema.Bar__c does not exist for field 'Lookup__r'" + "\n"
+            path"/objects/Foo__c/Foo__c.object-meta.xml: Missing: line 10:4 to 15:13: Lookup object Schema.Bar__c does not exist for field 'Lookup__r'" + "\n"
         )
 
         val basePath = root.join("objects", "Bar__c", "Bar__c.object-meta.xml")

--- a/jvm/src/test/scala/com/nawforce/apexlink/rpc/LocationRPCTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/rpc/LocationRPCTest.scala
@@ -1,0 +1,36 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+package com.nawforce.apexlink.rpc
+
+import com.nawforce.pkgforce.path.Location
+import io.github.shogowada.scala.jsonrpc.serializers.JSONRPCPickler.{read, write}
+import org.scalatest.funsuite.AnyFunSuite
+
+class LocationRPCTest extends AnyFunSuite {
+
+  test("RPC locations retain exact four-field ranges") {
+    val link = LocationLink(
+      Location.point(1, 2),
+      "/CustomLabels.labels",
+      Location.span(3, 4, 8, 13),
+      Location.wholeLine(5)
+    )
+
+    val json = ujson.read(write(link))
+    Seq("origin", "target", "targetSelection").foreach { field =>
+      assert(json(field).obj.keySet == Set("startLine", "startPosition", "endLine", "endPosition"))
+    }
+    assert(read[LocationLink](json.render()) == link)
+  }
+}

--- a/jvm/src/test/scala/com/nawforce/apexlink/types/CustomObjectTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/types/CustomObjectTest.scala
@@ -31,7 +31,7 @@ class CustomObjectTest extends AnyFunSuite with TestHelper {
       createOrg(root)
       assert(
         getMessages(root.join("objects", "Foo__c.object")) ==
-          "Error: line 10: Unrecognised type 'Silly' on custom field 'Bar__c'\n"
+          "Error: line 12 at 8-26: Unrecognised type 'Silly' on custom field 'Bar__c'\n"
       )
     }
   }

--- a/jvm/src/test/scala/com/nawforce/apexlink/types/LabelTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/types/LabelTest.scala
@@ -13,10 +13,12 @@
  */
 package com.nawforce.apexlink.types
 
-import com.nawforce.apexlink.TestHelper
+import com.nawforce.apexlink.TestHelper.CURSOR
+import com.nawforce.apexlink.types.other.LabelDeclaration
+import com.nawforce.apexlink.{LocationLinkString, TestHelper}
 import com.nawforce.pkgforce.PathInterpolator.PathInterpolator
 import com.nawforce.pkgforce.names.{Name, TypeIdentifier, TypeName}
-import com.nawforce.pkgforce.path.PathLike
+import com.nawforce.pkgforce.path.{Location, PathLike}
 import com.nawforce.runtime.FileSystemHelper
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -128,6 +130,59 @@ class LabelTest extends AnyFunSuite with TestHelper {
           .getDependencyHolders(labelsTypeId, apexOnly = false)
           .sameElements(Array(dummyTypeId))
       )
+    }
+  }
+
+  test("Label definitions and unused diagnostics select the complete label element") {
+    val labelsSource =
+      """<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
+        |  <labels>
+        |    <fullName>TestLabel</fullName>
+        |    <protected>false</protected>
+        |    <value>Test value</value>
+        |  </labels>
+        |  <labels>
+        |    <fullName>UnusedLabel</fullName>
+        |    <value>Unused value</value>
+        |  </labels>
+        |</CustomLabels>
+        |""".stripMargin
+    val expectedElement =
+      """<labels>
+        |    <fullName>TestLabel</fullName>
+        |    <protected>false</protected>
+        |    <value>Test value</value>
+        |  </labels>""".stripMargin
+    val expectedUnusedElement =
+      """<labels>
+        |    <fullName>UnusedLabel</fullName>
+        |    <value>Unused value</value>
+        |  </labels>""".stripMargin
+    val (apexSource, cursor) =
+      withCursor(s"public class Dummy { {String value = Label.Test${CURSOR}Label;} }")
+
+    FileSystemHelper.run(Map("CustomLabels.labels" -> labelsSource, "Dummy.cls" -> apexSource)) {
+      root: PathLike =>
+        val org        = createOrg(root)
+        val labelsPath = root.join("CustomLabels.labels")
+        val definition = org.unmanaged
+          .getDefinition(root.join("Dummy.cls"), line = 1, offset = cursor, None)
+          .head
+        assert(definition.targetPath == labelsPath.toString)
+        assert(definition.target == Location.span(2, 2, 6, 11))
+        assert(definition.targetSelection == definition.target)
+        assert(Location.extract(labelsSource, definition.target) == expectedElement)
+        assert(LocationLinkString(root, apexSource, definition).targetSelection == expectedElement)
+
+        val labelType = org.unmanaged.getTypeOfPathInternal(labelsPath).get
+        val declaration = labelType.module
+          .moduleType(labelType.typeName)
+          .get
+          .asInstanceOf[LabelDeclaration]
+        val unused = declaration.unused().head
+        assert(unused.diagnostic.location == Location.span(7, 2, 10, 11))
+        assert(unused.diagnostic.location != definition.target)
+        assert(Location.extract(labelsSource, unused.diagnostic.location) == expectedUnusedElement)
     }
   }
 

--- a/jvm/src/test/scala/com/nawforce/apexlink/types/StandardObjectTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/types/StandardObjectTest.scala
@@ -568,7 +568,7 @@ class StandardObjectTest extends AnyFunSuite with TestHelper {
       assert(
         getMessages(root.join("objects", "Account.object"))
           .startsWith(
-            "Error: line 10: Expecting element 'fields' to have a single 'type' child element\n"
+            "Error: line 10:4 to 15:13: Expecting element 'fields' to have a single 'type' child element\n"
           )
       )
     }

--- a/jvm/src/test/scala/com/nawforce/pkgforce/workspace/WorkspaceTest.scala
+++ b/jvm/src/test/scala/com/nawforce/pkgforce/workspace/WorkspaceTest.scala
@@ -298,34 +298,52 @@ class WorkspaceTest extends AnyFunSuite with Matchers {
   }
 
   test("Label events") {
+    val source =
+      """<?xml version="1.0" encoding="UTF-8"?>
+        |<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
+        |    <labels>
+        |        <fullName>TestLabel1</fullName>
+        |        <protected>false</protected>
+        |    </labels>
+        |    <labels>
+        |        <fullName>TestLabel2</fullName>
+        |        <protected>true</protected>
+        |    </labels>
+        |</CustomLabels>
+        |""".stripMargin
     FileSystemHelper.run(
-      Map[String, String](
-        "force-app/main/default/labels/CustomLabels.labels" ->
-          """<?xml version="1.0" encoding="UTF-8"?>
-          |<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
-          |    <labels><fullName>TestLabel1</fullName><protected>false</protected></labels>
-          |    <labels><fullName>TestLabel2</fullName><protected>true</protected></labels>
-          |</CustomLabels>
-          |""".stripMargin
-      )
+      Map[String, String]("force-app/main/default/labels/CustomLabels.labels" -> source)
     ) { root: PathLike =>
       val (ws, logger) = Workspace(root)
       assert(logger.isEmpty)
       assert(ws.nonEmpty)
 
-      ws.get.events.toList should matchPattern {
+      val events = ws.get.events.toList
+      events should matchPattern {
         case List(
-              LabelEvent(
-                PathLocation(labelsPath1, Location(3, 0, 3, 0)),
-                Name("TestLabel1"),
-                false
-              ),
-              LabelEvent(PathLocation(labelsPath2, Location(4, 0, 4, 0)), Name("TestLabel2"), true),
+              LabelEvent(PathLocation(labelsPath1, _), Name("TestLabel1"), false),
+              LabelEvent(PathLocation(labelsPath2, _), Name("TestLabel2"), true),
               LabelFileEvent(SourceInfo(PathLocation(labelsPath3, Location.all), _))
             )
             if labelsPath1 == labelsPath(root) &&
               labelsPath2 == labelsPath1 && labelsPath3 == labelsPath1 =>
       }
+
+      val locations = events.collect { case LabelEvent(location, _, _) => location.location }
+      assert(locations == Seq(Location.span(3, 4, 6, 13), Location.span(7, 4, 10, 13)))
+      assert(locations.distinct.length == 2)
+      assert(
+        locations.map(Location.extract(source, _)) == Seq(
+          """<labels>
+            |        <fullName>TestLabel1</fullName>
+            |        <protected>false</protected>
+            |    </labels>""".stripMargin,
+          """<labels>
+            |        <fullName>TestLabel2</fullName>
+            |        <protected>true</protected>
+            |    </labels>""".stripMargin
+        )
+      )
     }
   }
 
@@ -733,13 +751,14 @@ class WorkspaceTest extends AnyFunSuite with Matchers {
   }
 
   test("Bad Custom Setting") {
+    val source =
+      """<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+        |  <customSettingsType>Bad</customSettingsType>
+        |</CustomObject>
+        |""".stripMargin
     FileSystemHelper.run(
       Map[String, String](
-        "force-app/main/default/objects/MyObject__c/MyObject__c.object-meta.xml" ->
-          """<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
-          |  <customSettingsType>Bad</customSettingsType>
-          |</CustomObject>
-          |""".stripMargin
+        "force-app/main/default/objects/MyObject__c/MyObject__c.object-meta.xml" -> source
       )
     ) { root: PathLike =>
       val (ws, logger) = Workspace(root)
@@ -754,17 +773,21 @@ class WorkspaceTest extends AnyFunSuite with Matchers {
         "MyObject__c.object-meta.xml"
       )
       val location = PathLocation(path, Location.all)
-      ws.get.events.toList should matchPattern {
+      val events   = ws.get.events.toList
+      events should matchPattern {
         case List(
               SObjectEvent(sourceInfo, name, false, None, None),
-              IssuesEvent(
-                ArraySeq(Issue(objectPath, Diagnostic(ERROR_CATEGORY, Location(1, _, 1, _), _), _))
-              )
+              IssuesEvent(ArraySeq(Issue(objectPath, Diagnostic(ERROR_CATEGORY, _, _), _)))
             )
             if sourceInfo.get.location == location && name == Name(
               "MyObject__c"
             ) && objectPath == path =>
       }
+      val issue = events.collectFirst { case IssuesEvent(issues) => issues.head }.get
+      assert(
+        Location.extract(source, issue.diagnostic.location) ==
+          "<customSettingsType>Bad</customSettingsType>"
+      )
     }
   }
 
@@ -798,13 +821,14 @@ class WorkspaceTest extends AnyFunSuite with Matchers {
   }
 
   test("Bad SharingModel") {
+    val source =
+      """<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+        |   <sharingModel>Something</sharingModel>
+        |</CustomObject>
+        |""".stripMargin
     FileSystemHelper.run(
       Map[String, String](
-        "force-app/main/default/objects/MyObject__c/MyObject__c.object-meta.xml" ->
-          """<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
-          |   <sharingModel>Something</sharingModel>
-          |</CustomObject>
-          |""".stripMargin
+        "force-app/main/default/objects/MyObject__c/MyObject__c.object-meta.xml" -> source
       )
     ) { root: PathLike =>
       val (ws, logger) = Workspace(root)
@@ -819,17 +843,100 @@ class WorkspaceTest extends AnyFunSuite with Matchers {
         "MyObject__c.object-meta.xml"
       )
       val location = PathLocation(path, Location.all)
-      ws.get.events.toList should matchPattern {
+      val events   = ws.get.events.toList
+      events should matchPattern {
         case List(
               SObjectEvent(sourceInfo, name, false, None, None),
-              IssuesEvent(
-                ArraySeq(Issue(objectPath, Diagnostic(ERROR_CATEGORY, Location(1, _, 1, _), _), _))
-              )
+              IssuesEvent(ArraySeq(Issue(objectPath, Diagnostic(ERROR_CATEGORY, _, _), _)))
             )
             if sourceInfo.get.location == location && name == Name(
               "MyObject__c"
             ) && objectPath == path =>
       }
+      val issue = events.collectFirst { case IssuesEvent(issues) => issues.head }.get
+      assert(
+        Location.extract(source, issue.diagnostic.location) ==
+          "<sharingModel>Something</sharingModel>"
+      )
+    }
+  }
+
+  test("Inline Custom Object component locations cover complete elements") {
+    val source =
+      """<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+        |  <fields>
+        |    <fullName>Name__c</fullName>
+        |    <type>Text</type>
+        |  </fields>
+        |  <fieldSets>
+        |    <fullName>Summary</fullName>
+        |  </fieldSets>
+        |  <sharingReasons>
+        |    <fullName>Manual</fullName>
+        |  </sharingReasons>
+        |</CustomObject>
+        |""".stripMargin
+    FileSystemHelper.run(
+      Map("force-app/main/default/objects/MyObject__c/MyObject__c.object-meta.xml" -> source)
+    ) { root: PathLike =>
+      val (ws, logger) = Workspace(root)
+      assert(logger.isEmpty)
+      val events = ws.get.events.toList
+      events should matchPattern {
+        case List(
+              SObjectEvent(_, Name("MyObject__c"), false, None, None),
+              CustomFieldEvent(_, Name("Name__c"), Name("Text"), None, None),
+              FieldsetEvent(_, Name("Summary")),
+              SharingReasonEvent(_, Name("Manual"))
+            ) =>
+      }
+
+      val locations = events.collect {
+        case CustomFieldEvent(sourceInfo, _, _, _, _) => sourceInfo.location.location
+        case FieldsetEvent(sourceInfo, _)             => sourceInfo.location.location
+        case SharingReasonEvent(sourceInfo, _)        => sourceInfo.location.location
+      }
+      assert(
+        locations == Seq(
+          Location.span(2, 2, 5, 11),
+          Location.span(6, 2, 8, 14),
+          Location.span(9, 2, 11, 19)
+        )
+      )
+      assert(
+        locations.map(Location.extract(source, _)) == Seq(
+          """<fields>
+            |    <fullName>Name__c</fullName>
+            |    <type>Text</type>
+            |  </fields>""".stripMargin,
+          """<fieldSets>
+            |    <fullName>Summary</fullName>
+            |  </fieldSets>""".stripMargin,
+          """<sharingReasons>
+            |    <fullName>Manual</fullName>
+            |  </sharingReasons>""".stripMargin
+        )
+      )
+    }
+  }
+
+  test("Invalid inline Custom Object field type selects the type element") {
+    val source =
+      """<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+        |  <fields>
+        |    <fullName>Name__c</fullName>
+        |    <type>Silly</type>
+        |  </fields>
+        |</CustomObject>
+        |""".stripMargin
+    FileSystemHelper.run(
+      Map("force-app/main/default/objects/MyObject__c/MyObject__c.object-meta.xml" -> source)
+    ) { root: PathLike =>
+      val (ws, logger) = Workspace(root)
+      assert(logger.isEmpty)
+      val issue = ws.get.events.collectFirst { case IssuesEvent(issues) => issues.head }.get
+      assert(issue.diagnostic.location == Location.span(4, 4, 4, 22))
+      assert(Location.extract(source, issue.diagnostic.location) == "<type>Silly</type>")
     }
   }
 

--- a/jvm/src/test/scala/io/github/apexdevtools/apexls/CheckForIssuesTest.scala
+++ b/jvm/src/test/scala/io/github/apexdevtools/apexls/CheckForIssuesTest.scala
@@ -1,6 +1,11 @@
 package io.github.apexdevtools.apexls
 
+import com.nawforce.pkgforce.path.PathLike
+import com.nawforce.runtime.FileSystemHelper
 import org.scalatest.funsuite.AnyFunSuite
+
+import java.io.{ByteArrayOutputStream, PrintStream}
+import java.nio.charset.StandardCharsets
 
 class CheckForIssuesTest extends AnyFunSuite {
 
@@ -25,5 +30,55 @@ class CheckForIssuesTest extends AnyFunSuite {
     assert(
       CheckForIssues.exitStatus(hasErrors = false, hasWarnings = false, hasUnused = false) == 0
     )
+  }
+
+  test("JSON diagnostics preserve exact XML element ranges") {
+    withInvalidFieldType { root =>
+      val (status, output) = runAndCapture(root, "json")
+      assert(status == 4)
+      val message = ujson
+        .read(output)("files")(0)("messages")
+        .arr
+        .find(_("message").str.contains("Unrecognised type"))
+        .getOrElse(fail(output))
+      assert(message("start") == ujson.Obj("line" -> 4, "offset" -> 4))
+      assert(message("end") == ujson.Obj("line" -> 4, "offset" -> 22))
+    }
+  }
+
+  test("PMD diagnostics preserve exact XML element ranges") {
+    withInvalidFieldType { root =>
+      val (status, output) = runAndCapture(root, "pmd")
+      assert(status == 4)
+      val violation = (scala.xml.XML.loadString(output) \\ "violation")
+        .find(_.text.contains("Unrecognised type"))
+        .getOrElse(fail(output))
+      assert(violation \@ "beginline" == "4")
+      assert(violation \@ "endline" == "4")
+      assert(violation \@ "begincolumn" == "4")
+      assert(violation \@ "endcolumn" == "22")
+    }
+  }
+
+  private def withInvalidFieldType(verify: PathLike => Unit): Unit = {
+    val source =
+      """<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+        |  <fields>
+        |    <fullName>Name__c</fullName>
+        |    <type>Silly</type>
+        |  </fields>
+        |</CustomObject>
+        |""".stripMargin
+    FileSystemHelper.runTempDir(Map("objects/Foo__c.object" -> source))(verify)
+  }
+
+  private def runAndCapture(root: PathLike, format: String): (Int, String) = {
+    val bytes  = new ByteArrayOutputStream()
+    val stream = new PrintStream(bytes, true, StandardCharsets.UTF_8.name())
+    val status = Console.withOut(stream) {
+      CheckForIssues.run(format, "none", "errors", nocache = true, Seq.empty, root.toString, "")
+    }
+    stream.flush()
+    (status, new String(bytes.toByteArray, StandardCharsets.UTF_8))
   }
 }

--- a/shared/src/main/scala/com/nawforce/pkgforce/path/Location.scala
+++ b/shared/src/main/scala/com/nawforce/pkgforce/path/Location.scala
@@ -44,6 +44,62 @@ object Location {
   def apply(startLine: Int, startPosition: Int, endLine: Int, endPosition: Int): Location = {
     new Location(startLine, startPosition, endLine, endPosition)
   }
+
+  /** A zero-length point at the supplied one-based line and zero-based column. */
+  def point(line: Int, column: Int): Location =
+    new Location(line, column, line, column)
+
+  /** The complete content of a one-based line as a half-open range. The end column is an explicit
+    * sentinel which [[extract]] clamps before the line terminator.
+    */
+  def wholeLine(line: Int): Location =
+    new Location(line, 0, line, Int.MaxValue)
+
+  /** A half-open range from the supplied start coordinate (inclusive) to end coordinate
+    * (exclusive). Lines are one-based and columns are zero-based Unicode code-point offsets.
+    */
+  def span(startLine: Int, startColumn: Int, endLine: Int, endColumn: Int): Location =
+    new Location(startLine, startColumn, endLine, endColumn)
+
+  /** Extract a half-open location from source text. Coordinates beyond a line's content are
+    * clamped before its line terminator, so [[wholeLine]] never consumes the following newline.
+    * Lines beyond the source are clamped to the end, retaining [[all]] behavior.
+    */
+  def extract(source: String, location: Location): String =
+    source.substring(
+      sourceIndex(source, location.startLine, location.startPosition),
+      sourceIndex(source, location.endLine, location.endPosition)
+    )
+
+  private def sourceIndex(source: String, targetLine: Int, targetColumn: Int): Int = {
+    var index = 0
+    var line  = 1
+    while (line < targetLine && index < source.length) {
+      source.charAt(index) match {
+        case '\r' =>
+          index += 1
+          if (index < source.length && source.charAt(index) == '\n') index += 1
+          line += 1
+        case '\n' =>
+          index += 1
+          line += 1
+        case _ => index += Character.charCount(Character.codePointAt(source, index))
+      }
+    }
+
+    if (line < targetLine) {
+      source.length
+    } else {
+      val lineStart = index
+      while (
+        index < source.length && source.charAt(index) != '\r' && source.charAt(index) != '\n'
+      ) {
+        index += Character.charCount(Character.codePointAt(source, index))
+      }
+      val lineLength = source.codePointCount(lineStart, index)
+      source.offsetByCodePoints(lineStart, Math.max(0, Math.min(targetColumn, lineLength)))
+    }
+  }
 }
 
 sealed case class LocationAnd[T](location: Location, value: T)

--- a/shared/src/main/scala/com/nawforce/pkgforce/xml/XMLDocumentLike.scala
+++ b/shared/src/main/scala/com/nawforce/pkgforce/xml/XMLDocumentLike.scala
@@ -39,15 +39,12 @@ trait XMLElementLike {
   def checkIsOrThrow(value: String): Unit = {
     if (name.namespace != XMLDocumentLike.sfNamespace) {
       throw XMLException(
-        Location(line),
+        location,
         s"Expected element in Salesforce namespace, but has namespace '${name.namespace}' "
       )
     }
     if (name.label != value) {
-      throw XMLException(
-        Location(line),
-        s"Expected element named '$value', but found '${name.label}'"
-      )
+      throw XMLException(location, s"Expected element named '$value', but found '${name.label}'")
     }
   }
 
@@ -69,7 +66,7 @@ trait XMLElementLike {
     val text = getOptionalSingleChildAsString(name)
     if (text.isEmpty)
       throw XMLException(
-        Location(line),
+        location,
         s"Expecting element '${this.name.label}' to have a single '$name' child element"
       )
     text.get
@@ -85,7 +82,7 @@ trait XMLElementLike {
     val value = getOptionalSingleChildAsBoolean(name)
     if (value.isEmpty)
       throw XMLException(
-        Location(line),
+        location,
         s"Expecting element '${this.name.label}' to have a single '$name' child element"
       )
     value.get
@@ -98,7 +95,7 @@ trait XMLElementLike {
       val isBoolean = matched.get.text.matches("true|false")
       if (!isBoolean)
         throw XMLException(
-          Location(line),
+          matched.get.location,
           s"Expecting value to be either 'true' or 'false', found '${matched.get.text}'"
         )
       Some(matched.get.text == "true")

--- a/shared/src/test/scala/com/nawforce/pkgforce/documents/XMLDocumentTest.scala
+++ b/shared/src/test/scala/com/nawforce/pkgforce/documents/XMLDocumentTest.scala
@@ -390,6 +390,7 @@ class XMLDocumentTest extends AnyFunSuite {
           } catch {
             case ex: XMLException =>
               assert(ex.msg == "Expecting element 'test' to have a single 'a' child element")
+              assert(ex.where == doc.rootElement.location)
             case _: Throwable => assert(false)
           }
       }
@@ -412,9 +413,27 @@ class XMLDocumentTest extends AnyFunSuite {
           } catch {
             case ex: XMLException =>
               assert(ex.msg == "Expecting element 'test' to have a single 'a' child element")
+              assert(ex.where == doc.rootElement.location)
             case _: Throwable => assert(false)
           }
       }
+    }
+  }
+
+  test("element validation errors select the smallest offending element") {
+    val source =
+      s"<wrong xmlns='$namespace'><enabled>sometimes</enabled></wrong>"
+    withDocument(source) { doc =>
+      val root    = doc.rootElement
+      val enabled = root.getChildren("enabled").head
+
+      val wrongName = intercept[XMLException](root.checkIsOrThrow("expected"))
+      assert(wrongName.where == root.location)
+      assert(Location.extract(source, wrongName.where) == source)
+
+      val wrongBoolean = intercept[XMLException](root.getOptionalSingleChildAsBoolean("enabled"))
+      assert(wrongBoolean.where == enabled.location)
+      assert(Location.extract(source, wrongBoolean.where) == "<enabled>sometimes</enabled>")
     }
   }
 
@@ -427,30 +446,7 @@ class XMLDocumentTest extends AnyFunSuite {
     }
   }
 
-  private def slice(source: String, location: Location): String = {
-    source.substring(
-      indexAt(source, location.startLine, location.startPosition),
-      indexAt(source, location.endLine, location.endPosition)
-    )
-  }
-
-  private def indexAt(source: String, targetLine: Int, codePointColumn: Int): Int = {
-    var index       = 0
-    var currentLine = 1
-    while (currentLine < targetLine) {
-      source.charAt(index) match {
-        case '\r' =>
-          index += 1
-          if (index < source.length && source.charAt(index) == '\n') index += 1
-          currentLine += 1
-        case '\n' =>
-          index += 1
-          currentLine += 1
-        case char => index += Character.charCount(Character.codePointAt(source, index))
-      }
-    }
-    source.offsetByCodePoints(index, codePointColumn)
-  }
+  private def slice(source: String, location: Location): String = Location.extract(source, location)
 
   private def newlineName(newline: String): String = newline match {
     case "\n"   => "LF"

--- a/shared/src/test/scala/com/nawforce/pkgforce/path/LocationTest.scala
+++ b/shared/src/test/scala/com/nawforce/pkgforce/path/LocationTest.scala
@@ -1,0 +1,64 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+package com.nawforce.pkgforce.path
+
+import org.scalatest.funsuite.AnyFunSuite
+import upickle.default.{read, write}
+
+class LocationTest extends AnyFunSuite {
+
+  test("named factories retain constructor and sentinel compatibility") {
+    assert(Location.point(2, 3) == Location(2, 3))
+    assert(Location.span(2, 3, 4, 5) == Location(2, 3, 4, 5))
+    assert(Location.wholeLine(2) == Location(2, 0, 2, Int.MaxValue))
+    assert(Location.empty == Location(1))
+    assert(Location.all == Location(1, 0, Int.MaxValue, 0))
+  }
+
+  test("named factories retain structural equality, hashing and four-field serialization") {
+    val location = Location.span(2, 3, 4, 5)
+    assert(location == Location(2, 3, 4, 5))
+    assert(location.hashCode == Location(2, 3, 4, 5).hashCode)
+
+    val json = ujson.read(write(location))
+    assert(json.obj.keySet == Set("startLine", "startPosition", "endLine", "endPosition"))
+    assert(read[Location](json) == location)
+  }
+
+  Seq(
+    "LF"    -> ("first\nsecond\nthird", 2, "second"),
+    "CRLF"  -> ("first\r\nsecond\r\nthird", 2, "second"),
+    "CR"    -> ("first\rsecond\rthird", 2, "second"),
+    "empty" -> ("first\n\nthird", 2, ""),
+    "final" -> ("first\nfinal", 2, "final")
+  ).foreach { case (name, (source, line, expected)) =>
+    test(s"wholeLine clamps to $name line content") {
+      assert(Location.extract(source, Location.wholeLine(line)) == expected)
+    }
+  }
+
+  test("wholeLine clamps empty source and an empty final line") {
+    assert(Location.extract("", Location.wholeLine(1)).isEmpty)
+    assert(Location.extract("first\n", Location.wholeLine(2)).isEmpty)
+  }
+
+  test("span extraction is half-open and uses Unicode code-point columns") {
+    val source = "zero\né🤦abc\nlast"
+    assert(Location.extract(source, Location.span(2, 1, 2, 4)) == "🤦ab")
+    assert(Location.extract(source, Location.span(1, 2, 3, 2)) == "ro\né🤦abc\nla")
+    assert(Location.extract(source, Location.point(2, 2)).isEmpty)
+    assert(Location.extract(source, Location.all) == source)
+    assert(Location.extract("first\n", Location.all) == "first\n")
+  }
+}


### PR DESCRIPTION
Closes #362

## Summary

- add explicit `Location.point`, `Location.wholeLine`, and half-open `Location.span` factories without changing any existing `apply` overload, `empty`, `all`, structural equality/hash behavior, or the four-field codec shape
- add one shared, JVM/Scala.js-compatible `Location.extract` boundary that clamps `Int.MaxValue` whole-line end columns before LF, CRLF, and CR terminators while retaining `Location.all` whole-source behavior
- audit all seven production XML `Location(element.line)` consumers and migrate labels, inline SObject fields/field sets/sharing reasons, custom setting and sharing model errors, invalid field types, and XML validation to exact element locations
- retain `XMLElementLike.line`, its point-location default fallback, point-style parser/config diagnostics, standalone metadata `Location.all` events, and existing cache/protocol/outline-parser behavior
- document the factory, coordinate, extraction, and XML-consumer contracts

## Range and snapshot audit

- invalid custom-field values now select the smallest `<type>` child; missing child and derived lookup diagnostics select the enclosing inline `<fields>` element
- label definition target/selection and unused diagnostics select their distinct complete `<labels>` elements
- the navigation test extractor now renders the full source for `Location.all`; raw definition assertions confirm standalone metadata target and selection remain `Location.all`
- one pinned system snapshot changed: `Volunteers-for-Salesforce` now reports the complete inline Campaign `<fields>` element (`101:4` to `109:13`) instead of line 101
- no other npm/system snapshots and no cache formats changed

## Tests

- `sbt scalafmtAll`
- `sbt scalafmtCheck`
- focused shared/JVM/Scala.js Location, XML, workspace, label, SObject, JSON/RPC, JSON diagnostic, and PMD diagnostic tests
- `sbt apexlsJVM/test` (2,639 passed)
- `sbt apexlsJS/test` (400 passed)
- `sbt apexlsJVM/build`
- `sbt apexlsJS/build`
- `SAMPLES=.../apex-samples npm run test-samples -- --runInBand --silent` against recursively initialized `v1.4.0` fixtures (100 passed, 100 snapshots passed)

The standalone `npm test -- --runInBand src/__tests__/WorkspaceTest.ts` command remains non-green locally: its six memfs-backed workspace tests resolve host paths with the compiled bundle and fail before any location assertions. The Actions workflow does not run this unit command; the Scala.js suite and pinned npm system adapter/snapshot suite above are green.

## Risk

`Location.wholeLine` intentionally serializes its `Int.MaxValue` end-column sentinel in the existing four-integer shape. Source consumers should use `Location.extract` when slicing so the sentinel is clamped at line content; no optional fields or protocol changes were introduced.
