### PR TITLE
feat: validate accessibility of nested Apex types at source references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Errors when an inaccessible nested Apex class, interface, or enum is written explicitly in
   source, covering declared, parameter, return, construction, cast, `instanceof`, type literal,
   qualifier, catch, for-loop, switch, extends and implements positions, honouring same-file access
-  and the `@TestVisible` unit-test exception (#341)
+  and the `@TestVisible` unit-test exception. Type reference positions are checked for qualified
+  names such as `Outer.Hidden`; a name Apex resolves unqualified through a superclass in another
+  file is not reported there (#341)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bomb rankings (#528)
 - Public impacted and declared test-class discovery APIs, plus a deterministic `test-classes` JVM
   batch command with dependency explanations and namespace-qualified names (#529)
+- Errors when an inaccessible nested Apex class, interface, or enum is written explicitly in
+  source, covering declared, parameter, return, construction, cast, `instanceof`, type literal,
+  qualifier, catch, for-loop, switch, extends and implements positions, honouring same-file access
+  and the `@TestVisible` unit-test exception (#341)
 
 ### Changed
 
 - Labels, inline SObject components, and XML-derived metadata validation diagnostics now use exact
   element ranges; standalone metadata components continue to use whole-file locations (#362)
+- The private parent class check on `extends` now reports `Type is not visible: <type>` against the
+  written parent type name rather than the class identifier, and applies the same `@TestVisible`
+  and same-file rules as every other explicit type reference (#341)
 
 ## [6.2.0] - 2026-07-29
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/BodyDeclarations.scala
@@ -305,10 +305,11 @@ object ApexMethodDeclaration {
     val block = Option(from.block())
       .map(b => Block.constructOuterFromANTLR(parser, b))
 
+    val (returnTypeName, occurrences) = TypeReference.constructWithOccurrences(from.typeRef())
     new ApexMethodDeclaration(
       thisType,
       modifiers,
-      RelativeTypeName(typeContext, TypeReference.construct(from.typeRef())),
+      RelativeTypeName(typeContext, returnTypeName, occurrences),
       Id.construct(from.id()),
       FormalParameters.construct(parser, typeContext, from.formalParameters()),
       block
@@ -322,13 +323,13 @@ object ApexMethodDeclaration {
     modifiers: ModifierResults,
     from: InterfaceMethodDeclarationContext
   ): ApexMethodDeclaration = {
-    val typeName = Option(from.typeRef())
-      .map(tr => TypeReference.construct(tr))
-      .getOrElse(TypeNames.Void)
+    val (typeName, occurrences) = Option(from.typeRef())
+      .map(tr => TypeReference.constructWithOccurrences(tr))
+      .getOrElse((TypeNames.Void, SourceTypeOccurrence.empty))
     new ApexMethodDeclaration(
       thisType,
       modifiers,
-      RelativeTypeName(typeContext, typeName),
+      RelativeTypeName(typeContext, typeName, occurrences),
       Id.construct(from.id()),
       FormalParameters.construct(parser, typeContext, from.formalParameters()),
       None
@@ -341,7 +342,8 @@ final case class ApexFieldDeclaration(
   _modifiers: ModifierResults,
   typeName: TypeName,
   variableDeclarator: VariableDeclarator,
-  isEnumConstant: Boolean = false
+  isEnumConstant: Boolean = false,
+  typeOccurrences: ArraySeq[SourceTypeOccurrence] = SourceTypeOccurrence.empty
 ) extends ClassBodyDeclaration(_modifiers)
     with ApexFieldLike {
 
@@ -369,6 +371,8 @@ final case class ApexFieldDeclaration(
       context.log(Issue(ERROR_CATEGORY, location, s"protected field '${id.name}' cannot be static"))
     }
 
+    SourceTypeAccess.validate(typeOccurrences, context)
+
     variableDeclarator.verify(
       ExprContext(staticContext, context.thisType),
       new OuterScopeVerifyContext(context, modifiers.contains(STATIC_MODIFIER))
@@ -383,7 +387,8 @@ object ApexFieldDeclaration {
     modifiers: ModifierResults,
     fieldDeclaration: FieldDeclarationContext
   ): Seq[ApexFieldDeclaration] = {
-    val typeName = TypeReference.construct(fieldDeclaration.typeRef())
+    val (typeName, occurrences) =
+      TypeReference.constructWithOccurrences(fieldDeclaration.typeRef())
     VariableDeclarators
       .construct(
         typeName,
@@ -392,7 +397,8 @@ object ApexFieldDeclaration {
       )
       .declarators
       .map(vd => {
-        ApexFieldDeclaration(thisType, modifiers, typeName, vd).withContext(fieldDeclaration)
+        ApexFieldDeclaration(thisType, modifiers, typeName, vd, typeOccurrences = occurrences)
+          .withContext(fieldDeclaration)
       })
   }
 }
@@ -470,6 +476,7 @@ final case class FormalParameter(
   def verify(context: BodyDeclarationVerifyContext): Unit = {
     id.validate(context)
     modifiers.issues.foreach(context.log)
+    relativeTypeName.validateAccess(context)
   }
 }
 
@@ -487,9 +494,10 @@ object FormalParameter {
     typeContext: RelativeTypeContext,
     from: FormalParameterContext
   ): FormalParameter = {
+    val (typeName, occurrences) = TypeReference.constructWithOccurrences(from.typeRef)
     FormalParameter(
       ApexModifiers.parameterModifiers(parser, CodeParser.toScala(from.modifier()), from),
-      RelativeTypeName(typeContext, TypeReference.construct(from.typeRef)),
+      RelativeTypeName(typeContext, typeName, occurrences),
       Id.construct(from.id())
     )
   }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/CST.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/CST.scala
@@ -17,7 +17,7 @@ import com.nawforce.apexlink.diagnostics.IssueOps
 import com.nawforce.apexlink.names.XNames.NameUtils
 import com.nawforce.pkgforce.diagnostics.Issue
 import com.nawforce.pkgforce.names.{Name, Names, TypeName}
-import com.nawforce.pkgforce.path.Positionable
+import com.nawforce.pkgforce.path.{PathLocation, Positionable}
 import com.nawforce.runtime.parsers.{CodeParser, Source}
 import io.github.apexdevtools.apexparser.ApexParser._
 
@@ -89,6 +89,11 @@ object Id {
 
 final case class QualifiedName(names: Seq[Name]) extends CST {
   def asTypeName(): TypeName = TypeName(names.reverse)
+
+  /** Locations of the individual identifiers of the name, empty when constructed without a parse
+    * context. Used to report against the final identifier of a written type reference.
+    */
+  var idLocations: Seq[PathLocation] = Nil
 }
 
 object QualifiedName {
@@ -99,8 +104,10 @@ object QualifiedName {
   def construct(qualifiedName: QualifiedNameContext): Option[QualifiedName] = {
     Option(qualifiedName).map(qualifiedName => {
       val ids = CodeParser.toScala(qualifiedName.id())
-      QualifiedName(ids.map(id => Names(Option(id).map(_.getText).getOrElse(""))))
+      val qname = QualifiedName(ids.map(id => Names(Option(id).map(_.getText).getOrElse(""))))
         .withContext(qualifiedName)
+      CST.sourceContext.value.foreach(source => qname.idLocations = ids.map(source.getLocation))
+      qname
     })
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Creator.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Creator.scala
@@ -37,6 +37,12 @@ final case class CreatedName(idPairs: List[IdCreatedNamePair]) extends CST {
 
   def verify(context: ExpressionVerifyContext): ExprContext = {
 
+    // The written name is the dotted chain of ids, report against its final identifier
+    idPairs.lastOption.foreach(last =>
+      SourceTypeAccess.validate(typeName, last.id.location, context)
+    )
+    idPairs.foreach(pair => SourceTypeAccess.validate(pair.typeOccurrences, context))
+
     val newType = context.getTypeAndAddDependency(typeName, context.thisType).toOption
     if (newType.nonEmpty) {
       ExprContext(isStatic = Some(false), newType, newType.get)
@@ -54,7 +60,11 @@ object CreatedName {
   }
 }
 
-final case class IdCreatedNamePair(id: Id, types: ArraySeq[TypeName]) extends CST {
+final case class IdCreatedNamePair(
+  id: Id,
+  types: ArraySeq[TypeName],
+  typeOccurrences: ArraySeq[SourceTypeOccurrence] = SourceTypeOccurrence.empty
+) extends CST {
   val typeName: TypeName = {
     val encName = EncodedName(id.name)
     if (encName.ext.nonEmpty)
@@ -70,12 +80,10 @@ object IdCreatedNamePair {
   }
 
   def construct(from: IdCreatedNamePairContext): IdCreatedNamePair = {
-    IdCreatedNamePair(
-      Id.constructAny(from.anyId()),
-      Option(from.typeList())
-        .map(tl => TypeList.construct(tl))
-        .getOrElse(TypeNames.emptyTypeNames)
-    ).withContext(from)
+    val (types, occurrences) = Option(from.typeList())
+      .map(tl => TypeList.constructWithOccurrences(tl))
+      .getOrElse((TypeNames.emptyTypeNames, SourceTypeOccurrence.empty))
+    IdCreatedNamePair(Id.constructAny(from.anyId()), types, occurrences).withContext(from)
   }
 }
 

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Expressions.scala
@@ -476,10 +476,10 @@ final case class DotExpressionWithId(expression: Expression, safeNavigation: Boo
       )
     }
 
-    // TODO: Private/protected types?
     if (input.isStatic.contains(true)) {
       val nt = inputType.findLocalType(TypeName(name))
       if (nt.nonEmpty) {
+        SourceTypeAccess.validate(nt.get, target.location, context)
         return ExprContext(isStatic = Some(true), nt.get)
       }
     }
@@ -789,9 +789,14 @@ final case class NewExpression(creator: Creator) extends Expression {
   }
 }
 
-final case class CastExpression(typeName: TypeName, expression: Expression) extends Expression {
+final case class CastExpression(
+  typeName: TypeName,
+  expression: Expression,
+  typeOccurrences: ArraySeq[SourceTypeOccurrence] = SourceTypeOccurrence.empty
+) extends Expression {
   override def verify(input: ExprContext, context: ExpressionVerifyContext): ExprContext = {
     expression.verify(input, context)
+    SourceTypeAccess.validate(typeOccurrences, context)
 
     val castType = context.getTypeAndAddDependency(typeName, context.thisType).toOption
     if (castType.isEmpty) {
@@ -950,9 +955,13 @@ final case class BinaryExpression(lhs: Expression, rhs: Expression, op: String) 
   }
 }
 
-final case class InstanceOfExpression(expression: Expression, typeName: TypeName)
-    extends Expression {
+final case class InstanceOfExpression(
+  expression: Expression,
+  typeName: TypeName,
+  typeOccurrences: ArraySeq[SourceTypeOccurrence] = SourceTypeOccurrence.empty
+) extends Expression {
   override def verify(input: ExprContext, context: ExpressionVerifyContext): ExprContext = {
+    SourceTypeAccess.validate(typeOccurrences, context)
     val instanceOfType = context.getTypeAndAddDependency(typeName, context.thisType).toOption
     if (instanceOfType.isEmpty)
       context.missingType(location, typeName)
@@ -1035,10 +1044,8 @@ object Expression {
           NewExpression(Creator.construct(expr.creator()))
 
         case expr: CastExpressionContext =>
-          CastExpression(
-            TypeReference.construct(expr.typeRef()),
-            Expression.construct(expr.expression())
-          )
+          val (typeName, occurrences) = TypeReference.constructWithOccurrences(expr.typeRef())
+          CastExpression(typeName, Expression.construct(expr.expression()), occurrences)
 
         case expr: SubExpressionContext =>
           SubExpression(Expression.construct(expr.expression()))
@@ -1135,10 +1142,8 @@ object Expression {
           }
 
         case expr: InstanceOfExpressionContext =>
-          InstanceOfExpression(
-            Expression.construct(expr.expression()),
-            TypeReference.construct(expr.typeRef())
-          )
+          val (typeName, occurrences) = TypeReference.constructWithOccurrences(expr.typeRef())
+          InstanceOfExpression(Expression.construct(expr.expression()), typeName, occurrences)
 
         case expr: EqualityExpressionContext =>
           val op = Option(expr.EQUAL())

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Primaries.scala
@@ -67,8 +67,13 @@ final case class LiteralPrimary(literal: Literal) extends Primary {
   }
 }
 
-final case class TypeReferencePrimary(typeName: TypeName) extends Primary {
+final case class TypeReferencePrimary(
+  typeName: TypeName,
+  typeOccurrences: ArraySeq[SourceTypeOccurrence] = SourceTypeOccurrence.empty
+) extends Primary {
   override def verify(input: ExprContext, context: ExpressionVerifyContext): ExprContext = {
+
+    SourceTypeAccess.validate(typeOccurrences, context)
 
     // Workaround miss parsing of Foo__c.SObjectType.class as a typeRef
     val targetTypeName =
@@ -183,8 +188,10 @@ final case class IdPrimary(id: Id) extends Primary {
 
   private def isTypeReference(context: ExpressionVerifyContext): Option[ExprContext] = {
     context.getTypeAndAddDependency(TypeName(id.name), context.thisType) match {
-      case Right(td) => Some(ExprContext(isStatic = Some(true), Some(td), td))
-      case _         => None
+      case Right(td) =>
+        SourceTypeAccess.validate(td, id.location, context)
+        Some(ExprContext(isStatic = Some(true), Some(td), td))
+      case _ => None
     }
   }
 
@@ -424,7 +431,8 @@ object Primary {
         case ctx: LiteralPrimaryContext =>
           LiteralPrimary(Literal.construct(ctx.literal())).withContext(ctx.literal())
         case ctx: TypeRefPrimaryContext =>
-          TypeReferencePrimary(TypeReference.construct(ctx.typeRef()))
+          val (typeName, occurrences) = TypeReference.constructWithOccurrences(ctx.typeRef())
+          TypeReferencePrimary(typeName, occurrences)
         case _: VoidPrimaryContext =>
           TypeReferencePrimary(TypeName.Void)
         case id: IdPrimaryContext =>

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Properties.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Properties.scala
@@ -33,7 +33,8 @@ final case class ApexPropertyDeclaration(
   _modifiers: ModifierResults,
   typeName: TypeName,
   id: Id,
-  propertyBlocks: Seq[PropertyBlock]
+  propertyBlocks: Seq[PropertyBlock],
+  typeOccurrences: ArraySeq[SourceTypeOccurrence] = SourceTypeOccurrence.empty
 ) extends ClassBodyDeclaration(_modifiers)
     with ApexFieldLike {
 
@@ -67,6 +68,8 @@ final case class ApexPropertyDeclaration(
       .getOrElse(visibility.getOrElse(PRIVATE_MODIFIER))
 
   override def verify(context: BodyDeclarationVerifyContext): Unit = {
+    SourceTypeAccess.validate(typeOccurrences, context)
+
     val propertyType = context.getTypeAndAddDependency(typeName, context.thisType).toOption
     if (propertyType.isEmpty)
       context.missingType(id.location, typeName)
@@ -102,7 +105,8 @@ object ApexPropertyDeclaration {
     modifiers: ModifierResults,
     propertyDeclaration: PropertyDeclarationContext
   ): ApexPropertyDeclaration = {
-    val typeName = TypeReference.construct(propertyDeclaration.typeRef())
+    val (typeName, occurrences) =
+      TypeReference.constructWithOccurrences(propertyDeclaration.typeRef())
     ApexPropertyDeclaration(
       thisType,
       modifiers,
@@ -110,7 +114,8 @@ object ApexPropertyDeclaration {
       Id.construct(propertyDeclaration.id()),
       CodeParser
         .toScala(propertyDeclaration.propertyBlock())
-        .flatMap(pb => PropertyBlock.construct(parser, pb, typeName))
+        .flatMap(pb => PropertyBlock.construct(parser, pb, typeName)),
+      occurrences
     ).withContext(propertyDeclaration)
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/SourceTypeAccess.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/SourceTypeAccess.scala
@@ -1,0 +1,71 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.apexlink.cst
+
+import com.nawforce.apexlink.types.apex.ApexDeclaration
+import com.nawforce.apexlink.types.core.TypeDeclaration
+import com.nawforce.pkgforce.names.TypeName
+import com.nawforce.pkgforce.path.PathLocation
+
+import scala.collection.immutable.ArraySeq
+
+/** A type explicitly written in Apex source along with the location of the final identifier of the
+  * written name. A single type reference such as 'Map<String, Outer.Hidden[]>' yields an occurrence
+  * for each written component so that a diagnostic can be reported against the component at fault
+  * rather than against the normalized collection wrapper.
+  */
+final case class SourceTypeOccurrence(typeName: TypeName, location: PathLocation)
+
+object SourceTypeOccurrence {
+  val empty: ArraySeq[SourceTypeOccurrence] = ArraySeq.empty
+}
+
+/** Validation of the accessibility of types that are explicitly written in Apex source.
+  *
+  * Lookup and dependency registration are deliberately left alone; this is a pure post-resolution
+  * check so that a visibility failure does not disturb downstream analysis. Only nested Apex
+  * declarations are examined, other declaration kinds (platform, SObject, Component, Page, ghosted,
+  * synthetic) have their own visibility rules or none at all.
+  */
+object SourceTypeAccess {
+
+  def validate(occurrences: ArraySeq[SourceTypeOccurrence], context: VerifyContext): Unit = {
+    if (occurrences.nonEmpty && !context.suppressIssues)
+      occurrences.foreach(occurrence => validate(occurrence.typeName, occurrence.location, context))
+  }
+
+  /** Validate a written type name, resolving it via the normal (cached) lookup. */
+  def validate(typeName: TypeName, location: PathLocation, context: VerifyContext): Unit = {
+    if (!context.suppressIssues)
+      context
+        .getTypeFor(typeName, context.thisType)
+        .foreach(td => validate(td, location, context))
+  }
+
+  /** Validate an already resolved type that was explicitly written at the given location. */
+  def validate(td: TypeDeclaration, location: PathLocation, context: VerifyContext): Unit = {
+    td match {
+      case nested: ApexDeclaration if nested.outerTypeName.nonEmpty && !context.suppressIssues =>
+        TestVisibleAccess
+          .access(nested, Some(context.thisType))
+          .errorMessage
+          .foreach(message =>
+            if (context.recordTypeVisibilityIssue(location, nested.typeId))
+              context.logError(location, message)
+          )
+      case _ => ()
+    }
+  }
+}

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/SourceTypeAccess.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/SourceTypeAccess.scala
@@ -23,13 +23,31 @@ import scala.collection.immutable.ArraySeq
 
 /** A type explicitly written in Apex source along with the location of the final identifier of the
   * written name. A single type reference such as 'Map<String, Outer.Hidden[]>' yields an occurrence
-  * for each written component so that a diagnostic can be reported against the component at fault
-  * rather than against the normalized collection wrapper.
+  * for each written component that could denote a nested type, so that a diagnostic can be reported
+  * against the component at fault rather than against the normalized collection wrapper.
+  *
+  * Only qualified names are recorded, see TypeReference; an unqualified name is either a top level
+  * type or resolves to a nested type that is visible from where it is written.
   */
 final case class SourceTypeOccurrence(typeName: TypeName, location: PathLocation)
 
 object SourceTypeOccurrence {
   val empty: ArraySeq[SourceTypeOccurrence] = ArraySeq.empty
+
+  /** Join two occurrence lists, keeping the shared empty instance when neither recorded anything. */
+  def concat(
+    left: ArraySeq[SourceTypeOccurrence],
+    right: ArraySeq[SourceTypeOccurrence]
+  ): ArraySeq[SourceTypeOccurrence] = {
+    if (left.isEmpty) right
+    else if (right.isEmpty) left
+    else left ++ right
+  }
+
+  /** Join occurrence lists, keeping the shared empty instance when none recorded anything. */
+  def concat(parts: Seq[ArraySeq[SourceTypeOccurrence]]): ArraySeq[SourceTypeOccurrence] = {
+    if (parts.forall(_.isEmpty)) empty else ArraySeq.from(parts.flatten)
+  }
 }
 
 /** Validation of the accessibility of types that are explicitly written in Apex source.

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Statements.scala
@@ -327,8 +327,12 @@ object ForControl {
   * @param id loop variable identifier
   * @param expression iteration expression
   */
-final case class EnhancedForControl(typeName: TypeName, id: Id, expression: Expression)
-    extends ForControl {
+final case class EnhancedForControl(
+  typeName: TypeName,
+  id: Id,
+  expression: Expression,
+  typeOccurrences: ArraySeq[SourceTypeOccurrence] = SourceTypeOccurrence.empty
+) extends ForControl {
 
   /** Add vars introduced by the control to a context */
   override def addVars(context: ScopeVerifyContext): Unit = {
@@ -337,6 +341,7 @@ final case class EnhancedForControl(typeName: TypeName, id: Id, expression: Expr
 
   override def verify(context: ScopeVerifyContext): Unit = {
     id.validate(context)
+    SourceTypeAccess.validate(typeOccurrences, context)
 
     // Check expression first to build dependencies before we can bail out
     val exprContext = expression.verify(context)
@@ -409,10 +414,12 @@ final case class EnhancedForControl(typeName: TypeName, id: Id, expression: Expr
 object EnhancedForControl {
 
   def construct(from: EnhancedForControlContext): EnhancedForControl = {
+    val (typeName, occurrences) = TypeReference.constructWithOccurrences(from.typeRef())
     EnhancedForControl(
-      TypeReference.construct(from.typeRef()),
+      typeName,
       Id.construct(from.id()),
-      Expression.construct(from.expression())
+      Expression.construct(from.expression()),
+      occurrences
     ).withContext(from)
   }
 }
@@ -591,6 +598,11 @@ final case class CatchClause(
             context.module.any
           case Right(td) =>
             if (exceptionTypeName.name.endsWith(Names.Exception)) {
+              SourceTypeAccess.validate(
+                td,
+                qname.idLocations.lastOption.getOrElse(qname.location),
+                context
+              )
               td
             } else {
               context.log(

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeDeclarations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeDeclarations.scala
@@ -170,7 +170,7 @@ object ClassDeclaration {
       implementsType,
       bodyDeclarations
     ).withContext(classDeclaration)
-    td.superTypeOccurrences = extendOccurrences ++ implementsOccurrences
+    td.superTypeOccurrences = SourceTypeOccurrence.concat(extendOccurrences, implementsOccurrences)
     typeContext.freeze(td)
     td
   }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeDeclarations.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeDeclarations.scala
@@ -111,14 +111,14 @@ object ClassDeclaration {
     classDeclaration: ClassDeclarationContext
   ): ClassDeclaration = {
 
-    val extendType =
+    val (extendType, extendOccurrences) =
       Option(classDeclaration.typeRef())
-        .map(tr => TypeReference.construct(tr))
-        .getOrElse(TypeNames.InternalObject)
-    val implementsType =
+        .map(tr => TypeReference.constructWithOccurrences(tr))
+        .getOrElse((TypeNames.InternalObject, SourceTypeOccurrence.empty))
+    val (implementsType, implementsOccurrences) =
       Option(classDeclaration.typeList())
-        .map(tl => TypeList.construct(tl))
-        .getOrElse(TypeNames.emptyTypeNames)
+        .map(tl => TypeList.constructWithOccurrences(tl))
+        .getOrElse((TypeNames.emptyTypeNames, SourceTypeOccurrence.empty))
 
     val classBodyDeclarations = Option(classDeclaration.classBody())
       .map(cb => CodeParser.toScala(cb.classBodyDeclaration()))
@@ -170,6 +170,7 @@ object ClassDeclaration {
       implementsType,
       bodyDeclarations
     ).withContext(classDeclaration)
+    td.superTypeOccurrences = extendOccurrences ++ implementsOccurrences
     typeContext.freeze(td)
     td
   }
@@ -228,10 +229,10 @@ object InterfaceDeclaration {
     interfaceDeclaration: InterfaceDeclarationContext
   ): InterfaceDeclaration = {
 
-    val implementsType =
+    val (implementsType, implementsOccurrences) =
       Option(interfaceDeclaration.typeList())
-        .map(x => TypeList.construct(x))
-        .getOrElse(ArraySeq(TypeNames.InternalInterface))
+        .map(x => TypeList.constructWithOccurrences(x))
+        .getOrElse((ArraySeq(TypeNames.InternalInterface), SourceTypeOccurrence.empty))
 
     val typeContext = new RelativeTypeContext()
 
@@ -268,6 +269,7 @@ object InterfaceDeclaration {
       implementsType,
       methods
     ).withContext(interfaceDeclaration)
+    td.superTypeOccurrences = implementsOccurrences
     typeContext.freeze(td)
     td
   }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeReference.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeReference.scala
@@ -90,10 +90,22 @@ private[cst] object ANTLRCST {
 
 object TypeReference {
 
-  /** Accumulator for the located type occurrences of a written type reference. A null accumulator
-    * disables collection so the common construction path does no extra work.
+  /** Accumulator for the located type occurrences of a written type reference. The backing buffer
+    * is only created if something is actually recorded, and a null accumulator disables collection
+    * altogether so the common construction path does no extra work.
     */
-  private type Occurrences = mutable.ArrayBuffer[SourceTypeOccurrence]
+  private final class Occurrences {
+    private var buffer: mutable.ArrayBuffer[SourceTypeOccurrence] = _
+
+    def add(typeName: TypeName, location: PathLocation): Unit = {
+      if (buffer == null)
+        buffer = new mutable.ArrayBuffer[SourceTypeOccurrence](2)
+      buffer.append(SourceTypeOccurrence(typeName, location))
+    }
+
+    def result(): ArraySeq[SourceTypeOccurrence] =
+      if (buffer == null) SourceTypeOccurrence.empty else ArraySeq.from(buffer)
+  }
 
   def construct(typeRefs: List[TypeRefContext]): List[TypeName] = {
     typeRefs.map(x => TypeReference.construct(x))
@@ -119,9 +131,9 @@ object TypeReference {
   def constructWithOccurrences(
     typeRefOpt: Option[CSTTypeReference]
   ): (TypeName, ArraySeq[SourceTypeOccurrence]) = {
-    val accum    = new mutable.ArrayBuffer[SourceTypeOccurrence]()
+    val accum    = new Occurrences
     val typeName = build(typeRefOpt, accum)
-    (typeName, if (accum.isEmpty) SourceTypeOccurrence.empty else ArraySeq.from(accum))
+    (typeName, accum.result())
   }
 
   private def build(typeRefOpt: Option[CSTTypeReference], accum: Occurrences): TypeName = {
@@ -133,12 +145,12 @@ object TypeReference {
 
           // Only decode head as rest can't legally be in EncodedName format
           val typeName = createTypeName(decodeName(names.head, accum), names.tail, accum)
-          if (accum != null) {
+          if (accum != null && names.sizeIs > 1) {
+            // Only a qualified name can denote a nested type, so 'String', 'Account' and the like
+            // are never recorded; type arguments record themselves through the recursion above.
             // Record against the last written identifier, e.g. the 'Hidden' of 'Outer.Hidden'. The
             // array subscripts are excluded so we validate the component, not the List wrapper.
-            names.lastOption
-              .flatMap(_.idLocation)
-              .foreach(location => accum.append(SourceTypeOccurrence(typeName, location)))
+            names.last.idLocation.foreach(location => accum.add(typeName, location))
           }
           typeName.withArraySubscripts(arraySubs)
         }
@@ -201,6 +213,6 @@ object TypeList {
     typeList: TypeListContext
   ): (ArraySeq[TypeName], ArraySeq[SourceTypeOccurrence]) = {
     val results = CodeParser.toScala(typeList.typeRef()).map(TypeReference.constructWithOccurrences)
-    (results.map(_._1), results.flatMap(_._2))
+    (results.map(_._1), SourceTypeOccurrence.concat(results.map(_._2)))
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeReference.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/TypeReference.scala
@@ -17,6 +17,7 @@ package com.nawforce.apexlink.cst
 import com.nawforce.apexlink.names.TypeNames
 import com.nawforce.apexlink.names.TypeNames._
 import com.nawforce.pkgforce.names.{EncodedName, Name, Names, TypeName}
+import com.nawforce.pkgforce.path.PathLocation
 import com.nawforce.runtime.parsers.CodeParser
 import io.github.apexdevtools.apexparser.ApexParser.{
   TypeArgumentsContext,
@@ -26,6 +27,7 @@ import io.github.apexdevtools.apexparser.ApexParser.{
 }
 
 import scala.collection.immutable.ArraySeq
+import scala.collection.mutable
 
 trait CSTTypeName {
   def typeArguments(): CSTTypeArguments
@@ -33,6 +35,11 @@ trait CSTTypeName {
   def isSet: Boolean
   def isMap: Boolean
   def getIdText: Option[String]
+
+  /** Source location of the identifier of this segment, if the adapter can provide one. Collection
+    * keywords (List/Set/Map) and synthetic types have no identifier so return None.
+    */
+  def idLocation: Option[PathLocation] = None
 }
 
 trait CSTTypeReference {
@@ -69,6 +76,8 @@ private[cst] object ANTLRCST {
     override def isMap: Boolean  = Option(typeName.MAP()).nonEmpty
     override def getIdText: Option[String] =
       Option(typeName.id()).map(id => Option(id).map(_.getText).getOrElse(""))
+    override def idLocation: Option[PathLocation] =
+      Option(typeName.id()).flatMap(id => CST.sourceContext.value.map(_.getLocation(id)))
   }
 
   private[cst] class ANTLRTypeReference(typeRef: TypeRefContext) extends CSTTypeReference {
@@ -81,6 +90,11 @@ private[cst] object ANTLRCST {
 
 object TypeReference {
 
+  /** Accumulator for the located type occurrences of a written type reference. A null accumulator
+    * disables collection so the common construction path does no extra work.
+    */
+  private type Occurrences = mutable.ArrayBuffer[SourceTypeOccurrence]
+
   def construct(typeRefs: List[TypeRefContext]): List[TypeName] = {
     typeRefs.map(x => TypeReference.construct(x))
   }
@@ -90,6 +104,27 @@ object TypeReference {
   }
 
   def construct(typeRefOpt: Option[CSTTypeReference]): TypeName = {
+    build(typeRefOpt, null)
+  }
+
+  /** Construct a type name along with the located occurrences of each explicitly written component
+    * of the reference, for use in source level accessibility validation.
+    */
+  def constructWithOccurrences(
+    typeRef: TypeRefContext
+  ): (TypeName, ArraySeq[SourceTypeOccurrence]) = {
+    constructWithOccurrences(Option(typeRef).map(new ANTLRCST.ANTLRTypeReference(_)))
+  }
+
+  def constructWithOccurrences(
+    typeRefOpt: Option[CSTTypeReference]
+  ): (TypeName, ArraySeq[SourceTypeOccurrence]) = {
+    val accum    = new mutable.ArrayBuffer[SourceTypeOccurrence]()
+    val typeName = build(typeRefOpt, accum)
+    (typeName, if (accum.isEmpty) SourceTypeOccurrence.empty else ArraySeq.from(accum))
+  }
+
+  private def build(typeRefOpt: Option[CSTTypeReference], accum: Occurrences): TypeName = {
     typeRefOpt
       .map { typeRef =>
         {
@@ -97,7 +132,15 @@ object TypeReference {
           val names: ArraySeq[CSTTypeName] = typeRef.typeNames()
 
           // Only decode head as rest can't legally be in EncodedName format
-          createTypeName(decodeName(names.head), names.tail).withArraySubscripts(arraySubs)
+          val typeName = createTypeName(decodeName(names.head, accum), names.tail, accum)
+          if (accum != null) {
+            // Record against the last written identifier, e.g. the 'Hidden' of 'Outer.Hidden'. The
+            // array subscripts are excluded so we validate the component, not the List wrapper.
+            names.lastOption
+              .flatMap(_.idLocation)
+              .foreach(location => accum.append(SourceTypeOccurrence(typeName, location)))
+          }
+          typeName.withArraySubscripts(arraySubs)
         }
       }
       .getOrElse(TypeNames.Void)
@@ -110,8 +153,8 @@ object TypeReference {
     else name.getIdText.map(Names(_)).getOrElse(Names.Empty)
   }
 
-  private def decodeName(name: CSTTypeName): TypeName = {
-    val params   = createTypeParams(name.typeArguments())
+  private def decodeName(name: CSTTypeName, accum: Occurrences): TypeName = {
+    val params   = createTypeParams(name.typeArguments(), accum)
     val typeName = getName(name)
     val encType  = EncodedName(typeName)
     if (encType.ext.nonEmpty)
@@ -121,22 +164,30 @@ object TypeReference {
   }
 
   @scala.annotation.tailrec
-  private def createTypeName(outer: TypeName, names: Seq[CSTTypeName]): TypeName = {
+  private def createTypeName(
+    outer: TypeName,
+    names: Seq[CSTTypeName],
+    accum: Occurrences
+  ): TypeName = {
     names match {
       case Nil => outer
       case hd +: tl =>
         createTypeName(
-          TypeName(getName(hd), createTypeParams(hd.typeArguments()), Some(outer)).intern,
-          tl
+          TypeName(getName(hd), createTypeParams(hd.typeArguments(), accum), Some(outer)).intern,
+          tl,
+          accum
         )
     }
   }
 
-  private def createTypeParams(typeArguments: CSTTypeArguments): Seq[TypeName] = {
+  private def createTypeParams(
+    typeArguments: CSTTypeArguments,
+    accum: Occurrences
+  ): Seq[TypeName] = {
     if (typeArguments.typeRefs().isEmpty)
       TypeName.emptySeq
     else
-      typeArguments.typeRefs().map(param => TypeReference.construct(Option(param)))
+      typeArguments.typeRefs().map(param => build(Option(param), accum))
   }
 }
 
@@ -144,5 +195,12 @@ object TypeList {
   def construct(typeList: TypeListContext): ArraySeq[TypeName] = {
     val types = CodeParser.toScala(typeList.typeRef())
     types.map(t => TypeReference.construct(t))
+  }
+
+  def constructWithOccurrences(
+    typeList: TypeListContext
+  ): (ArraySeq[TypeName], ArraySeq[SourceTypeOccurrence]) = {
+    val results = CodeParser.toScala(typeList.typeRef()).map(TypeReference.constructWithOccurrences)
+    (results.map(_._1), results.flatMap(_._2))
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/Variables.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/Variables.scala
@@ -122,9 +122,12 @@ object VariableDeclarators {
 final case class LocalVariableDeclaration(
   modifiers: ModifierResults,
   typeName: TypeName,
-  variableDeclarators: VariableDeclarators
+  variableDeclarators: VariableDeclarators,
+  typeOccurrences: ArraySeq[SourceTypeOccurrence] = SourceTypeOccurrence.empty
 ) extends CST {
   def verify(context: ScopeVerifyContext): Unit = {
+
+    SourceTypeAccess.validate(typeOccurrences, context)
 
     variableDeclarators.declarators.foreach(vd => {
       context.thisType.findField(vd.id.name, None).foreach {
@@ -159,7 +162,7 @@ object LocalVariableDeclaration {
     parser: CodeParser,
     from: LocalVariableDeclarationContext
   ): LocalVariableDeclaration = {
-    val typeName = TypeReference.construct(from.typeRef())
+    val (typeName, occurrences) = TypeReference.constructWithOccurrences(from.typeRef())
     val modifiers = ApexModifiers.localVariableModifiers(
       parser,
       CodeParser.toScala(from.modifier()),
@@ -173,7 +176,8 @@ object LocalVariableDeclaration {
         typeName,
         modifiers.modifiers.contains(FINAL_MODIFIER),
         from.variableDeclarators()
-      )
+      ),
+      occurrences
     ).withContext(from)
   }
 
@@ -182,7 +186,7 @@ object LocalVariableDeclaration {
     varModifiers: ArraySeq[ModifierContext],
     from: FieldDeclarationContext
   ): LocalVariableDeclaration = {
-    val typeName = TypeReference.construct(from.typeRef())
+    val (typeName, occurrences) = TypeReference.constructWithOccurrences(from.typeRef())
     val modifiers =
       ApexModifiers.localVariableModifiers(parser, varModifiers, from, isTrigger = true)
     LocalVariableDeclaration(
@@ -192,7 +196,8 @@ object LocalVariableDeclaration {
         typeName,
         modifiers.modifiers.contains(FINAL_MODIFIER),
         from.variableDeclarators()
-      )
+      ),
+      occurrences
     ).withContext(from)
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/VerifyContext.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/VerifyContext.scala
@@ -93,6 +93,14 @@ trait VerifyContext {
     }
   }
 
+  /** Record that a type visibility issue is about to be reported for a written type reference,
+    * returning false if an equivalent issue has already been reported during this validation. The
+    * same written type can be reached more than once, for example by the several declarators of a
+    * single field declaration, and should only be reported once.
+    */
+  def recordTypeVisibilityIssue(location: PathLocation, typeId: TypeId): Boolean =
+    parent().forall(_.recordTypeVisibilityIssue(location, typeId))
+
   def missingType(location: PathLocation, typeName: TypeName): Unit = {
     if (!module.isGulped && !module.isGhostedType(typeName) && !suppressIssues)
       OrgInfo.log(IssueOps.noTypeDeclaration(location, typeName, isApexType))
@@ -239,6 +247,11 @@ final class TypeVerifyContext(
 
   private val typeCache = mutable.Map[(TypeName, TypeDeclaration), TypeResponse]()
 
+  /** Type visibility issues already reported while validating this type, keyed on the source
+    * location of the written reference and the identity of the resolved type.
+    */
+  private val reportedTypeVisibilityIssues = mutable.Set[(PathLocation, TypeId)]()
+
   private val plugin =
     if (enablePlugins)
       Some(typeDeclaration.module.pkg.org.pluginsManager.createPlugin(typeDeclaration))
@@ -254,6 +267,9 @@ final class TypeVerifyContext(
 
   override def getTypeFor(typeName: TypeName, from: TypeDeclaration): TypeResponse =
     typeCache.getOrElseUpdate((typeName, from), TypeResolver(typeName, from, Some(module)))
+
+  override def recordTypeVisibilityIssue(location: PathLocation, typeId: TypeId): Boolean =
+    reportedTypeVisibilityIssues.add((location, typeId))
 
   override def modifiers(pred: Modifier => Boolean): Boolean =
     typeDeclaration.modifiers.exists(pred) || super.modifiers(pred)

--- a/jvm/src/main/scala/com/nawforce/apexlink/cst/stmts/Switch.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/cst/stmts/Switch.scala
@@ -28,6 +28,8 @@ import io.github.apexdevtools.apexparser.ApexParser.{
   WhenValueContext
 }
 
+import scala.collection.immutable.ArraySeq
+
 sealed abstract class WhenLiteral extends CST {
   def isComparableTo(typeName: TypeName): Boolean
 }
@@ -157,6 +159,7 @@ final case class WhenLiteralsValue(literals: Seq[WhenLiteral]) extends WhenValue
                 )
                 return Seq()
               }
+              SourceTypeAccess.validate(qualifierType, iv.qualifier.last.location, context)
               context.addDependency(qualifierType)
             case Left(_) =>
               context.logError(
@@ -181,7 +184,11 @@ final case class WhenLiteralsValue(literals: Seq[WhenLiteral]) extends WhenValue
   }
 }
 
-final case class WhenSObjectValue(typeName: TypeName, id: Id) extends WhenValue {
+final case class WhenSObjectValue(
+  typeName: TypeName,
+  id: Id,
+  typeOccurrences: ArraySeq[SourceTypeOccurrence] = SourceTypeOccurrence.empty
+) extends WhenValue {
   def checkMatchableTo(context: ScopeVerifyContext, typeName: TypeName): Seq[String] = {
     context.logError(id.location, s"A $typeName literal is required for this value")
     Seq()
@@ -205,6 +212,7 @@ final case class WhenSObjectValue(typeName: TypeName, id: Id) extends WhenValue 
   }
 
   override def verify(context: ScopeVerifyContext): Unit = {
+    SourceTypeAccess.validate(typeOccurrences, context)
     context.addVar(id.name, id, isReadOnly = false, typeName, context.thisType)
   }
 }
@@ -220,7 +228,8 @@ object WhenValue {
             .flatMap(l => WhenLiteral.construct(l))
         )
       } else {
-        WhenSObjectValue(TypeReference.construct(value.typeRef()), Id.construct(value.id()))
+        val (typeName, occurrences) = TypeReference.constructWithOccurrences(value.typeRef())
+        WhenSObjectValue(typeName, Id.construct(value.id()), occurrences)
       })
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/finding/RelativeTypeName.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/finding/RelativeTypeName.scala
@@ -14,7 +14,13 @@
 
 package com.nawforce.apexlink.finding
 
-import com.nawforce.apexlink.cst.{ScopeVerifyContext, CST, VerifyContext}
+import com.nawforce.apexlink.cst.{
+  CST,
+  ScopeVerifyContext,
+  SourceTypeAccess,
+  SourceTypeOccurrence,
+  VerifyContext
+}
 import com.nawforce.apexlink.finding.TypeResolver.TypeResponse
 import com.nawforce.apexlink.names.TypeNames
 import com.nawforce.apexlink.types.core.TypeDeclaration
@@ -22,6 +28,7 @@ import com.nawforce.pkgforce.names.{Name, TypeName}
 import com.nawforce.pkgforce.parsers.Nature
 import com.nawforce.pkgforce.path.PathLocation
 
+import scala.collection.immutable.ArraySeq
 import scala.collection.mutable
 
 /** Context to aid RelativeTypeName resolve via the originating ApexDeclaration. This needs freezing
@@ -78,7 +85,11 @@ final class RelativeTypeContext {
  * the relative TypeName to be converted to an absolute form. Assumes outerTypeName can always be resolved
  * against the module!
  */
-final case class RelativeTypeName(typeContext: RelativeTypeContext, relativeTypeName: TypeName) {
+final case class RelativeTypeName(
+  typeContext: RelativeTypeContext,
+  relativeTypeName: TypeName,
+  occurrences: ArraySeq[SourceTypeOccurrence] = SourceTypeOccurrence.empty
+) {
 
   /** Is this the magical void? */
   def isVoid: Boolean = {
@@ -94,6 +105,11 @@ final case class RelativeTypeName(typeContext: RelativeTypeContext, relativeType
     }
   }
 
+  /** Validate the accessibility of the written form of this type, see SourceTypeAccess. */
+  def validateAccess(context: VerifyContext): Unit = {
+    SourceTypeAccess.validate(occurrences, context)
+  }
+
   /** Helper for creating a dependence on a relative type name. */
   def dependOn(location: PathLocation, context: VerifyContext): Unit = {
     if (relativeTypeName != TypeNames.Void) {
@@ -106,6 +122,7 @@ final case class RelativeTypeName(typeContext: RelativeTypeContext, relativeType
           td.typeName.params.foreach(typeName =>
             context.getTypeAndAddDependency(typeName, typeContext.contextTypeDeclaration)
           )
+          validateAccess(context)
         case None => ()
       }
     }

--- a/jvm/src/main/scala/com/nawforce/apexlink/opcst/TypeDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/opcst/TypeDeclaration.scala
@@ -174,7 +174,8 @@ private[opcst] object OutlineParserClassDeclaration {
       implementsType,
       bodyDeclarations
     )
-    declaration.superTypeOccurrences = extendOccurrences ++ implementsOccurrences
+    declaration.superTypeOccurrences =
+      SourceTypeOccurrence.concat(extendOccurrences, implementsOccurrences)
     stampLocation(
       declaration,
       ctd.location.copy(

--- a/jvm/src/main/scala/com/nawforce/apexlink/opcst/TypeDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/opcst/TypeDeclaration.scala
@@ -34,6 +34,7 @@ import com.nawforce.apexlink.cst.{
   InterfaceDeclaration,
   PropertyBlock,
   QualifiedName,
+  SourceTypeOccurrence,
   VariableDeclarator
 }
 import com.nawforce.apexlink.finding.{RelativeTypeContext, RelativeTypeName}
@@ -98,12 +99,14 @@ private[opcst] object OutlineParserClassDeclaration {
   ): ClassDeclaration = {
 
     val id = OutlineParserId.construct(ctd.id, source.path)
-    val extendType =
+    val (extendType, extendOccurrences) =
       Option(ctd.extendsTypeRef)
-        .map(tr => TypeReference.construct(tr))
-        .getOrElse(TypeNames.InternalObject)
-    val implementsType =
-      Option(ctd.implementsTypeList).map(TypeList.construct).getOrElse(TypeNames.emptyTypeNames)
+        .map(tr => TypeReference.constructWithOccurrences(tr, source.path))
+        .getOrElse((TypeNames.InternalObject, SourceTypeOccurrence.empty))
+    val (implementsType, implementsOccurrences) =
+      Option(ctd.implementsTypeList)
+        .map(TypeList.constructWithOccurrences(_, source.path))
+        .getOrElse((TypeNames.emptyTypeNames, SourceTypeOccurrence.empty))
 
     val typeContext = new RelativeTypeContext
 
@@ -171,6 +174,7 @@ private[opcst] object OutlineParserClassDeclaration {
       implementsType,
       bodyDeclarations
     )
+    declaration.superTypeOccurrences = extendOccurrences ++ implementsOccurrences
     stampLocation(
       declaration,
       ctd.location.copy(
@@ -232,10 +236,10 @@ private[opcst] object OutlineParserInterfaceDeclaration {
     endLineOffset: Option[Int] = None
   ): InterfaceDeclaration = {
 
-    val implementsType =
+    val (implementsType, implementsOccurrences) =
       Option(itd.implementsTypeList)
-        .map(TypeList.construct)
-        .getOrElse(ArraySeq(TypeNames.InternalInterface))
+        .map(TypeList.constructWithOccurrences(_, source.path))
+        .getOrElse((ArraySeq(TypeNames.InternalInterface), SourceTypeOccurrence.empty))
     val typeContext = new RelativeTypeContext
     val id          = OutlineParserId.construct(itd.id, source.path)
 
@@ -262,6 +266,7 @@ private[opcst] object OutlineParserInterfaceDeclaration {
       implementsType,
       ArraySeq.from(methods)
     )
+    declaration.superTypeOccurrences = implementsOccurrences
     stampLocation(
       declaration,
       itd.location.copy(
@@ -423,13 +428,15 @@ private[opcst] object OutlineParserClassBodyDeclaration {
       .flatMap(OutlineParserFormalParameter.construct(path, _, source, typeContext))
       .pipe(ArraySeq.from)
 
+    val (methodTypeName, methodTypeOccurrences) = TypeReference.constructWithOccurrences(
+      md.typeRef.asInstanceOf[Option[UnresolvedTypeRef]],
+      source.path
+    )
+
     val declaration = new ApexMethodDeclaration(
       thisType,
       modifierResults,
-      RelativeTypeName(
-        typeContext,
-        TypeReference.construct(md.typeRef.asInstanceOf[Option[UnresolvedTypeRef]])
-      ),
+      RelativeTypeName(typeContext, methodTypeName, methodTypeOccurrences),
       OutlineParserId.construct(md.id, source.path),
       parameters,
       block
@@ -476,13 +483,15 @@ private[opcst] object OutlineParserClassBodyDeclaration {
       .flatMap(OutlineParserFormalParameter.construct(path, _, source, typeContext))
       .pipe(ArraySeq.from)
 
+    val (methodTypeName, methodTypeOccurrences) = TypeReference.constructWithOccurrences(
+      md.typeRef.asInstanceOf[Option[UnresolvedTypeRef]],
+      source.path
+    )
+
     val declaration = new ApexMethodDeclaration(
       thisType,
       modifierResults,
-      RelativeTypeName(
-        typeContext,
-        TypeReference.construct(md.typeRef.asInstanceOf[Option[UnresolvedTypeRef]])
-      ),
+      RelativeTypeName(typeContext, methodTypeName, methodTypeOccurrences),
       OutlineParserId.construct(md.id, source.path),
       parameters,
       None
@@ -522,7 +531,11 @@ private[opcst] object OutlineParserClassBodyDeclaration {
   ): Option[ClassBodyDeclaration] = {
 
     val modifierResults = fieldModifiers(path, fd.id, fd.annotations, fd.modifiers, isOuter)
-    val fieldTypeName   = TypeReference.construct(fd.typeRef.asInstanceOf[UnresolvedTypeRef])
+    val (fieldTypeName, fieldTypeOccurrences) =
+      TypeReference.constructWithOccurrences(
+        fd.typeRef.asInstanceOf[UnresolvedTypeRef],
+        source.path
+      )
     val vd = constructVariableDeclarator(
       fd,
       source,
@@ -531,7 +544,13 @@ private[opcst] object OutlineParserClassBodyDeclaration {
       isOuter
     )
 
-    val declaration = ApexFieldDeclaration(thisType, modifierResults, fieldTypeName, vd)
+    val declaration = ApexFieldDeclaration(
+      thisType,
+      modifierResults,
+      fieldTypeName,
+      vd,
+      typeOccurrences = fieldTypeOccurrences
+    )
     val location = OPLocation(
       fd.typeRef.asInstanceOf[UnresolvedTypeRef].typeNameSegments(0).id.location.startLine,
       fd.typeRef
@@ -640,7 +659,11 @@ private[opcst] object OutlineParserClassBodyDeclaration {
     thisType: ThisType
   ): Option[ClassBodyDeclaration] = {
 
-    val propertyTypeName = TypeReference.construct(pd.typeRef.asInstanceOf[UnresolvedTypeRef])
+    val (propertyTypeName, propertyTypeOccurrences) =
+      TypeReference.constructWithOccurrences(
+        pd.typeRef.asInstanceOf[UnresolvedTypeRef],
+        source.path
+      )
 
     def parsePropertyBlock(pb: OPPropertyBlock): Option[PropertyBlock] = {
 
@@ -668,7 +691,8 @@ private[opcst] object OutlineParserClassBodyDeclaration {
         modifierResults,
         propertyTypeName,
         OutlineParserId.construct(pd.id, source.path),
-        propertyBlocks
+        propertyBlocks,
+        propertyTypeOccurrences
       )
 
     val location = OPLocation(
@@ -699,9 +723,11 @@ private[opcst] object OutlineParserFormalParameter {
     typeContext: RelativeTypeContext
   ): Option[FormalParameter] = {
 
+    val (typeName, occurrences) =
+      TypeReference.constructWithOccurrences(src.typeRef, source.path)
     val fp = FormalParameter(
       parameterModifiers(path, src.location, src.annotations, src.modifiers),
-      RelativeTypeName(typeContext, TypeReference.construct(src.typeRef)),
+      RelativeTypeName(typeContext, typeName, occurrences),
       OutlineParserId.construct(src, source.path)
     )
     Some(fp)

--- a/jvm/src/main/scala/com/nawforce/apexlink/opcst/TypeReference.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/opcst/TypeReference.scala
@@ -12,32 +12,60 @@ import com.nawforce.apexlink.cst.{
   CSTTypeArguments,
   CSTTypeName,
   CSTTypeReference,
+  SourceTypeOccurrence,
   TypeReference => CSTTypeReferenceAlias
 }
 import com.nawforce.pkgforce.names.TypeName
+import com.nawforce.pkgforce.path.{PathLike, PathLocation}
+import com.nawforce.runtime.platform.OutlineParserLocationOps
 
 import scala.collection.immutable.ArraySeq
 
 private[opcst] object TypeReference {
 
   def construct(tr: Option[OPTypeRef]): TypeName = {
-    CSTTypeReferenceAlias.construct(Some(new OutlineParserTypeReference(tr)))
+    CSTTypeReferenceAlias.construct(Some(new OutlineParserTypeReference(tr, None)))
   }
 
   def construct(tr: OPTypeRef): TypeName = {
-    CSTTypeReferenceAlias.construct(Some(new OutlineParserTypeReference(Some(tr))))
+    CSTTypeReferenceAlias.construct(Some(new OutlineParserTypeReference(Some(tr), None)))
   }
 
-  private class OutlineParserTypeName(typeName: OPTypeName) extends CSTTypeName {
+  /** As construct, but also returning the located occurrences of each written component of the
+    * reference so that source level accessibility can be validated.
+    */
+  def constructWithOccurrences(
+    tr: Option[OPTypeRef],
+    path: PathLike
+  ): (TypeName, ArraySeq[SourceTypeOccurrence]) = {
+    CSTTypeReferenceAlias.constructWithOccurrences(
+      Some(new OutlineParserTypeReference(tr, Some(path)))
+    )
+  }
+
+  def constructWithOccurrences(
+    tr: OPTypeRef,
+    path: PathLike
+  ): (TypeName, ArraySeq[SourceTypeOccurrence]) = {
+    constructWithOccurrences(Some(tr), path)
+  }
+
+  private class OutlineParserTypeName(typeName: OPTypeName, path: Option[PathLike])
+      extends CSTTypeName {
     override def typeArguments(): CSTTypeArguments =
-      new OutlineParserTypeArgument(typeName.typeArguments)
+      new OutlineParserTypeArgument(typeName.typeArguments, path)
     override def isList: Boolean           = typeName.id.lowerCaseName == "list"
     override def isSet: Boolean            = typeName.id.lowerCaseName == "set"
     override def isMap: Boolean            = typeName.id.lowerCaseName == "map"
     override def getIdText: Option[String] = Option(typeName.id.name)
+    override def idLocation: Option[PathLocation] = {
+      // Collection keywords are not identifiers, matching how the ANTLR adapter sees them
+      if (isList || isSet || isMap) None
+      else path.map(PathLocation(_, OutlineParserLocationOps.toLocation(typeName.id.location)))
+    }
   }
 
-  private class OutlineParserTypeReference(typeReference: Option[OPTypeRef])
+  private class OutlineParserTypeReference(typeReference: Option[OPTypeRef], path: Option[PathLike])
       extends CSTTypeReference {
     override def arraySubscriptsCount(): Int = {
       // TODO: is this actually right behaviour?
@@ -51,21 +79,32 @@ private[opcst] object TypeReference {
       // TODO: is this actually right behaviour?
       typeReference match {
         case Some(utr: UnresolvedTypeRef) =>
-          ArraySeq.from(utr.typeNameSegments.map(new OutlineParserTypeName(_)))
+          ArraySeq.from(utr.typeNameSegments.map(new OutlineParserTypeName(_, path)))
         case _ => ArraySeq.empty
       }
     }
   }
 
-  private class OutlineParserTypeArgument(typeArguments: ArraySeq[OPTypeRef])
-      extends CSTTypeArguments {
+  private class OutlineParserTypeArgument(
+    typeArguments: ArraySeq[OPTypeRef],
+    path: Option[PathLike]
+  ) extends CSTTypeArguments {
     override def typeRefs(): ArraySeq[CSTTypeReference] =
-      ArraySeq.from(typeArguments.map(tr => new OutlineParserTypeReference(Some(tr))))
+      ArraySeq.from(typeArguments.map(tr => new OutlineParserTypeReference(Some(tr), path)))
   }
 }
 
 private[opcst] object TypeList {
   def construct(typeList: ArraySeq[OPTypeRef]): ArraySeq[TypeName] = {
     ArraySeq.from(typeList.map(t => TypeReference.construct(Some(t))))
+  }
+
+  def constructWithOccurrences(
+    typeList: ArraySeq[OPTypeRef],
+    path: PathLike
+  ): (ArraySeq[TypeName], ArraySeq[SourceTypeOccurrence]) = {
+    val results =
+      ArraySeq.from(typeList.map(t => TypeReference.constructWithOccurrences(Some(t), path)))
+    (results.map(_._1), results.flatMap(_._2))
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/opcst/TypeReference.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/opcst/TypeReference.scala
@@ -105,6 +105,6 @@ private[opcst] object TypeList {
   ): (ArraySeq[TypeName], ArraySeq[SourceTypeOccurrence]) = {
     val results =
       ArraySeq.from(typeList.map(t => TypeReference.constructWithOccurrences(Some(t), path)))
-    (results.map(_._1), results.flatMap(_._2))
+    (results.map(_._1), SourceTypeOccurrence.concat(results.map(_._2)))
   }
 }

--- a/jvm/src/main/scala/com/nawforce/apexlink/types/apex/FullDeclaration.scala
+++ b/jvm/src/main/scala/com/nawforce/apexlink/types/apex/FullDeclaration.scala
@@ -82,6 +82,11 @@ abstract class FullDeclaration(
   override val nature: Nature
   override val inTest: Boolean = _inTest
 
+  /** Located occurrences of the types written in the extends and implements clauses. Set after
+    * construction as the clauses are parsed before the declaration itself exists.
+    */
+  var superTypeOccurrences: ArraySeq[SourceTypeOccurrence] = SourceTypeOccurrence.empty
+
   // Track if this has been flushed to cache yet
   private var flushedToCache = false
 
@@ -222,16 +227,6 @@ abstract class FullDeclaration(
       if (superClassDeclaration.nature != CLASS_NATURE) {
         OrgInfo.logError(id.location, s"Parent type '${superClass.get.asDotName}' must be a class")
       } else if (
-        !inTest &&
-        superClassDeclaration.visibility.getOrElse(PRIVATE_MODIFIER) == PRIVATE_MODIFIER &&
-        superClassDeclaration.outermostTypeDeclaration != outermostTypeDeclaration
-      ) {
-        // Private is OK with Outer extends Inner, Inner extends Inner or Test classes
-        OrgInfo.logError(
-          id.location,
-          s"Parent class '${superClass.get.asDotName}' is private, it must be public or global"
-        )
-      } else if (
         superClassDeclaration.modifiers
           .intersect(Seq(VIRTUAL_MODIFIER, ABSTRACT_MODIFIER))
           .isEmpty
@@ -242,6 +237,10 @@ abstract class FullDeclaration(
         )
       }
     })
+
+    // Accessibility of the written extends/implements types, this covers what was previously a
+    // bespoke private parent class check
+    SourceTypeAccess.validate(superTypeOccurrences, context)
 
     // Check for duplicate nested types
     val duplicateNestedType =

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/ExtendsTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/ExtendsTest.scala
@@ -58,7 +58,7 @@ class ExtendsTest extends AnyFunSuite with TestHelper {
     )
     assert(
       dummyIssues ==
-        "Error: line 1 at 13-18: Parent class 'Outer.SuperClass' is private, it must be public or global\n"
+        "Error: line 1 at 33-43: Type is not visible: Outer.SuperClass\n"
     )
   }
 
@@ -71,7 +71,37 @@ class ExtendsTest extends AnyFunSuite with TestHelper {
         )
       ).size == 2
     )
+    assert(
+      dummyIssues ==
+        "Error: line 1 at 55-65: Type is not visible: Outer.SuperClass\n"
+    )
+  }
+
+  test("Private @TestVisible superclass (from test)") {
+    assert(
+      typeDeclarations(
+        Map(
+          "Outer.cls" -> "global class Outer { @TestVisible private virtual class SuperClass {}}",
+          "Dummy.cls" -> "@isTest public class Dummy {class InTest extends Outer.SuperClass {}}"
+        )
+      ).size == 2
+    )
     assert(dummyIssues.isEmpty)
+  }
+
+  test("Private @TestVisible superclass (from non-test)") {
+    assert(
+      typeDeclarations(
+        Map(
+          "Outer.cls" -> "global class Outer { @TestVisible private virtual class SuperClass {}}",
+          "Dummy.cls" -> "global class Dummy extends Outer.SuperClass {}"
+        )
+      ).size == 2
+    )
+    assert(
+      dummyIssues ==
+        "Error: line 1 at 33-43: Type is not visible: Outer.SuperClass\n"
+    )
   }
 
   test("Private superclass (peer)") {

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/NestedTypeVisibilityCacheTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/NestedTypeVisibilityCacheTest.scala
@@ -1,0 +1,153 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.apexlink.cst
+
+import com.nawforce.apexlink.api.{Org, ServerOps}
+import com.nawforce.apexlink.org.OPM
+import com.nawforce.apexlink.rpc.OpenOptions
+import com.nawforce.apexlink.types.apex.{FullDeclaration, SummaryDeclaration}
+import com.nawforce.pkgforce.names.{Name, TypeName}
+import com.nawforce.pkgforce.path.PathLike
+import com.nawforce.runtime.FileSystemHelper
+import com.nawforce.runtime.platform.Environment
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Nested type visibility must behave the same whether the target declaration is parsed (Full) or
+  * loaded from the parsed cache (Summary), and must track refreshes of either file.
+  */
+class NestedTypeVisibilityCacheTest extends AnyFunSuite {
+
+  private val hiddenTarget = "global class Target { private class Hidden {} }"
+  private val shownTarget  = "global class Target { public class Shown {} private class Hidden {} }"
+  private val visibleTarget = "global class Target { @TestVisible private class Hidden {} }"
+
+  private val hiddenCaller = "global class Dummy { Target.Hidden a; }"
+  private val testCaller   = "@isTest global class Dummy { Target.Hidden a; }"
+  private val shownCaller  = "global class Dummy { Target.Shown a; }"
+
+  private val sources = Map("Target.cls" -> hiddenTarget, "Dummy.cls" -> hiddenCaller)
+
+  private def withIsolatedRuntime[T](op: => T): T = {
+    val originalCache     = Environment.getCacheDirOverride
+    val originalAutoFlush = ServerOps.isAutoFlushEnabled
+    Environment.setCacheDirOverride(Some(None))
+    try op
+    finally {
+      Environment.setCacheDirOverride(originalCache)
+      ServerOps.setAutoFlush(originalAutoFlush)
+    }
+  }
+
+  private def openOrg(root: PathLike, cacheEnabled: Boolean): OPM.OrgImpl = {
+    val options = OpenOptions
+      .default()
+      .withAutoFlush(enabled = false)
+      .withCacheDirectory(if (cacheEnabled) root.join(".cache").toString else "")
+      .withCache(cacheEnabled)
+    Org.newOrg(root, options).asInstanceOf[OPM.OrgImpl]
+  }
+
+  private def visibilityIssues(org: OPM.OrgImpl, root: PathLike): Seq[String] =
+    org.issueManager
+      .issuesForFileInternal(root.join("Dummy.cls"))
+      .map(_.diagnostic.message)
+      .filter(_.contains("Type is not visible"))
+
+  private def declaration(org: OPM.OrgImpl, name: String): Any =
+    org.unmanaged.orderedModules.flatMap(_.findModuleType(TypeName(Name(name)))).head
+
+  private def refresh(org: OPM.OrgImpl, root: PathLike, file: String, content: String): Unit = {
+    root.join(file).write(content)
+    org.unmanaged.refreshAll(Array(root.join(file)))
+    org.flush()
+  }
+
+  test("cache disabled reports against a Full target declaration") {
+    withIsolatedRuntime {
+      FileSystemHelper.runTempDir(sources) { root: PathLike =>
+        val org = openOrg(root, cacheEnabled = false)
+        assert(declaration(org, "Target").isInstanceOf[FullDeclaration])
+        assert(visibilityIssues(org, root) == Seq("Type is not visible: Target.Hidden"))
+      }
+    }
+  }
+
+  test("cache enabled reports identically against a Summary target declaration") {
+    withIsolatedRuntime {
+      FileSystemHelper.runTempDir(sources, setupCache = true) { root: PathLike =>
+        val cold = openOrg(root, cacheEnabled = true)
+        assert(declaration(cold, "Target").isInstanceOf[FullDeclaration])
+        assert(visibilityIssues(cold, root) == Seq("Type is not visible: Target.Hidden"))
+        cold.flush()
+
+        val warm = openOrg(root, cacheEnabled = true)
+        assert(declaration(warm, "Target").isInstanceOf[SummaryDeclaration])
+        assert(visibilityIssues(warm, root) == Seq("Type is not visible: Target.Hidden"))
+      }
+    }
+  }
+
+  test("same file access holds across Full and Summary loading") {
+    withIsolatedRuntime {
+      val sameFile = Map(
+        "Dummy.cls" ->
+          "global class Dummy { private class Hidden {} class Peer { Dummy.Hidden a; } }"
+      )
+      FileSystemHelper.runTempDir(sameFile, setupCache = true) { root: PathLike =>
+        val cold = openOrg(root, cacheEnabled = true)
+        assert(visibilityIssues(cold, root).isEmpty)
+        cold.flush()
+
+        val warm = openOrg(root, cacheEnabled = true)
+        assert(declaration(warm, "Dummy").isInstanceOf[SummaryDeclaration])
+        assert(visibilityIssues(warm, root).isEmpty)
+      }
+    }
+  }
+
+  test("refreshing the target visibility adds and removes the diagnostic") {
+    withIsolatedRuntime {
+      FileSystemHelper.runTempDir(sources, setupCache = true) { root: PathLike =>
+        val org = openOrg(root, cacheEnabled = true)
+        assert(visibilityIssues(org, root) == Seq("Type is not visible: Target.Hidden"))
+
+        refresh(org, root, "Target.cls", visibleTarget)
+        assert(visibilityIssues(org, root) == Seq("Type is not visible: Target.Hidden"))
+
+        refresh(org, root, "Dummy.cls", testCaller)
+        assert(visibilityIssues(org, root).isEmpty)
+
+        refresh(org, root, "Target.cls", hiddenTarget)
+        assert(visibilityIssues(org, root) == Seq("Type is not visible: Target.Hidden"))
+
+        refresh(org, root, "Dummy.cls", hiddenCaller)
+        assert(visibilityIssues(org, root) == Seq("Type is not visible: Target.Hidden"))
+      }
+    }
+  }
+
+  test("refreshing to an accessible nested type clears the diagnostic") {
+    withIsolatedRuntime {
+      FileSystemHelper.runTempDir(sources, setupCache = true) { root: PathLike =>
+        val org = openOrg(root, cacheEnabled = true)
+        assert(visibilityIssues(org, root) == Seq("Type is not visible: Target.Hidden"))
+
+        refresh(org, root, "Target.cls", shownTarget)
+        refresh(org, root, "Dummy.cls", shownCaller)
+        assert(visibilityIssues(org, root).isEmpty)
+      }
+    }
+  }
+}

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/NestedTypeVisibilityTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/NestedTypeVisibilityTest.scala
@@ -1,0 +1,428 @@
+/*
+ Copyright (c) 2026 Kevin Jones, All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ */
+
+package com.nawforce.apexlink.cst
+
+import com.nawforce.apexlink.TestHelper
+import com.nawforce.apexlink.api.ServerOps
+import com.nawforce.pkgforce.path.PathLike
+import com.nawforce.runtime.FileSystemHelper
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.util.matching.Regex
+
+/** Accessibility of nested Apex types written explicitly in source, see issue #341.
+  *
+  * Both parser adapters are exercised for every case as declaration level types are constructed by
+  * the outline parser when it is in use, while statement and expression types always come from the
+  * ANTLR parser.
+  */
+class NestedTypeVisibilityTest extends AnyFunSuite with TestHelper {
+
+  private val parsers = Seq("outlinemulti", "antlr")
+
+  private val hiddenClass = "global class Target { private class Hidden {} }"
+  private val hiddenClassWithStatic =
+    "global class Target { private class Hidden { public static Integer get() { return 1; } } }"
+  private val shownClass  = "global class Target { public class Shown {} }"
+  private val hiddenIface = "global class Target { private interface Hidden {} }"
+  private val shownIface  = "global class Target { public interface Shown {} }"
+  private val hiddenEnum  = "global class Target { private enum Hidden { A, B } }"
+  private val testVisible = "global class Target { @TestVisible private class Hidden {} }"
+  private val hiddenExcept =
+    "global class Target { private class HiddenException extends Exception {} }"
+
+  private def messagesFor(classes: Map[String, String], parser: String, file: String): String = {
+    try {
+      ServerOps.setAutoFlush(false)
+      FileSystemHelper.run(classes) { root: PathLike =>
+        this.root = root
+        createOrg(root, Some(parser))
+        getMessages(root.join(file))
+      }
+    } finally {
+      ServerOps.setAutoFlush(true)
+    }
+  }
+
+  private def visibilityIssues(classes: Map[String, String], parser: String): Seq[String] =
+    messagesFor(classes, parser, "Dummy.cls").linesIterator
+      .filter(_.contains("Type is not visible"))
+      .toSeq
+
+  /** Expected diagnostic for each place the given identifier is written in the source. This keeps
+    * the expected ranges tied to the source rather than to hand counted offsets.
+    */
+  private def expectedAt(source: String, identifier: String, typeName: String): Seq[String] = {
+    val matcher = new Regex(s"\\b$identifier\\b")
+    source
+      .split("\n", -1)
+      .zipWithIndex
+      .flatMap { case (line, index) =>
+        matcher
+          .findAllMatchIn(line)
+          .map(m =>
+            s"Error: line ${index + 1} at ${m.start}-${m.end}: Type is not visible: $typeName"
+          )
+      }
+      .toSeq
+  }
+
+  /** Assert the visibility diagnostics reported for Dummy.cls, in both parser adapters. */
+  private def assertHidden(target: String, dummy: String, identifier: String = "Hidden"): Unit = {
+    val classes  = Map("Target.cls" -> target, "Dummy.cls" -> dummy)
+    val expected = expectedAt(dummy, identifier, s"Target.$identifier")
+    assert(expected.nonEmpty, "test source does not mention the hidden type")
+    parsers.foreach(parser =>
+      assert(visibilityIssues(classes, parser) == expected, s"parser '$parser'")
+    )
+  }
+
+  /** Assert Dummy.cls has no diagnostics at all, in both parser adapters. */
+  private def assertClean(target: String, dummy: String): Unit = {
+    val classes = Map("Target.cls" -> target, "Dummy.cls" -> dummy)
+    parsers.foreach(parser =>
+      assert(messagesFor(classes, parser, "Dummy.cls").isEmpty, s"parser '$parser'")
+    )
+  }
+
+  /** Assert only the visibility diagnostics, ignoring any other analysis of the same source. */
+  private def assertHiddenCount(target: String, dummy: String, count: Int): Unit = {
+    val classes = Map("Target.cls" -> target, "Dummy.cls" -> dummy)
+    parsers.foreach(parser =>
+      assert(visibilityIssues(classes, parser).size == count, s"parser '$parser'")
+    )
+  }
+
+  // Declared types
+
+  test("Field type") {
+    assertHidden(hiddenClass, "global class Dummy { Target.Hidden a; }")
+  }
+
+  test("Field type (accessible)") {
+    assertClean(shownClass, "global class Dummy { Target.Shown a; }")
+  }
+
+  test("Static field type") {
+    assertHidden(hiddenClass, "global class Dummy { static Target.Hidden a; }")
+  }
+
+  test("Property type") {
+    assertHidden(hiddenClass, "global class Dummy { Target.Hidden a { get; set; } }")
+  }
+
+  test("Property type (accessible)") {
+    assertClean(shownClass, "global class Dummy { Target.Shown a { get; set; } }")
+  }
+
+  test("Local variable type") {
+    assertHidden(hiddenClass, "global class Dummy { void func() { Target.Hidden a; } }")
+  }
+
+  test("Local variable type (accessible)") {
+    assertClean(shownClass, "global class Dummy { void func() { Target.Shown a; } }")
+  }
+
+  test("Method return type") {
+    assertHidden(hiddenClass, "global class Dummy { Target.Hidden func() { return null; } }")
+  }
+
+  test("Method return type (accessible)") {
+    assertClean(shownClass, "global class Dummy { Target.Shown func() { return null; } }")
+  }
+
+  test("Method parameter type") {
+    assertHidden(hiddenClass, "global class Dummy { void func(Target.Hidden a) {} }")
+  }
+
+  test("Method parameter type (accessible)") {
+    assertClean(shownClass, "global class Dummy { void func(Target.Shown a) {} }")
+  }
+
+  test("Constructor parameter type") {
+    assertHidden(hiddenClass, "global class Dummy { public Dummy(Target.Hidden a) {} }")
+  }
+
+  test("Interface method return & parameter types") {
+    assertHidden(hiddenClass, "global interface Dummy { Target.Hidden func(Target.Hidden a); }")
+  }
+
+  // Construction & expressions
+
+  test("Object construction") {
+    assertHidden(
+      hiddenClass,
+      "global class Dummy { void func() { Object a = new Target.Hidden(); } }"
+    )
+  }
+
+  test("Object construction (accessible)") {
+    assertClean(shownClass, "global class Dummy { void func() { Object a = new Target.Shown(); } }")
+  }
+
+  test("Generic construction") {
+    assertHidden(
+      hiddenClass,
+      "global class Dummy { void func() { Object a = new List<Target.Hidden>(); } }"
+    )
+  }
+
+  test("Cast type") {
+    assertHidden(
+      hiddenClass,
+      "global class Dummy { void func(Object o) { Object a = (Target.Hidden)o; } }"
+    )
+  }
+
+  test("instanceof type") {
+    assertHidden(
+      hiddenClass,
+      "global class Dummy { void func(Object o) { Boolean a = o instanceof Target.Hidden; } }"
+    )
+  }
+
+  test("Type literal") {
+    assertHidden(
+      hiddenClass,
+      "global class Dummy { void func() { Type a = Target.Hidden.class; } }"
+    )
+  }
+
+  test("Static type qualifier") {
+    assertHidden(
+      hiddenClassWithStatic,
+      "global class Dummy { void func() { Integer a = Target.Hidden.get(); } }"
+    )
+  }
+
+  test("Static type qualifier (accessible)") {
+    assertClean(
+      "global class Target { public class Shown { public static Integer get() { return 1; } } }",
+      "global class Dummy { void func() { Integer a = Target.Shown.get(); } }"
+    )
+  }
+
+  // Statements
+
+  test("Basic for loop variable type") {
+    assertHidden(
+      hiddenClass,
+      "global class Dummy { void func() { for (Target.Hidden a = null; a == null;) {} } }"
+    )
+  }
+
+  test("Enhanced for loop variable type") {
+    assertHiddenCount(
+      hiddenClass,
+      "global class Dummy { void func(List<Object> l) { for (Target.Hidden a : l) {} } }",
+      1
+    )
+  }
+
+  test("Catch exception type") {
+    assertHidden(
+      hiddenExcept,
+      "global class Dummy { void func() { try {} catch (Target.HiddenException e) {} } }",
+      "HiddenException"
+    )
+  }
+
+  test("Catch exception type (accessible)") {
+    assertClean(
+      "global class Target { public class ShownException extends Exception {} }",
+      "global class Dummy { void func() { try {} catch (Target.ShownException e) {} } }"
+    )
+  }
+
+  test("Enum qualified switch case") {
+    assertHiddenCount(
+      hiddenEnum,
+      "global class Dummy { void func(Target.Hidden e) { switch on e { when A {} when else {} } } }",
+      1
+    )
+  }
+
+  // Extends & implements
+
+  test("Implements a hidden interface") {
+    assertHidden(hiddenIface, "global class Dummy implements Target.Hidden {}")
+  }
+
+  test("Implements a visible interface (accessible)") {
+    assertClean(shownIface, "global class Dummy implements Target.Shown {}")
+  }
+
+  test("Interface extends a hidden interface") {
+    assertHidden(hiddenIface, "global interface Dummy extends Target.Hidden {}")
+  }
+
+  // Natures
+
+  test("Nested interface as a declared type") {
+    assertHidden(hiddenIface, "global class Dummy { Target.Hidden a; }")
+  }
+
+  test("Nested enum as a declared type") {
+    assertHidden(hiddenEnum, "global class Dummy { Target.Hidden a; }")
+  }
+
+  test("Nested enum as a parameter type") {
+    assertHidden(hiddenEnum, "global class Dummy { void func(Target.Hidden a) {} }")
+  }
+
+  test("Nested enum as a return type") {
+    assertHidden(hiddenEnum, "global class Dummy { Target.Hidden func() { return null; } }")
+  }
+
+  // Generics and arrays
+
+  test("Generic argument is reported at the component") {
+    assertHidden(hiddenClass, "global class Dummy { List<Target.Hidden> a; }")
+  }
+
+  test("Recursive generic argument is reported at the component") {
+    assertHidden(hiddenClass, "global class Dummy { Map<String, List<Target.Hidden>> a; }")
+  }
+
+  test("Array element type is reported at the component") {
+    assertHidden(hiddenClass, "global class Dummy { Target.Hidden[] a; }")
+  }
+
+  test("Array within a generic is reported at the component") {
+    assertHidden(hiddenClass, "global class Dummy { Map<String, Target.Hidden[]> a; }")
+  }
+
+  test("Multiple declarators of one written type report once") {
+    assertHiddenCount(hiddenClass, "global class Dummy { Target.Hidden a, b, c; }", 1)
+  }
+
+  test("Multiple written references each report") {
+    assertHidden(hiddenClass, "global class Dummy { Target.Hidden a; Target.Hidden b; }")
+  }
+
+  // Same file access
+
+  test("Same file nested access is allowed") {
+    assert(
+      typeDeclarations(
+        Map(
+          "Dummy.cls" ->
+            "global class Dummy { private class Hidden {} class Peer { Hidden a; Dummy.Hidden b; } }"
+        )
+      ).nonEmpty
+    )
+    assert(dummyIssues.isEmpty)
+  }
+
+  test("Same file nested access from the outer type is allowed") {
+    assert(
+      typeDeclarations(
+        Map("Dummy.cls" -> "global class Dummy { private class Hidden {} Hidden a; }")
+      ).nonEmpty
+    )
+    assert(dummyIssues.isEmpty)
+  }
+
+  // Test context
+
+  test("@TestVisible private type from a test class") {
+    assertClean(testVisible, "@isTest global class Dummy { Target.Hidden a; }")
+  }
+
+  test("@TestVisible private type from a nested type of a test class") {
+    assertClean(testVisible, "@isTest global class Dummy { class Inner { Target.Hidden a; } }")
+  }
+
+  test("@TestVisible private type from a normal class") {
+    assertHidden(testVisible, "global class Dummy { Target.Hidden a; }")
+  }
+
+  test("Private type without @TestVisible from a test class") {
+    assertHidden(hiddenClass, "@isTest global class Dummy { Target.Hidden a; }")
+  }
+
+  test("@TestVisible private interface from a test class") {
+    assertClean(
+      "global class Target { @TestVisible private interface Hidden {} }",
+      "@isTest global class Dummy { Target.Hidden a; }"
+    )
+  }
+
+  test("@TestVisible private enum from a test class") {
+    assertClean(
+      "global class Target { @TestVisible private enum Hidden { A, B } }",
+      "@isTest global class Dummy { Target.Hidden a; }"
+    )
+  }
+
+  // Subtypes get no extra access
+
+  test("Subclass of the outer type can not see a private nested type") {
+    assertHidden(
+      "global virtual class Target { private class Hidden {} }",
+      "global class Dummy extends Target { Target.Hidden a; }"
+    )
+  }
+
+  // Exclusions
+
+  test("Derived field type is not diagnosed") {
+    assertClean(
+      "global class Target { private class Hidden { public Integer value; } " +
+        "@TestVisible private static Hidden instance; }",
+      "@isTest global class Dummy { static void func() { Integer a = Target.instance.value; } }"
+    )
+  }
+
+  test("Derived method return type is not diagnosed") {
+    assertClean(
+      "global class Target { private class Hidden { public Integer value; } " +
+        "@TestVisible private static Hidden make() { return null; } }",
+      "@isTest global class Dummy { static void func() { Integer a = Target.make().value; } }"
+    )
+  }
+
+  test("Top level types are never diagnosed") {
+    assertClean("global class Target {}", "global class Dummy { Target a; }")
+  }
+
+  test("Nested non-Apex declarations are never diagnosed") {
+    // A Visualforce component is a nested type of the Component declaration but is not an Apex
+    // declaration, applying the rule to it caused false positives during investigation
+    parsers.foreach(parser =>
+      FileSystemHelper.run(
+        Map(
+          "Test.component" -> "<apex:component/>",
+          "Page.page"      -> "<apex:page/>",
+          "Dummy.cls" ->
+            "global class Dummy { Component.Test c; PageReference p = Page.Page; }"
+        )
+      ) { root: PathLike =>
+        this.root = root
+        createOrg(root, Some(parser))
+        assert(getMessages(root.join("Dummy.cls")).isEmpty, s"parser '$parser'")
+      }
+    )
+  }
+
+  test("SObject switch value type is checked") {
+    assertHiddenCount(
+      hiddenClass,
+      "global class Dummy { void func(SObject s) { switch on s { when Target.Hidden h {} " +
+        "when else {} } } }",
+      1
+    )
+  }
+}

--- a/jvm/src/test/scala/com/nawforce/apexlink/cst/NestedTypeVisibilityTest.scala
+++ b/jvm/src/test/scala/com/nawforce/apexlink/cst/NestedTypeVisibilityTest.scala
@@ -398,6 +398,66 @@ class NestedTypeVisibilityTest extends AnyFunSuite with TestHelper {
     assertClean("global class Target {}", "global class Dummy { Target a; }")
   }
 
+  // Unqualified names inherited from a superclass in another file
+  //
+  // Occurrences are only collected for qualified names, since an unqualified name is either a top
+  // level type or a nested type that is visible from where it is written -- with one exception,
+  // a nested type Apex resolves through the superclass. These are not diagnosed at type reference
+  // sites. The tests below pin that gap; it is a false negative, never a false positive, and the
+  // qualified form is unaffected. Sites that check an already resolved declaration rather than a
+  // written type reference, construction and catch clauses, do still report.
+
+  private val inheritedTarget =
+    "global virtual class Target { private class Hidden { Hidden() {} } " +
+      "private class HiddenException extends Exception {} }"
+
+  test("Qualified inherited private nested type is diagnosed") {
+    assertHidden(inheritedTarget, "global class Dummy extends Target { Target.Hidden a; }")
+  }
+
+  test("Unqualified inherited private nested type is not diagnosed at type reference sites") {
+    Seq(
+      "Hidden a;",
+      "List<Hidden> a;",
+      "void func() { Hidden a; }",
+      "void func(Hidden a) {}",
+      "Hidden func() { return null; }",
+      "void func(Object o) { Object a = (Hidden)o; }",
+      "void func(Object o) { Boolean a = o instanceof Hidden; }",
+      "void func() { Type a = Hidden.class; }"
+    ).foreach(body =>
+      assertHiddenCount(inheritedTarget, s"global class Dummy extends Target { $body }", 0)
+    )
+  }
+
+  test("Unqualified inherited private nested type is diagnosed on construction") {
+    assertHiddenCount(
+      inheritedTarget,
+      "global class Dummy extends Target { void func() { Object a = new Hidden(); } }",
+      1
+    )
+  }
+
+  test("Unqualified inherited private nested type is diagnosed in a catch clause") {
+    assertHiddenCount(
+      inheritedTarget,
+      "global class Dummy extends Target { void func() { try {} catch (HiddenException e) {} } }",
+      1
+    )
+  }
+
+  test("Unqualified same file nested type is never diagnosed") {
+    assert(
+      typeDeclarations(
+        Map(
+          "Dummy.cls" ->
+            "global class Dummy { private class Hidden {} class Peer extends Dummy { Hidden a; } }"
+        )
+      ).nonEmpty
+    )
+    assert(!dummyIssues.contains("not visible"))
+  }
+
   test("Nested non-Apex declarations are never diagnosed") {
     // A Visualforce component is a nested type of the Component declaration but is not an Apex
     // declaration, applying the rule to it caused false positives during investigation


### PR DESCRIPTION
Closes #341.

## What

Referencing an inaccessible nested Apex class, interface, or enum is a compiler error (confirmed by API 67/68 check-only org validation), but apex-ls resolved these references without reporting anything. This adds an `ERROR_CATEGORY` diagnostic, `Type is not visible: Outer.Hidden`, at explicit source references.

## How

Written type references now retain the source location of each component identifier alongside the existing normalized `TypeName` (`SourceTypeOccurrence`). After a *successful* resolution, `SourceTypeAccess` applies the shared `TestVisibleAccess.access(resolvedType, Some(context.thisType))` predicate introduced by #523, restricted to nested `ApexDeclaration` targets.

Lookup and dependency registration are deliberately untouched — no visibility failures were added to `getTypeFor`/`getTypeAndAddDependency`, so the original `TypeResponse` is returned unchanged and downstream analysis continues exactly as before.

Diagnostics are deduplicated by source path, range, and resolved type identity, held per `TypeVerifyContext`, so the several declarators of one field declaration report once.

### What occurrences are collected (review feedback)

Occurrences are recorded **only for qualified names**, filtered at the point of collection in `TypeReference.build` rather than discarded later at validation.

| Written | Occurrence recorded | Why |
|---|---|---|
| `String`, `Integer`, `Account` | no | unqualified, cannot denote an inaccessible nested type |
| `List<String>`, `Map<String, Integer>` | no | wrapper and arguments are all unqualified |
| `Outer.Hidden`, `Outer.Hidden[]` | yes, at `Hidden` | qualified |
| `Map<String, Outer.Hidden[]>` | yes, at `Hidden` only | wrapper skipped, the argument records itself |
| `Schema.Account`, `System.String` | yes, then discarded | qualified, but not a nested `ApexDeclaration` |

References that record nothing end up with the shared `SourceTypeOccurrence.empty` instance, so there is no retained per-reference allocation, and the accumulator only creates its backing buffer once something is recorded. `TypeList` and the extends/implements join preserve the shared instance the same way via `SourceTypeOccurrence.concat`.

Location precision is unchanged and every pre-existing test in both new suites passes untouched.

### The inherited unqualified case — limitation, stated

Apex resolves a superclass's nested type unqualified across files, so `class Sub extends Outer { Hidden h; }` compiles to a reference to `Outer.Hidden`, and the compiler rejects it when `Hidden` is private. The qualified-name filter gives this up at type reference positions.

**Decision: state the limitation rather than handle it.** Detecting it at collection time needs resolution, which is not available there; the alternative is threading superclass knowledge through ~10 construct signatures in both adapters, and it would still miss statement-level types because blocks are parsed lazily. The result would be coarse (admitting every unqualified name in any subclass) and inconsistent.

The trade-off is bounded and one-directional:

- It is a **false negative, never a false positive** — we stop reporting something real, we never invent one.
- The **qualified form is unaffected**: `Sub extends Outer { Outer.Hidden h; }` still reports.
- **Same-file** unqualified nested references were never diagnosable anyway; they are always accessible.
- Sites that check an **already resolved declaration** rather than a written type reference still report: `new Hidden()` and `catch (HiddenException e)`.

So the gap is exactly: an unqualified reference to a *private* nested type of a superclass in a *different file*, at a type reference position (field, local, parameter, return, generic argument, cast, `instanceof`, type literal).

`NestedTypeVisibilityTest` pins the behaviour on both sides of that line, so any future change to it is visible.

### Coverage

Field, property, local variable, method return, method/constructor parameter, basic and enhanced for-loop variable, object and generic construction, cast, `instanceof`, type literal, static/nested type qualifier, catch exception, `when` SObject value, enum-qualified switch case qualifier, and `extends`/`implements` — in **both** parser adapters (ANTLR and outline parser).

For generics and arrays the diagnostic points at the inaccessible nested component, not the normalized wrapper: `Map<String, Outer.Hidden[]>` highlights `Hidden`.

### Behaviour change

The bespoke private-parent `extends` check is replaced by the shared predicate. It now:

- reports `Type is not visible: <type>` against the written parent type name rather than the class identifier, and
- honours the `@TestVisible` unit-test exception, so a test class extending a private nested type that is *not* `@TestVisible` is now an error (matching the compiler).

The parent nature (`must be a class`) and `must be declared virtual or abstract` checks are unchanged.

### Exclusions

Derived types (fields, properties, method returns, collection unwrapping, common-type calculations) are not diagnosed unless the type name is explicitly written at that location. Non-Apex declarations — notably Visualforce `Component.*` nested types, which produced false positives in an earlier unconstrained prototype — are excluded by the `ApexDeclaration` restriction, and are covered by a regression test.

## Tests

- `NestedTypeVisibilityTest` — 58 tests: class/interface/enum x declared/param/return/construction/expression/statement x same-file/cross-file x test/non-test x with/without `@TestVisible`, precise ranges for recursive generics and arrays, multiple-declarator deduplication, derived-type and non-Apex exclusions, and the inherited-unqualified limitation described above. Every case runs against both parser adapters.
- `NestedTypeVisibilityCacheTest` — 5 tests: Full vs Summary target declarations, cache enabled/disabled, cold/warm loading, and refresh ordering across visibility, `@TestVisible`, and caller `@IsTest` changes.
- `ExtendsTest` updated for the replaced check, plus new `@TestVisible` accessible/inaccessible cases.

### Commands run

```
sbt scalafmtAll
sbt apexlsJVM/test        # 2704 tests, 130 suites, 0 failures
sbt apexlsJS/compile
sbt apexlsJVM/build
cd js/npm && SAMPLES=.../apex-samples npm run test-samples -- --runInBand
```

**Sample regression: zero added diagnostics.** The 100 pinned `apex-samples` projects report 100/100 tests and 100/100 snapshots passing with no `Type is not visible` diagnostic anywhere — matching the measurement from the investigation prototype.

## Risks

The `extends` behaviour change is the only diagnostic that moves for existing code; it produces no change across the sample corpus. New diagnostics are errors, so a project relying on apex-ls not reporting an inaccessible nested type reference will now see an error — which is what the compiler reports.

The occurrence filter is a coverage reduction in the one case documented above, not a change to any diagnostic that is still produced. No measurement tooling was added for the allocation saving; that is left to the load profiling in #540.
